### PR TITLE
Fix LinQuadOptInterface compatibility

### DIFF
--- a/L/LinQuadOptInterface/Compat.toml
+++ b/L/LinQuadOptInterface/Compat.toml
@@ -24,4 +24,4 @@ MathOptInterface = "0.6.3-0.6"
 MathOptInterface = "0.7"
 
 ["0.6-0"]
-MathOptInterface = "0.8-0"
+MathOptInterface = "0.8"


### PR DESCRIPTION
LinQuadOptInterface is not compatible with MathOptInterface > 0.8.x. This is stated in the original [REQUIRE](https://github.com/JuliaOpt/LinQuadOptInterface.jl/blob/148334e6b74c37f2108ff8dc92169d18e99584a7/REQUIRE).

Closes https://github.com/JuliaOpt/JuMP.jl/issues/2047.