### PR TITLE
Change Compat bounds on Atom-related packages

### DIFF
--- a/A/ASTInterpreter2/Compat.toml
+++ b/A/ASTInterpreter2/Compat.toml
@@ -1,3 +1,3 @@
 [0]
 DebuggerFramework = "0.1.1-0"
-julia = "0.6-0"
+julia = "0.6"

--- a/A/Atom/Compat.toml
+++ b/A/Atom/Compat.toml
@@ -1,5 +1,5 @@
 ["0-0.4"]
-julia = "0.4-0"
+julia = "0.4-0.7"
 
 ["0-0.5.2"]
 Lazy = "0"
@@ -24,7 +24,7 @@ Requires = "0"
 MacroTools = "0"
 
 ["0.5"]
-julia = "0.5-0"
+julia = "0.5-0.7"
 
 ["0.5-0.6.0"]
 ASTInterpreter = "0"
@@ -40,7 +40,7 @@ Lazy = "0.11.3-0"
 Juno = "0.2.6-0"
 
 ["0.6-0.6.15"]
-julia = "0.6-0"
+julia = "0.6"
 
 ["0.6.14-0.7.1"]
 Juno = "0.4.1-0"
@@ -104,15 +104,13 @@ CodeTools = "0.6.4-0.6"
 CodeTracking = "0.5.7-0.5"
 HTTP = "0.8"
 Hiccup = "0.2.2-0.2"
-JuliaInterpreter = "0.6"
+JuliaInterpreter = "0.6-0.7"
 Juno = "0.7"
 Lazy = "0.13"
 MacroTools = "0.5"
 TreeViews = "0.3"
 WebIO = "0.8.1-0.8"
-julia = "0.7.0-*"
-
-["0.8.6-0.8"]
+julia = "0.7.0-1"
 JSON = "0.20"
 
 ["0.9-0"]


### PR DESCRIPTION
An attempt to fix https://discourse.julialang.org/t/juno-support-for-julia-1-2-0-not-ready-yet/27804. CC @pfitzseb. Whoever reviews this, please check these bounds carefully, I am not sure this is right (https://github.com/JuliaLang/Pkg.jl/issues/1190).