### PR TITLE
Yank ProgressMeterLogging.jl

### DIFF
--- a/P/ProgressMeterLogging/Versions.toml
+++ b/P/ProgressMeterLogging/Versions.toml
@@ -1,2 +1,3 @@
 ["0.1.0"]
 git-tree-sha1 = "0cdd35e361f0d00ea1d19e903150080cbb28c029"
+yanked = true


### PR DESCRIPTION
close #4917

As I mentioned in #4917, I renamed ProgressMeterLogging.jl to ConsoleProgressMonitor.jl so I would like to make ProgressMeterLogging.jl uninstallable.  From the discussion in #4917, it seems yanking is the best approach, IIUC.