### PR TITLE
Upper bound: have Flux only use CuArrays <=1.3

### DIFF
--- a/F/Flux/Compat.toml
+++ b/F/Flux/Compat.toml
@@ -56,7 +56,7 @@ julia = "0.7-1"
 
 ["0.9"]
 CUDAapi = "1.1.0-1"
-CuArrays = "1.2.0-1"
+CuArrays = "1.2.0-1.3"
 NNlib = "0.6"
 Tracker = "0.2"
 julia = ["0.7", "1"]


### PR DESCRIPTION
Flux uses non-public API that broke with a minor release.

Upcoming Flux release will use the available APIs and regain compatibility with CuArrays 1.4+