### PR TITLE
RegistryCI: Run cron job every 10 minutes

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: AutoMerge
 
 on:
   schedule:
-    - cron: '15,45 * * * *'
+    - cron: '0/10 * * * *'
   pull_request:
 
 jobs:


### PR DESCRIPTION
The cron jobs take approximately 1-3 minutes to run.

Therefore, I think we can and should run the cron jobs more frequently.

This PR changes the cron job to run every 10 minutes.

---

Please note: no matter how frequently we run the cron job, we will never merge a PR before the appropriate waiting period (3 days for new packages, 15 minutes for new versions) has elapsed. The values passed as the keyword arguments `new_package_waiting_period` and `new_version_waiting_period` to the `RegistryCI.AutoMerge.run` function are "hard limits". That is, AutoMerge ensures that no pull request is ever merged if the relevant waiting period has not yet completed.

--- 

## Motivation:

Currently, we run the cron job every 30 minutes - at the 15th minute and 45th minute of every hour.

- The shortest possible time between opening a new version PR and having that PR merged is 15 minutes - you open a PR at 2:30pm. Your PR is approved, and then when the cron job runs at 2:45pm, your PR is 15 minutes old (and thus the new version waiting period has elapsed), so your PR is merged. And you had to wait 15 minutes.
- The longest possible time between a new version PR and having that PR merged is 28 or 29 minutes - you open a PR at 2:47pm (and the cron job, which takes approximately 2 minutes, has already completed). Your PR is approved, and then when the cron job runs at 3:15pm, your PR is 28 minutes old (and thus the new version waiting period has elapsed), so your PR is merged. And you had to wait 28 or 29 minutes.

If we merge this PR, then we will run the cron job every 10 minutes - at minute 0, 10, 20, 30, 40, and 50

- The shortest possible time between opening a new version PR and having that PR merged will be 15 minutes - you open a PR at 2:35pm. Your PR is approved. The cron job runs at 2:40pm but your PR is 5 minutes old so it is not merged. The next cron job runs at 2:50pm, your PR is now 15 minutes old (and thus the new version waiting period has elapsed), so your PR is merged. And you had to wait 15 minutes.

- The longest possible time between a new version PR and having that PR merged is 18 or 19 minutes - you open a PR at 2:32 (and the cron job, which takes approximately 2 minutes, has already completed). Your PR is approved. The cron job runs at 2:40pm but your PR is 8 minutes old so it is not merged. The next cron job runs at 2:50pm, your PR is now 18 minutes old (and thus the new version waiting period has elapsed), so your PR is merged. And you had to wait 18 or 19 minutes.

So, in summary, if we merge this PR, then the shortest possible time between opening a new version PR and having that PR merged is unchanged (it stays 15 minutes). But, the longest possible wait time decreases from 28 or 29 minutes to 18 or 19 minutes.