### PR TITLE
Yank BinaryProvider `v0.5.5`

### DIFF
--- a/B/BinaryProvider/Versions.toml
+++ b/B/BinaryProvider/Versions.toml
@@ -69,3 +69,4 @@ git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
 
 ["0.5.5"]
 git-tree-sha1 = "8153fd64131cd00a79544bb23788877741f627bb"
+yanked = true

--- a/B/BinaryProvider/Versions.toml
+++ b/B/BinaryProvider/Versions.toml
@@ -70,3 +70,6 @@ git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
 ["0.5.5"]
 git-tree-sha1 = "8153fd64131cd00a79544bb23788877741f627bb"
 yanked = true
+
+["0.5.6"]
+git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"


### PR DESCRIPTION
This yanks BP v0.5.5 for Julia 1.0 as well as 1.1+ by both using `yanked = true` and setting a `Compat` entry for Julia `v1.0.X`