### PR TITLE
Update URL for LazyJSON

### DIFF
--- a/L/LazyJSON/Package.toml
+++ b/L/LazyJSON/Package.toml
@@ -1,3 +1,3 @@
 name = "LazyJSON"
 uuid = "fc18253b-5e1b-504c-a4a2-9ece4944c004"
-repo = "https://github.com/samoconnor/LazyJSON.jl.git"
+repo = "https://github.com/JuliaCloud/LazyJSON.jl.git"


### PR DESCRIPTION
The General registry repo URL for `LazyJSON` still points to Sam OConnors personal account, this needs to be updated to the JuliaCloud organization.

I just tried to register a new version of `LazyJSON` and got a failure message from the [Registrator.](https://github.com/JuliaCloud/LazyJSON.jl/commit/cb3813802e365ed163f745b2096a4c574f22ea60#commitcomment-36527450)