### PR TITLE
Revise upper bounds for MetaArrays

### DIFF
--- a/M/MetaArrays/Compat.toml
+++ b/M/MetaArrays/Compat.toml
@@ -1,2 +1,3 @@
 [0]
 julia = "1"
+Requires = "0.5"


### PR DESCRIPTION
In light of the discussion [here](https://discourse.julialang.org/t/please-be-mindful-of-version-bounds-and-semantic-versioning-when-tagging-your-packages/30708/126), I'm updating the upper bounds for older versions of my packages.