### PR TITLE
Fix a dependency

### DIFF
--- a/C/Currencies/Deps.toml
+++ b/C/Currencies/Deps.toml
@@ -11,8 +11,6 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CurrenciesBase = "a33ca353-0707-5c2b-b398-646075a850cd"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-
-["0.10-0.12"]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 ["0.11-0.12"]


### PR DESCRIPTION
Hi,

I hope this can get merge, but understand if it is better to wait for the new registration process.

Neither my REQUIRE file nor my Project.toml indicate a dependency on Test (v0.12.0), yet, for some reason, it is showing up as a dependency here on General.

This is not the end of the world, but slightly annoying because I have 7 other packages (and growing) that depend on this package and all of the manifests are being polluted by this extraneous dependency on Test. I understand they are stdlib dependencies, but still, it would be nice to clean it up if possible.

In any case, I truly appreciate all the hard work and brainpower going into this and I look forward to the new registration process. Thank you 🙏