### PR TITLE
Upper bound TimerOutputs for release NNlib

### DIFF
--- a/N/NNlib/Compat.toml
+++ b/N/NNlib/Compat.toml
@@ -5,3 +5,4 @@ julia = "0.7-1"
 
 ["0.6-0"]
 julia = "1"
+TimerOutputs = "0.5.0"


### PR DESCRIPTION
Ref: https://github.com/FluxML/NNlib.jl/issues/141

Also, just to confirm, will this guarantee version `0.5.0-0.5.0`?

cc. @MikeInnes