### PR TITLE
JLL Registration: JuliaBinaryWrappers/libserialport_jll.jl-v0.1.1+1

### DIFF
--- a/L/libserialport_jll/Versions.toml
+++ b/L/libserialport_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.1+0"]
 git-tree-sha1 = "4238f317d2544ea1ff664f2ccb41854029afe772"
+
+["0.1.1+1"]
+git-tree-sha1 = "85ba6db81c67019fd6cab39faae970930fbc54fb"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libserialport_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libserialport_jll.jl
* Version: v0.1.1+1
