### PR TITLE
Switch Brane Project repositories' url to GitLab

### DIFF
--- a/B/BitConverter/Package.toml
+++ b/B/BitConverter/Package.toml
@@ -1,3 +1,3 @@
 name = "BitConverter"
 uuid = "3a3ce9e8-98e7-11e9-0fa0-055639f146d3"
-repo = "https://gitlab.com/braneproject/bitconverter.jl.git"
+repo = "https://gitlab.com/braneproject/BitConverter.jl.git"

--- a/B/BitConverter/Package.toml
+++ b/B/BitConverter/Package.toml
@@ -1,3 +1,3 @@
 name = "BitConverter"
 uuid = "3a3ce9e8-98e7-11e9-0fa0-055639f146d3"
-repo = "https://github.com/roshii/BitConverter.jl.git"
+repo = "https://gitlab.com/braneproject/bitconverter.jl.git"

--- a/B/Bitcoin/Package.toml
+++ b/B/Bitcoin/Package.toml
@@ -1,3 +1,3 @@
 name = "Bitcoin"
 uuid = "785d7830-48c5-59de-ae5e-7712913079e9"
-repo = "https://github.com/roshii/Bitcoin.jl.git"
+repo = "https://gitlab.com/braneproject/Bitcoin.jl.git"

--- a/E/ECC/Package.toml
+++ b/E/ECC/Package.toml
@@ -1,3 +1,3 @@
 name = "ECC"
 uuid = "a99b485a-c5c8-540e-ab00-7a7265134077"
-repo = "https://github.com/roshii/ECC.jl.git"
+repo = "https://gitlab.com/braneproject/ecc.jl.git"

--- a/E/ECC/Package.toml
+++ b/E/ECC/Package.toml
@@ -1,3 +1,3 @@
 name = "ECC"
 uuid = "a99b485a-c5c8-540e-ab00-7a7265134077"
-repo = "https://gitlab.com/braneproject/ecc.jl.git"
+repo = "https://gitlab.com/braneproject/ECC.jl.git"

--- a/M/MerkleTrees/Package.toml
+++ b/M/MerkleTrees/Package.toml
@@ -1,3 +1,3 @@
 name = "MerkleTrees"
 uuid = "06dfef30-8e85-11e9-0a8e-cb6ed32fdbef"
-repo = "https://github.com/roshii/MerkleTrees.jl.git"
+repo = "https://gitlab.com/braneproject/merkletrees.jl.git"

--- a/M/MerkleTrees/Package.toml
+++ b/M/MerkleTrees/Package.toml
@@ -1,3 +1,3 @@
 name = "MerkleTrees"
 uuid = "06dfef30-8e85-11e9-0a8e-cb6ed32fdbef"
-repo = "https://gitlab.com/braneproject/merkletrees.jl.git"
+repo = "https://gitlab.com/braneproject/MerkleTrees.jl.git"

--- a/S/Secp256k1/Package.toml
+++ b/S/Secp256k1/Package.toml
@@ -1,3 +1,3 @@
 name = "Secp256k1"
 uuid = "bfa37bea-997f-11e9-0e02-2d50932a0e04"
-repo = "https://github.com/roshii/Secp256k1.jl.git"
+repo = "https://gitlab.com/braneproject/secp256k1.jl.git"

--- a/S/Secp256k1/Package.toml
+++ b/S/Secp256k1/Package.toml
@@ -1,3 +1,3 @@
 name = "Secp256k1"
 uuid = "bfa37bea-997f-11e9-0e02-2d50932a0e04"
-repo = "https://gitlab.com/braneproject/secp256k1.jl.git"
+repo = "https://gitlab.com/braneproject/Secp256k1.jl.git"


### PR DESCRIPTION
I recently discovered https://pkg.julialang.org/registrator but ran into the following error when trying to update a package.

```
ERROR: Registration failed: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.
```

If I'm not mistaking I have to update my repo urls with this pull request.