### PR TITLE
JLL Registration: JuliaBinaryWrappers/Fontconfig_jll.jl-v2.13.1+7

### DIFF
--- a/F/Fontconfig_jll/Versions.toml
+++ b/F/Fontconfig_jll/Versions.toml
@@ -18,3 +18,6 @@ git-tree-sha1 = "dc9cd19ac99495b68d157910913a07d706ca7646"
 
 ["2.13.1+6"]
 git-tree-sha1 = "ea493e1d65ae536a4fd5e521c08e63b037f1e053"
+
+["2.13.1+7"]
+git-tree-sha1 = "8bb266765907c529c045d2a4d0112cb1e409e305"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package Fontconfig_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/Fontconfig_jll.jl
* Version: v2.13.1+7
