### PR TITLE
add version upperbounds to several JuliaML packages

### DIFF
--- a/M/MLDataPattern/Compat.toml
+++ b/M/MLDataPattern/Compat.toml
@@ -1,5 +1,5 @@
 ["0.5"]
-LearnBase = "0.2-0"
-MLLabelUtils = "0.4-0"
-StatsBase = "0.24-0"
+LearnBase = "0.2"
+MLLabelUtils = "0.4-0.5"
+StatsBase = "0.24-0.32"
 julia = ["0.7", "1"]

--- a/M/MLDataUtils/Compat.toml
+++ b/M/MLDataUtils/Compat.toml
@@ -1,12 +1,12 @@
 ["0.4"]
-DataFrames = "0.11-0"
+DataFrames = "0.11-0.20"
 
 ["0.4-0.5"]
-LearnBase = "0.2-0"
-MLDataPattern = "0.5-0"
-MLLabelUtils = "0.4-0"
-StatsBase = "0.13-0"
+LearnBase = "0.2"
+MLDataPattern = "0.5"
+MLLabelUtils = "0.4-0.5"
+StatsBase = "0.13-0.32"
 julia = ["0.7", "1"]
 
 ["0.5"]
-DataFrames = "0.17-0"
+DataFrames = "0.17-0.20"

--- a/M/MLDatasets/Compat.toml
+++ b/M/MLDatasets/Compat.toml
@@ -1,7 +1,7 @@
 ["0-0.2"]
-GZip = "0"
+GZip = "0-0.5"
 ImageCore = "0.1.2-0.7"
-MAT = "0"
+MAT = "0-0.7"
 
 ["0-0.3"]
 BinDeps = "0"
@@ -11,11 +11,11 @@ FixedPointNumbers = "0.3-0.5"
 julia = ["0.7", "1"]
 
 ["0.3"]
-GZip = "0.5-0"
+GZip = "0.5"
 Requires = "0"
 
 ["0.4-0"]
-ColorTypes = "0.4.0-*"
-DataDeps = "0.3.0-*"
-FixedPointNumbers = "0.3.0-*"
-julia = "1.0.0-1"
+ColorTypes = "0.4.0-0.9"
+DataDeps = "0.3.0-0.7"
+FixedPointNumbers = "0.3.0-0.7"
+julia = "1"

--- a/M/MLLabelUtils/Compat.toml
+++ b/M/MLLabelUtils/Compat.toml
@@ -1,5 +1,5 @@
 ["0.4-0.5"]
-LearnBase = "0.2-0"
-MappedArrays = "0.2-0"
-StatsBase = "0.24-0"
+LearnBase = "0.2"
+MappedArrays = "0.2"
+StatsBase = "0.24-0.32"
 julia = ["0.7", "1"]


### PR DESCRIPTION
The idea here is to restrict the upper bound to the latest available versions (at this time point) for some packages under JuliaML and then use CompatHelper to roll the versions. These packages are what I plan to maintain in the near future.

cf: https://github.com/JuliaML/MLDataPattern.jl/pull/34

cc: @evizero @joshday