### PR TITLE
reintroduce upper bounds to debugger stack

### DIFF
--- a/A/Atom/Compat.toml
+++ b/A/Atom/Compat.toml
@@ -89,12 +89,12 @@ Traceur = "0"
 Juno = "0.6-0"
 
 ["0.8-0.8.3"]
-CodeTracking = "0.4-0"
-JuliaInterpreter = "0.3-0"
+CodeTracking = "0.4-0.5"
+JuliaInterpreter = "0.3-0.5"
 
 ["0.8.2-0"]
 Juno = "0.7-0"
 
 ["0.8.4-0"]
-CodeTracking = "0.5-0"
-JuliaInterpreter = "0.4-0"
+CodeTracking = "0.5.0-0.5"
+JuliaInterpreter = "0.4-0.5"

--- a/D/Debugger/Compat.toml
+++ b/D/Debugger/Compat.toml
@@ -1,20 +1,20 @@
 [0]
 Crayons = "3-4"
-Highlights = "0.3.1-0"
+Highlights = "0.3.1-0.3"
 julia = "1"
 
 ["0-0.1"]
-JuliaInterpreter = "0.2-0"
+JuliaInterpreter = "0.2-0.5"
 
 ["0-0.3"]
-CodeTracking = "0.3.2-0"
+CodeTracking = "0.3.2-0.5"
 
 ["0.2"]
-JuliaInterpreter = "0.3-0"
+JuliaInterpreter = "0.3-0.5"
 
 ["0.3"]
-JuliaInterpreter = "0.4-0"
+JuliaInterpreter = "0.4-0.5"
 
 ["0.4-0"]
-CodeTracking = "0.5.7-0"
-JuliaInterpreter = "0.5-0"
+CodeTracking = "0.5.7-0.5"
+JuliaInterpreter = "0.5.0-0.5"

--- a/L/LoweredCodeUtils/Compat.toml
+++ b/L/LoweredCodeUtils/Compat.toml
@@ -2,8 +2,8 @@
 julia = "1.1-1"
 
 ["0.1.1-0.3.1"]
-JuliaInterpreter = "0"
+JuliaInterpreter = "0.5.0-0.5"
 julia = "1"
 
 ["0.3.2-0"]
-JuliaInterpreter = "0.3-0"
+JuliaInterpreter = "0.3-0.5"

--- a/R/Rebugger/Compat.toml
+++ b/R/Rebugger/Compat.toml
@@ -23,8 +23,8 @@ Revise = "1"
 Revise = "1.0.2-1"
 
 ["0.3-0.3.1"]
-CodeTracking = "0"
-JuliaInterpreter = "0"
+CodeTracking = "0-0.5"
+JuliaInterpreter = "0-0.5"
 Revise = "2"
 
 ["0.3.2-0"]

--- a/R/Revise/Compat.toml
+++ b/R/Revise/Compat.toml
@@ -23,7 +23,7 @@ OrderedCollections = "0-1"
 julia = "1"
 
 ["1.1-1"]
-CodeTracking = "0"
+CodeTracking = "0-0.5"
 
 ["2-2.0.1"]
 CodeTracking = "0.4"
@@ -33,10 +33,10 @@ LoweredCodeUtils = "0.2"
 JuliaInterpreter = "0.2-0.3"
 
 ["2.0.2-2.0"]
-CodeTracking = "0.4-0"
+CodeTracking = "0.4-0.5"
 
 ["2.0.2-2.0.4"]
-LoweredCodeUtils = "0.3-0"
+LoweredCodeUtils = "0.3.0-0.3"
 
 ["2.0.5-2.1.1"]
 JuliaInterpreter = "0.2-0.4"
@@ -45,13 +45,13 @@ JuliaInterpreter = "0.2-0.4"
 LoweredCodeUtils = "0.3.1"
 
 ["2.1-2.1.3"]
-CodeTracking = "0.5.1-0"
+CodeTracking = "0.5.1-0.5"
 
 ["2.1.2-2.1.3"]
-JuliaInterpreter = "0.2-0"
+JuliaInterpreter = "0.2-0.5"
 
 ["2.1.3"]
-LoweredCodeUtils = "0.3.2-0"
+LoweredCodeUtils = "0.3.2-0.3"
 
 ["2.1.4-2"]
 CodeTracking = "0.5.1-0.5"


### PR DESCRIPTION
These either didn't exist in the first place or were lost in the "normalization process" that ended up removing many upper bounds.