### PR TITLE
Change URL for GroupSlices.jl to 1.0 fork

### DIFF
--- a/G/GroupSlices/Package.toml
+++ b/G/GroupSlices/Package.toml
@@ -1,3 +1,3 @@
 name = "GroupSlices"
 uuid = "d853e229-7c7c-56e9-b6be-9a1acc5f13d9"
-repo = "https://github.com/AndyGreenwell/GroupSlices.jl.git"
+repo = "https://github.com/mcabbott/GroupSlices.jl.git"


### PR DESCRIPTION
As discussed here: https://github.com/AndyGreenwell/GroupSlices.jl/issues/10

(Not really sure I’m doing this correctly.)