### PR TITLE
JLL Registration: JuliaBinaryWrappers/Zlib_jll.jl-v1.2.11+7

### DIFF
--- a/Z/Zlib_jll/Versions.toml
+++ b/Z/Zlib_jll/Versions.toml
@@ -15,3 +15,6 @@ git-tree-sha1 = "02b171e3e5766ab7c9fa51aca145d691da8f7a0e"
 
 ["1.2.11+6"]
 git-tree-sha1 = "41c595c518bd0e47ff26b4746c828b69c9e53c60"
+
+["1.2.11+7"]
+git-tree-sha1 = "5618a43055eb09377edca21d19d0e99bce24a9c3"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package Zlib_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/Zlib_jll.jl
* Version: v1.2.11+7
