### PR TITLE
Register JuliaBinaryWrappers/Libpciaccess_jll.jl v0.16.0+1

### DIFF
--- a/L/Libpciaccess_jll/Deps.toml
+++ b/L/Libpciaccess_jll/Deps.toml
@@ -2,3 +2,4 @@
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 X11_jll = "546b0b6d-9ca3-5ba2-8705-1bc1841d8479"
+Xorg_util_macros_jll = "7c09cfe3-afe2-5798-bcc9-d6b7fecfdca5"

--- a/L/Libpciaccess_jll/Versions.toml
+++ b/L/Libpciaccess_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["0.16.0+0"]
 git-tree-sha1 = "a7929150205eddd7ed77602ec587424d513cbe61"
+
+["0.16.0+1"]
+git-tree-sha1 = "8baa7b9cdd2331b316e569d5b7d256193ec308f1"


### PR DESCRIPTION
Autogenerated registration for JuliaBinaryWrappers/Libpciaccess_jll.jl v0.16.0+1
