### PR TITLE
Fix incorrect Julia upper bound in Nabla 0.11.1

### DIFF
--- a/N/Nabla/Compat.toml
+++ b/N/Nabla/Compat.toml
@@ -26,7 +26,7 @@ DiffRules = "0.0"
 DualNumbers = "0.6"
 FDM = "0.1-0.4"
 SpecialFunctions = "0.5-0.7"
-julia = "1.0-1.1"
+julia = "1.0-1.3"
 
 ["0.2-0.10"]
 DualNumbers = "0.6"


### PR DESCRIPTION
Julia's upper bound was incorrectly identified as 1.1 for the most recent tag of Nabla, making it uninstallable on Julia 1.2 and nightly.