### PR TITLE
Don’t run the `remember_to_update_registryci` workflow on forks

### DIFF
--- a/.github/workflows/remember_to_update_registryci.yml
+++ b/.github/workflows/remember_to_update_registryci.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Update .ci/Manifest.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'include(".ci/remember_to_update_registryci.jl"); RememberToUpdateRegistryCI.main(".ci"; registry = "${{ github.repository }}")'
+        run: julia -e 'include(".ci/remember_to_update_registryci.jl"); "${{ github.repository }}" == "JuliaRegistries/General" && RememberToUpdateRegistryCI.main(".ci"; registry = "${{ github.repository }}")'


### PR DESCRIPTION
Fixes #6858 