### PR TITLE
Add a very barebones README, that we can expand on later

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# General: the official registry of general Julia packages
+
+Please read the 
+[`Registrator.jl` README](https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.md) 
+for instructions on how to register a Julia package.
+
+If your registration meets the 
+[automerge guidelines](https://github.com/JuliaRegistries/RegistryCI.jl/blob/master/README.md#automatic-merging-guidelines), 
+it will be automatically merged. Otherwise, it will require manual review by a human.


### PR DESCRIPTION
#3567 has been languishing in the queue for a while.

I think that it's important for us to get some kind of README added to the General registry. This pull request adds a very small barebones README file, consisting just of the header and two sentences.

We can add more content later (e.g. content from #3567), after this PR is merged. But I think we should get something added now.