### PR TITLE
Update repo URL for RadiationSpectra and SolidStateDetectors

### DIFF
--- a/R/RadiationSpectra/Package.toml
+++ b/R/RadiationSpectra/Package.toml
@@ -1,3 +1,3 @@
 name = "RadiationSpectra"
 uuid = "4f207c7e-01da-51d7-a1a0-c8c06dd1d883"
-repo = "https://github.com/JuliaHEP/RadiationSpectra.jl.git"
+repo = "https://github.com/JuliaPhysics/RadiationSpectra.jl.git"

--- a/S/SolidStateDetectors/Package.toml
+++ b/S/SolidStateDetectors/Package.toml
@@ -1,3 +1,3 @@
 name = "SolidStateDetectors"
 uuid = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
-repo = "https://github.com/JuliaHEP/SolidStateDetectors.jl.git"
+repo = "https://github.com/JuliaPhysics/SolidStateDetectors.jl.git"


### PR DESCRIPTION
Both packages were moved from JuliaHEP to JuliaPhysics.