### PR TITLE
JLL Registration: JuliaBinaryWrappers/libfdk_aac_jll.jl-v0.1.6+1

### DIFF
--- a/L/libfdk_aac_jll/Versions.toml
+++ b/L/libfdk_aac_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.6+0"]
 git-tree-sha1 = "40a77ef1cd100e8e5617e63e8d60e2d40d86241d"
+
+["0.1.6+1"]
+git-tree-sha1 = "0e4ace600c20714a8dd67700c4502714d8473e8e"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libfdk_aac_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libfdk_aac_jll.jl
* Version: v0.1.6+1
