### PR TITLE
Update Package.toml for CALCEPH repository new URL

### DIFF
--- a/C/CALCEPH/Package.toml
+++ b/C/CALCEPH/Package.toml
@@ -1,3 +1,3 @@
 name = "CALCEPH"
 uuid = "1537fe66-4725-5aba-80f4-3a74792cecc1"
-repo = "https://github.com/bgodard/CALCEPH.jl.git"
+repo = "https://github.com/JuliaAstro/CALCEPH.jl.git"


### PR DESCRIPTION
Change location of CALCEPH repository: moved to JuliaAstro organization.