### PR TITLE
update weave's url to show move to JunoLab

### DIFF
--- a/W/Weave/Package.toml
+++ b/W/Weave/Package.toml
@@ -1,3 +1,3 @@
 name = "Weave"
 uuid = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
-repo = "https://github.com/mpastell/Weave.jl.git"
+repo = "https://github.com/JunoLab/Weave.jl.git"


### PR DESCRIPTION
Weave was recently moved to JunoLab and this causing issues for JuliaRegistrator, this PR fixes the repo url. 