### PR TITLE
Updated URL for AWSSQS Repo

### DIFF
--- a/A/AWSSQS/Package.toml
+++ b/A/AWSSQS/Package.toml
@@ -1,3 +1,3 @@
 name = "AWSSQS"
 uuid = "6e80b5ca-5733-51f9-999e-c18680912812"
-repo = "https://github.com/samoconnor/AWSSQS.jl.git"
+repo = "https://github.com/JuliaCloud/AWSSQS.jl.git"


### PR DESCRIPTION
The General registry repo URL for `AWSSQS` still points to Sam OConnors personal account, this needs to be updated to the JuliaCloud organization.

I just tried to register a new version of `AWSSQS` and got a failure message from the Registrator

> https://github.com/JuliaCloud/AWSSQS.jl/commit/ab566ad5f6580f4f543f1d7f339602d02b7bad9c

I wasn't able to find the appropriate steps in the FAQ, not sure if anything else needs to be updated or not, or if this is the proper steps in doing so.