### PR TITLE
JuLIP.jl repository transfer

### DIFF
--- a/J/JuLIP/Package.toml
+++ b/J/JuLIP/Package.toml
@@ -1,3 +1,3 @@
 name = "JuLIP"
 uuid = "945c410c-986d-556a-acb1-167a618e0462"
-repo = "https://github.com/libAtoms/JuLIP.jl.git"
+repo = "https://github.com/JuliaMolSim/JuLIP.jl.git"


### PR DESCRIPTION
moved `JuLIP.jl` from `https://github.com/cortner/JuLIP.jl.git` to `https://github.com/JuliaMolSim/JuLIP.jl`