### PR TITLE
change StructArrays URL

### DIFF
--- a/S/StructArrays/Package.toml
+++ b/S/StructArrays/Package.toml
@@ -1,3 +1,3 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-repo = "https://github.com/piever/StructArrays.jl.git"
+repo = "https://github.com/JuliaArrays/StructArrays.jl.git"


### PR DESCRIPTION
I was recommended by `@JuliaRegistrator` to do this change manually as the package was moved to the JuliaArrays organization.