### PR TITLE
Bump RegistryCI

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -102,8 +102,8 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RegistryCI]]
 deps = ["Dates", "GitHub", "HTTP", "JSON", "LibGit2", "Pkg", "Test", "TimeZones"]
-git-tree-sha1 = "93a98f5a5115bbdc6abf96d9539d1c1e9460b1fa"
-repo-rev = "12a7484a7094250b71e20063ab0e625cddb2fc86"
+git-tree-sha1 = "36227e3f6a067d48acf2e2db8507f0c28909a61f"
+repo-rev = "4dcd6b098db1f6fa2c572f56e597eea2b0d4f9e5"
 repo-url = "https://github.com/JuliaRegistries/RegistryCI.jl.git"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 version = "0.3.0-DEV"


### PR DESCRIPTION
Bump RegistryCI with the following improvements:
 - Process PRs in reverse order
 - Wait for PRs to be mergeable when trying to merge
 - Delete the branch after merging