### PR TITLE
Atom.jl: Update compat entry for Lazy.jl

### DIFF
--- a/A/Atom/Compat.toml
+++ b/A/Atom/Compat.toml
@@ -14,7 +14,7 @@ Media = "0"
 ["0.10-0"]
 CSTParser = "0.6.2-0.6"
 JuliaInterpreter = "0.7"
-Lazy = "0.14"
+Lazy = "0.13-0.14"
 julia = ["0.7", "1"]
 
 ["0.3-0.6"]


### PR DESCRIPTION
Turns out it's really hard to get newer Atom.jl versions at the moment, because Lazy.jl 0.14 was released a couple of days ago and the rest of the ecosystem hasn't caught up with that yet.