### PR TITLE
Pin automerge action to commit hash

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ jobs:
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
-       - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
+      - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
       - uses: julia-actions/setup-julia@a072d0b2e463063d60f08e151727e0e548db233d # v0.2.1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ jobs:
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
+      - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819 # v1.0.0
       - uses: julia-actions/setup-julia@a072d0b2e463063d60f08e151727e0e548db233d # v0.2.1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,7 @@ jobs:
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v1.0.0
+       - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
       - uses: julia-actions/setup-julia@a072d0b2e463063d60f08e151727e0e548db233d # v0.2.1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@a072d0b2e463063d60f08e151727e0e548db233d # v0.2.1
         with:
           version: ${{ matrix.julia-version }}
       - name: Install dependencies


### PR DESCRIPTION
Before, everyone with write access to setup-julia could modify the tag and compromise the automerger, thus compromising the entire registry. While the usual settings like enforced 2FA and branch protections are enabled on the action repo, it makes sense to go beyond that for something as key to the Julia ecosystem as the General registry, and minimise the attack surface as much as possible which in this case would mean reducing the amount of GH accounts that could be targetted to gain access to the registry. Additionally, using `latest` risks that there might be uncaught bugs.

Unlike tags, commit hashes are can't easily be changed, so the potential risk is much lower.

(See also: https://julialang.slack.com/archives/CBF3Z1D7V/p1572955925497800)