### PR TITLE
Revert "Bump RegistryCI from e535da3 to 4de1927"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ julia:
 # matrix:
 #   allow_failures:
 #     - julia: nightly
-before_script: julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaRegistries/RegistryCI.jl", rev="4de1927"))'
+before_script: julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaRegistries/RegistryCI.jl", rev="e535da3"))'
 script: julia --color=yes -e 'import RegistryCI; RegistryCI.test()'
 after_success:
   # - exit 0 # Administrators: uncomment this line to disable all automerging


### PR DESCRIPTION
Reverts JuliaRegistries/General#4527

@fredrikekre @StefanKarpinski `4de1927` breaks automerge, so we need to revert to `e535da3`