### PR TITLE
[URL updated] Transfer MusicXML.jl to JuliaMusic

### DIFF
--- a/M/MusicXML/Package.toml
+++ b/M/MusicXML/Package.toml
@@ -1,3 +1,3 @@
 name = "MusicXML"
 uuid = "521615e9-e573-4eb2-bc7e-702d55c0bb95"
-repo = "https://github.com/aminya/MusicXML.jl.git"
+repo = "https://github.com/JuliaMusic/MusicXML.jl.git"


### PR DESCRIPTION
Because of bot's message:

> Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.