### PR TITLE
add missing versions for DiffEqBase, DiffEqNoiseProcess, and StochasticDiffEq

### DIFF
--- a/D/DiffEqBase/Versions.toml
+++ b/D/DiffEqBase/Versions.toml
@@ -525,3 +525,9 @@ git-tree-sha1 = "1ceac229f11e13f69070d4de1ffe819ab44a55f2"
 
 ["5.0.1"]
 git-tree-sha1 = "f52b84dd3224bca7829f5d5d04560409d3f91b40"
+
+["5.1.0"]
+git-tree-sha1 = "ad42e331fbae2fc1daed7b7f56a131cbe84c1f8c"
+
+["5.2.0"]
+git-tree-sha1 = "df41d4df5cb7033dc74d876778255439d7f4a1df"

--- a/D/DiffEqNoiseProcess/Versions.toml
+++ b/D/DiffEqNoiseProcess/Versions.toml
@@ -93,3 +93,6 @@ git-tree-sha1 = "ee4e193cf3085a392d0f75767414f73af935b954"
 
 ["3.0.0"]
 git-tree-sha1 = "c6147bbef7d3b5b3a5b10d53b7c6cc8b341a8015"
+
+["3.1.0"]
+git-tree-sha1 = "f7c17a65b9b64ae6d2219eb7659299bc7751138f"

--- a/S/StochasticDiffEq/Versions.toml
+++ b/S/StochasticDiffEq/Versions.toml
@@ -321,3 +321,6 @@ git-tree-sha1 = "de4f1f2b02f8c6c33fa5475e68799e15c487d824"
 
 ["6.0.0"]
 git-tree-sha1 = "87a45df67842dca86249134abaa4d2dac0691fd0"
+
+["6.1.0"]
+git-tree-sha1 = "c472f5f38504cacf1f2a9c01dd1ddfdba5e17d4c"


### PR DESCRIPTION
These 3 packages did not add their recent updates to the Versions file. This should at least temporarily fix the package manager so that way it's not down until this is fixed.