### PR TITLE
Fix JuMP compatibility

### DIFF
--- a/J/JuMP/Compat.toml
+++ b/J/JuMP/Compat.toml
@@ -89,7 +89,7 @@ julia = "1"
 Calculus = "0"
 DataStructures = "0"
 ForwardDiff = "0.5-0"
-MathOptInterface = "0.8.1-0"
+MathOptInterface = "0.8.1-0.8"
 NaNMath = "0.2.1-0"
 
 ["0.19.1-0"]


### PR DESCRIPTION
Pkg is allowing MathOptInterface 0.9 to be installed with JuMP 0.19.0. They're not compatible. This attempts to fix the issue, although I don't understand the format of the version specifiers used here (they're not documented at https://julialang.github.io/Pkg.jl/dev/compatibility/#Compatibility-1).