### PR TITLE
Fix version bounds for CuArrays/CUDAnative

### DIFF
--- a/C/CuArrays/Compat.toml
+++ b/C/CuArrays/Compat.toml
@@ -113,7 +113,7 @@ CUDAapi = "1.2.0-1"
 Requires = "0.5"
 
 ["1.4"]
-CUDAnative = "2.5.0-2"
+CUDAnative = "2.5.0-2.6"
 
 ["1.4-1.4.1"]
 julia = "1.2.0-1"
@@ -132,10 +132,11 @@ AbstractFFTs = "0.4-0.5"
 CUDAapi = "2"
 
 ["1.5-1"]
-CUDAnative = "2.6.0-2"
+CUDAnative = "2.6.0-2.6"
 TimerOutputs = "0.5"
 
 ["1.6-1"]
 CUDAapi = "2.1.0-2"
 CUDAdrv = "5"
+CUDAnative = "2.7.0-2"
 Requires = ["0.5", "1"]


### PR DESCRIPTION
Two bounds needs adjustment:
- CUDAnative v2.7 is incompatible with CuArrays <v1.6 (non-public API change)
- CuArrays v1.6 requires CUDAnative v2.7 (bug in Project.toml at the time of registration)

```
# CuArrays 1.4
julia> v"2.7" in Pkg.Types.VersionSpec("2.5.0-2.6")
false

# CuArrays 1.5
julia> v"2.7" in Pkg.Types.VersionSpec("2.6.0-2.6")
false

# CuArrays 1.6
julia> v"2.6" in Pkg.Types.VersionSpec("2.7.0-2")
false
```