### PR TITLE
Fix WebIO's compat for JSExpr

### DIFF
--- a/W/WebIO/Compat.toml
+++ b/W/WebIO/Compat.toml
@@ -25,9 +25,11 @@ Observables = "0.2.2-0"
 
 ["0.8-0.8.1"]
 Widgets = "0.5.1-0"
+JSExpr = "0.5"
 
 ["0.8.11-0"]
 julia = ["0.7", "1"]
+JSExpr = "0.5"
 
 ["0.8.13-0"]
 AssetRegistry = "0.1"
@@ -37,6 +39,8 @@ Observables = "0.2.3-0.2"
 Requires = ["0.4.4-0.5", "1"]
 WebSockets = "1.5.0-1"
 Widgets = "0.6.2-0.6"
+JSExpr = "0.5"
 
 ["0.8.3-0.8.9"]
 julia = "1"
+JSExpr = "0.5"


### PR DESCRIPTION
I'm not 100% on the version specification format here. My understanding is that `0.5` means `[0.5.0, 0.6)`.

Please merge ASAP if looks good. :^)