### PR TITLE
Updates repo URL to point to JuliaImages Org

### DIFF
--- a/I/ImageContrastAdjustment/Package.toml
+++ b/I/ImageContrastAdjustment/Package.toml
@@ -1,3 +1,3 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
-repo = "https://github.com/zygmuntszpak/ImageContrastAdjustment.jl.git"
+repo = "https://github.com/JuliaImages/ImageContrastAdjustment.jl.git"


### PR DESCRIPTION
My ImageContrastAdjustment package is now hosted under the JuliaImages organisation. This pull-request ensures that the repo URL points to the new location.