### PR TITLE
Zygote 0.3 compatibility

### DIFF
--- a/Z/Zygote/Compat.toml
+++ b/Z/Zygote/Compat.toml
@@ -25,6 +25,7 @@ NNlib = "0.6"
 
 ["0.3.1-0.3"]
 IRTools = "0.2"
+ZygoteRules = "0.1"
 
 ["0.4-0"]
 DiffRules = "0.0"


### PR DESCRIPTION
Versions prior to 0.3.3 did not depend on ZygoteRules, so this means that all versions have correct compat bounds for this specific dependency. I'll follow up with more improvements, but would like to get this in so that version 0.3 of Zygote is usable; currently it will just throw an error on load.