### PR TITLE
JLL Registration: JuliaBinaryWrappers/libvorbis_jll.jl-v1.3.6+2

### DIFF
--- a/L/libvorbis_jll/Versions.toml
+++ b/L/libvorbis_jll/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "734d7075e7eb26b3d8c6733b39a4c5f13757cc88"
 
 ["1.3.6+1"]
 git-tree-sha1 = "8e36d57c33173823a6aeb9529f4a0723aaebac85"
+
+["1.3.6+2"]
+git-tree-sha1 = "71e54fb89ac3e0344c7185d1876fd96b0f246952"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libvorbis_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libvorbis_jll.jl
* Version: v1.3.6+2
