### PR TITLE
Remove mentioning of users

### DIFF
--- a/.ci/remember_to_update_registryci.jl
+++ b/.ci/remember_to_update_registryci.jl
@@ -149,7 +149,7 @@ function main(relative_path;
               master_branch = "master",
               pr_branch = "github_actions/remember_to_update_registryci",
               pr_title = "Update RegistryCI.jl by updating the .ci/Manifest.toml file",
-              cc_usernames = ["DilumAluthge", "fredrikekre"],
+              cc_usernames = String[],
               my_username = "github-actions[bot]",
               my_email = "41898282+github-actions[bot]@users.noreply.github.com")
     original_project = Base.active_project()


### PR DESCRIPTION
Given that actions are enabled by default on repos I get pinged from every fork of the registry too. I suspect you also find this annoying @DilumAluthge ?