### PR TITLE
Fix incorrect compat entry for PlotAxes

### DIFF
--- a/P/PlotAxes/Compat.toml
+++ b/P/PlotAxes/Compat.toml
@@ -1,13 +1,15 @@
 [0]
 AxisArrays = "0.3"
 Requires = "0.5"
-Compat = "2"
 
 ["0-0.1"]
 julia = ["0.7", "1"]
 
 ["0-0.2.2"]
 DataFrames = "0.14"
+
+["0.1.12-0"]
+Compat = "2"
 
 ["0.2-0"]
 julia = "1"


### PR DESCRIPTION
https://github.com/JuliaRegistries/General/pull/5338 added an incorrect compat entry to `PlotAxes.jl`, specifically for its `Compat.jl` dependency.

This pull request fixes that error.

cc: @fredrikekre @haberdashPI 