### PR TITLE
Register JuliaBinaryWrappers/Glib_jll.jl v2.59.0+1

### DIFF
--- a/G/Glib_jll/Versions.toml
+++ b/G/Glib_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["2.59.0+0"]
 git-tree-sha1 = "41d483e74382219041f50a9defaf8b2a8b85fb65"
+
+["2.59.0+1"]
+git-tree-sha1 = "9a7e1ad28f1313da50e5ab8568725bed5f131ad1"


### PR DESCRIPTION
Autogenerated registration for JuliaBinaryWrappers/Glib_jll.jl v2.59.0+1
