### PR TITLE
QueryOperators supports IteratorInterfaceExtensions 1.0

### DIFF
--- a/Q/QueryOperators/Compat.toml
+++ b/Q/QueryOperators/Compat.toml
@@ -17,7 +17,7 @@ TableShowUtils = "0"
 
 ["0.3-0"]
 DataStructures = "0.11-0"
-IteratorInterfaceExtensions = "0.1.1-0"
+IteratorInterfaceExtensions = "0.1.1-1"
 TableShowUtils = "0.1.1-0"
 julia = "0.7-1"
 


### PR DESCRIPTION
Matches the Project.toml file in the project, and tested locally. @davidanthoff is that correct?

Fixes https://github.com/JuliaData/Tables.jl/issues/88.