### PR TITLE
Adding artifacts

### DIFF
--- a/J/julia/Artifacts.toml
+++ b/J/julia/Artifacts.toml
@@ -1,0 +1,18 @@
+[[julia]]
+arch = "x86_64"
+git-tree-sha1 = "46ce4d79337bdd257ee2e3d2f4bb1c55ff0a5030"
+libc = "glibc"
+os = "linux"
+
+    [[julia.download]]
+    sha256 = "44099e27a3d9ebdaf9d67bfdaf745c3899654c24877c76cbeff9cade5ed79139"
+    url = "https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-linux-gnu.tar.gz"
+    
+[[julia]]
+arch = "x86_64"
+git-tree-sha1 = "46ce4d79337bdd257ee2e3d2f4bb1c55ff0a5030"
+os = "macos"
+
+    [[julia.download]]
+    sha256 = "f2e5359f03314656c06e2a0a28a497f62e78f027dbe7f5155a5710b4914439b1"
+    url = "https://github.com/Gnimuc/JuliaBuilder/releases/download/v1.3.0/julia-1.3.0-x86_64-apple-darwin14.tar.gz"


### PR DESCRIPTION
Cxx and CxxWrap need a julia binary at build time. Following a discussion with @giordano and @Gnimuc on slack how to specify julia as a binary dependency in BinaryBuilder, this is my first attempt to help with that.
I don't really know what I'm doing so this may or may not work.  