### PR TITLE
Fix repo URL due to username change

### DIFF
--- a/L/LorentzVectors/Package.toml
+++ b/L/LorentzVectors/Package.toml
@@ -1,3 +1,3 @@
 name = "LorentzVectors"
 uuid = "3f54b04b-17fc-5cd4-9758-90c048d965e3"
-repo = "https://github.com/Element-126/LorentzVectors.jl.git"
+repo = "https://github.com/JLTastet/LorentzVectors.jl.git"


### PR DESCRIPTION
I unexpectedly broke registration by changing my GitHub user name :flushed:. This PR fixes the repo URL.

Additionally, there is a UUID mismatch between the Project.toml and Package.toml. Not sure how that happened and what is the correct way to fix it. I would happily welcome your suggestions!