### PR TITLE
Add upper bounds to FFTW and DSP Compats

### DIFF
--- a/D/DSP/Compat.toml
+++ b/D/DSP/Compat.toml
@@ -1,20 +1,21 @@
-["0-0.5"]
-AbstractFFTs = "0"
+["0.5.1-0.5"]
+AbstractFFTs = "0-0.4"
 Compat = "1-2"
-FFTW = "0"
-Polynomials = "0.1-0"
-Reexport = "0"
-SpecialFunctions = "0"
+FFTW = "0-1.0"
+Polynomials = "0.1-0.6"
+Reexport = "0-0.2"
+SpecialFunctions = "0-0.8"
 julia = "0.6-1"
 
 ["0.6-0"]
+Reexport = "0.2"
+SpecialFunctions = "0.8"
 julia = "1"
 
 ["0.6.0"]
-Polynomials = "0.1.0-*"
+Polynomials = "0.1-0.6"
+FFTW = "0-1.0"
 
 ["0.6.1-0"]
-FFTW = "1.1.0-1"
+FFTW = "1.1-1"
 Polynomials = "0.6"
-Reexport = "0.2"
-SpecialFunctions = "0.8"

--- a/F/FFTW/Compat.toml
+++ b/F/FFTW/Compat.toml
@@ -1,5 +1,5 @@
 ["0-0.1"]
-AbstractFFTs = "0.2-0"
+AbstractFFTs = "0.2-0.4"
 Compat = "0.27-2"
 
 ["0-0.2"]
@@ -10,7 +10,7 @@ julia = "0.7-1"
 BinDeps = "0.6-0"
 
 ["0.2"]
-AbstractFFTs = "0.3-0"
+AbstractFFTs = "0.3-0.4"
 
 ["0.2-0.2.2"]
 Compat = "0.60-2"
@@ -21,14 +21,14 @@ Compat = "0.62-2"
 Conda = "0-1"
 
 ["0.3-0"]
-AbstractFFTs = "0.3.0-*"
+AbstractFFTs = "0.3-0.4"
 BinaryProvider = "0.3.0-*"
 
 ["0.3-1"]
 julia = "1"
 
 ["1.0"]
-AbstractFFTs = "0.3.0-*"
+AbstractFFTs = "0.3.0-0.4"
 BinaryProvider = "0.3.0-*"
 
 ["1.1-1"]


### PR DESCRIPTION
This is another attempt at #5230, which itself was an attempt at fixing the breakage
caused by JuliaMath/AbstractFFTs.jl#26 (e.g. JuliaDSP/DSP.jl#320,
JuliaDSP/DSP.jl#323, JuliaDSP/DSP.jl#324). The underlying problem is that
JuliaMath/AbstractFFTs.jl#26 moved functions from DSP.jl to AbstractFFTs.jl,
requiring users to have versions of both of those packages either before that
change or after it. Because FFTW reexports AbstractFFTs, users also have to
coordinate versions of DSP.jl and FFTW.jl.

This problem was fixed for the most recent versions of DSP.jl and
FFTW.jl (v0.6.1 and v1.1, respectively) by JuliaDSP/DSP.jl#322 and
JuliaMath/FFTW.jl#124. However, because earlier versions of FFTW do not have an
upper bound for its dependency on AbstractFFTs, and neither does DSP, Pkg cannot
currently tell that some combinations of versions for AsbtractFFTs and DSP.jl
are incompatible, which is causing users to experience issues even after the
problem was fixed for the most recent versions (JuliaDSP/DSP.jl#323,
JuliaDSP/DSP.jl#324).

Fixing the problem is made slightly more complicated because DSP does not
explicitly depend on AbstractFFTs, but instead DSP implicitly depends on
AbstractFFTs through FFTW's reexport of it, and in turn DSP explicitly depends
on FFTW.

To fix this problem, I have changed the Compat.toml for FFTW to place a upper
bound on AbstractFFTs, so that packages get a consistent interface when using
FFTW. I have also changed the Compat.toml for DSP, to avoid breakage caused by
AbstractFFTs v0.5 taking some functions that were previously defined in DSP.

In addition, the Compat.toml for DSP showed versions before 0.5.1 to be
compatible with Julia 1, which was inaccurate. I have therefore changed this
TOML table to restrict the DSP versions to the range that is compatible with
Julia 1.

I have tested that these changes work for the most recent versions of DSP and
FFTW, as well as older versions.