### PR TITLE
JLL Registration: JuliaBinaryWrappers/libvorbis_jll.jl-v1.3.6+1

### DIFF
--- a/L/libvorbis_jll/Versions.toml
+++ b/L/libvorbis_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["1.3.6+0"]
 git-tree-sha1 = "734d7075e7eb26b3d8c6733b39a4c5f13757cc88"
+
+["1.3.6+1"]
+git-tree-sha1 = "8e36d57c33173823a6aeb9529f4a0723aaebac85"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libvorbis_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libvorbis_jll.jl
* Version: v1.3.6+1
