### PR TITLE
Bump RegistryCI from "2077cca" to "94ac736"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ julia:
 # matrix:
 #   allow_failures:
 #     - julia: nightly
-before_script: julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaRegistries/RegistryCI.jl", rev="2077cca"))'
+before_script: julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaRegistries/RegistryCI.jl", rev="94ac736"))'
 script: julia --color=yes -e 'import RegistryCI; RegistryCI.test()'
 after_success:
   # - exit 0 # Administrators: uncomment this line to disable all automerging


### PR DESCRIPTION
There is currently a very subtle typo in the automerge code. As a result, automerge will merge a PR even if the PR has one or more blocking comments.

The typo was fixed in https://github.com/JuliaRegistries/RegistryCI.jl/pull/43/files.

This pull request updates the `rev` of RegistryCI to incorporate this new fix.

cc: @fredrikekre @StefanKarpinski 