### PR TITLE
Fix FilePaths compat

### DIFF
--- a/F/FilePaths/Compat.toml
+++ b/F/FilePaths/Compat.toml
@@ -19,7 +19,7 @@ Compat = "0.17-2"
 julia = "0.6-0"
 
 ["0.6"]
-FilePathsBase = "0"
+FilePathsBase = "0.1-0.5"
 URIParser = "0"
 
 ["0.6-0"]
@@ -27,6 +27,6 @@ Reexport = "0.1-0"
 
 ["0.7-0"]
 Compat = "1-2"
-FilePathsBase = "0.3-0"
+FilePathsBase = "0.3-0.5"
 URIParser = "0.3.1-0"
 julia = "0.6-1"


### PR DESCRIPTION
FilePathsBase v0.6.0 is a breaking release, so we need to add these bounds here.

@rofinn or @oxinabox could you briefly confirm that this is right?

Speed with this one here would be great, I'm supposed to teach a workshop tomorrow, and this is breaking our whole stack right now :)