### PR TITLE
Add missing 0.9.6 compatibility to Colors

### DIFF
--- a/C/Colors/Compat.toml
+++ b/C/Colors/Compat.toml
@@ -19,5 +19,9 @@ ColorTypes = "0.9"
 ["0.9.3-0.9.5"]
 ColorTypes = "0.7.4-0.7"
 
+["0.9.6"]
+ColorTypes = "0.7.4-0.8"
+FixedPointNumbers = "0.6"
+
 ["0.9.6-0"]
 julia = "1"


### PR DESCRIPTION
Sorry to trouble you again! https://github.com/JuliaGraphics/ColorTypes.jl/pull/143#issuecomment-567206533