### PR TITLE
Update JLL repository locations

### DIFF
--- a/B/Bzip2_jll/Package.toml
+++ b/B/Bzip2_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Bzip2_jll"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-repo = "https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl.git"

--- a/E/Expat_jll/Package.toml
+++ b/E/Expat_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Expat_jll"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-repo = "https://github.com/JuliaBinaryWrappers/Expat_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Expat_jll.jl.git"

--- a/F/Fontconfig_jll/Package.toml
+++ b/F/Fontconfig_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Fontconfig_jll"
 uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
-repo = "https://github.com/JuliaBinaryWrappers/Fontconfig_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Fontconfig_jll.jl.git"

--- a/F/FreeType2_jll/Package.toml
+++ b/F/FreeType2_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "FreeType2_jll"
 uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
-repo = "https://github.com/JuliaBinaryWrappers/FreeType2_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/FreeType2_jll.jl.git"

--- a/G/GMP_jll/Package.toml
+++ b/G/GMP_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "GMP_jll"
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
-repo = "https://github.com/JuliaBinaryWrappers/GMP_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/GMP_jll.jl.git"

--- a/G/Gettext_jll/Package.toml
+++ b/G/Gettext_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Gettext_jll"
 uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
-repo = "https://github.com/JuliaBinaryWrappers/Gettext_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Gettext_jll.jl.git"

--- a/L/LZO_jll/Package.toml
+++ b/L/LZO_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "LZO_jll"
 uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
-repo = "https://github.com/JuliaBinaryWrappers/LZO_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/LZO_jll.jl.git"

--- a/L/Libiconv_jll/Package.toml
+++ b/L/Libiconv_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Libiconv_jll"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-repo = "https://github.com/JuliaBinaryWrappers/Libiconv_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Libiconv_jll.jl.git"

--- a/L/Libuuid_jll/Package.toml
+++ b/L/Libuuid_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Libuuid_jll"
 uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
-repo = "https://github.com/JuliaBinaryWrappers/Libuuid_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Libuuid_jll.jl.git"

--- a/L/libpng_jll/Package.toml
+++ b/L/libpng_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "libpng_jll"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-repo = "https://github.com/JuliaBinaryWrappers/libpng_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/libpng_jll.jl.git"

--- a/M/MPFR_jll/Package.toml
+++ b/M/MPFR_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "MPFR_jll"
 uuid = "3a97d323-0669-5f0c-9066-3539efd106a3"
-repo = "https://github.com/JuliaBinaryWrappers/MPFR_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/MPFR_jll.jl.git"

--- a/O/OpenSpecFun_jll/Package.toml
+++ b/O/OpenSpecFun_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "OpenSpecFun_jll"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-repo = "https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl.git"

--- a/P/Pixman_jll/Package.toml
+++ b/P/Pixman_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Pixman_jll"
 uuid = "30392449-352a-5448-841d-b1acce4e97dc"
-repo = "https://github.com/JuliaBinaryWrappers/Pixman_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Pixman_jll.jl.git"

--- a/P/p7zip_jll/Package.toml
+++ b/P/p7zip_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "p7zip_jll"
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-repo = "https://github.com/JuliaBinaryWrappers/p7zip_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/p7zip_jll.jl.git"

--- a/X/X11_jll/Package.toml
+++ b/X/X11_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "X11_jll"
 uuid = "546b0b6d-9ca3-5ba2-8705-1bc1841d8479"
-repo = "https://github.com/JuliaBinaryWrappers/X11_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/X11_jll.jl.git"

--- a/Z/Zlib_jll/Package.toml
+++ b/Z/Zlib_jll/Package.toml
@@ -1,3 +1,3 @@
 name = "Zlib_jll"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-repo = "https://github.com/JuliaBinaryWrappers/Zlib_jll.jl"
+repo = "https://github.com/JuliaBinaryWrappers/Zlib_jll.jl.git"


### PR DESCRIPTION
Unfortunately, Registrator doesn't support changing package URLs, so we have to do it manually.