### PR TITLE
Add a deprecation notice for TagBot as a GitHub App

### DIFF
--- a/.ci/tagbot.py
+++ b/.ci/tagbot.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import json
+import os
+import re
+
+from github import Github
+
+WARNING = """
+TagBot as a GitHub App is deprecated in favour of TagBot as a GitHub Action.
+This comes with the significant advantage of no longer needing to hand over repository write permissions to an unknown third party.
+See [here](https://github.com/marketplace/actions/julia-tagbot) for more information on installing TagBot as a GitHub Action.
+
+cc: {}
+"""
+
+with open(os.environ["GITHUB_EVENT_PATH"]) as f:
+    event = json.load(f)
+gh = Github(os.environ["API_TOKEN"])
+r = gh.get_repo(os.environ["GITHUB_REPOSITORY"])
+pr = r.get_pull(event["issue"]["number"])
+creator = re.search("- Created by: (@.+)", pr.body).group(1)
+pr.create_issue_comment(WARNING.format(creator))

--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -1,0 +1,17 @@
+name: TagBot App Deprecation Notice
+on:
+  issue_comment:
+    types: created
+jobs:
+  warn:
+    if: github.event.sender.login == 'julia-tagbot[bot]' && contains(github.event.comment.body, 'created release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - run: pip install PyGithub==1.44
+      - run: $GITHUB_WORKSPACE/.ci/tagbot.py
+        env:
+          API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action will respond to TagBot's "I've created release \<version>" messages with a suggestion to switch to GitHub Actions.
The TagBot GitHub App itself will stay up for a long time but eventually I'd like to switch completely to Actions.

Not to be merged until November 13th when GitHub Actions hits general availability!