### PR TITLE
NOMAD.jl Repo URL change

### DIFF
--- a/N/NOMAD/Package.toml
+++ b/N/NOMAD/Package.toml
@@ -1,3 +1,3 @@
 name = "NOMAD"
 uuid = "02130f1c-4665-5b79-af82-ff1385104aa0"
-repo = "https://github.com/jbrea/NOMAD.jl.git"
+repo = "https://github.com/ppascal97/NOMAD.jl.git"


### PR DESCRIPTION
Hi Everyone,

I'd like to replace the old NOMAD package registered with mine. I'm in touch with jbrea who is the owner of the former package and he agrees to replace his with mine. As I was advised in https://github.com/JuliaRegistries/General/pull/3640 (I will close the old PR soon), I update the URL of the package to point to my repo.

Thanks for the help, fredrikekre !