### PR TITLE
JLL Registration: JuliaBinaryWrappers/ATK_jll.jl-v2.34.1+2

### DIFF
--- a/A/ATK_jll/Versions.toml
+++ b/A/ATK_jll/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "34d3ef15a3b5084c92e6e45c0ff1ea5404e6f6f4"
 
 ["2.34.1+1"]
 git-tree-sha1 = "d8f0989d715dd2651fc2967e6f34c1e6ba6c109d"
+
+["2.34.1+2"]
+git-tree-sha1 = "7129d58ed99d42032cefe21bcd14171a878143d2"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package ATK_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/ATK_jll.jl
* Version: v2.34.1+2
