### PR TITLE
AutoMerge should check the status of Travis during the cron job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           AUTOMERGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JULIA_DEBUG: RegistryCI,AutoMerge
-        run: julia --project=.ci/ -e 'using RegistryCI; using Dates; RegistryCI.AutoMerge.run(merge_new_packages=true, merge_new_versions=true, new_package_waiting_period=Day(3), new_version_waiting_period=Minute(15), registry="JuliaRegistries/General", authorized_authors=["JuliaRegistrator", "jlbuild"], suggest_onepointzero=false)'
+        run: julia --project=.ci/ -e 'using RegistryCI; using Dates; RegistryCI.AutoMerge.run(merge_new_packages = true, merge_new_versions = true, new_package_waiting_period = Day(3), new_version_waiting_period = Minute(15), registry = "JuliaRegistries/General", authorized_authors = String["JuliaRegistrator", "jlbuild"], suggest_onepointzero = false, additional_statuses = String[], additional_check_runs = String["Travis CI - Pull Request"])'


### PR DESCRIPTION
During the cron job, AutoMerge should check the `Travis CI - Pull Request` status. If Travis did not pass, AutoMerge should not merge the pull request.