### PR TITLE
replace old NOMAD package from jbrea with new one

### DIFF
--- a/N/NOMAD/Compat.toml
+++ b/N/NOMAD/Compat.toml
@@ -1,12 +1,5 @@
-[0]
-Cxx = "0"
-MathProgBase = "0"
+[1.0.0]
+julia = "1.2.0"
+Cxx = "0.3.2"
+BinaryProvider = "0.5.5"
 
-["0-0.1.1"]
-julia = "0.6-0"
-
-["0.1.1-0"]
-BinDeps = "0"
-
-["0.1.2-0"]
-julia = "0.6"

--- a/N/NOMAD/Deps.toml
+++ b/N/NOMAD/Deps.toml
@@ -1,7 +1,6 @@
-[0]
-Cxx = "a0b5b9ef-44b7-5148-a2d1-f6db19f3c3d2"
-MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
-
-["0.1.1-0"]
-BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+[1.0.0]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Cxx = "a0b5b9ef-44b7-5148-a2d1-f6db19f3c3d2"
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/N/NOMAD/Package.toml
+++ b/N/NOMAD/Package.toml
@@ -1,3 +1,3 @@
 name = "NOMAD"
-uuid = "02130f1c-4665-5b79-af82-ff1385104aa0"
-repo = "https://github.com/jbrea/NOMAD.jl.git"
+uuid = "d227bf30-5bb1-11e9-2f08-c35a5fc780a2"
+repo = "https://github.com/ppascal97/NOMAD.jl.git"

--- a/N/NOMAD/Versions.toml
+++ b/N/NOMAD/Versions.toml
@@ -1,8 +1,2 @@
-["0.1.0"]
-git-tree-sha1 = "3891e678cf6d2eb848e7a307906ed6a825f3aea4"
-
-["0.1.1"]
-git-tree-sha1 = "1a7574d9d4dd52e5fa26e9d4384bfd7160f238e4"
-
-["0.1.2"]
-git-tree-sha1 = "d912b3f37c1fcda276eb67bf001e5db4c2e15a96"
+["1.0.0"]
+git-tree-sha1 = "14e119c815dc5327c9fd962235bc54b4f55f0f4b"


### PR DESCRIPTION
As mentioned in https://discourse.julialang.org/t/replace-registered-package/28830/2 , I'd like to replace the old NOMAD package registered with mine. I'm in touch with jbrea who is the owner of the former package and he agrees to replace his with mine. I tried to modify all the .toml from N/NOMAD correctly, and hope everything is ok. 

Thanks for your help and hard work !