### PR TITLE
Update ArviZ.jl GitHub URL

### DIFF
--- a/A/ArviZ/Package.toml
+++ b/A/ArviZ/Package.toml
@@ -1,3 +1,3 @@
 name = "ArviZ"
 uuid = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
-repo = "https://github.com/sethaxen/ArviZ.jl.git"
+repo = "https://github.com/arviz-devs/ArviZ.jl.git"


### PR DESCRIPTION
ArviZ.jl has moved to the arviz-devs GitHub org: https://github.com/arviz-devs/ArviZ.jl

Fixes https://github.com/arviz-devs/ArviZ.jl/issues/9