### PR TITLE
Fix JSExpr compat for Knockout.jl

### DIFF
--- a/K/Knockout/Compat.toml
+++ b/K/Knockout/Compat.toml
@@ -10,10 +10,12 @@ JSExpr = "0"
 JSON = "0"
 
 ["0.2.0-0.2.2"]
+JSExpr = "0"
 Observables = "0.2.2-0"
 WebIO = "0.3-0"
 julia = ["0.7", "1"]
 
 ["0.2.3"]
+JSExpr = "0"
 WebIO = "0.8.0-*"
 julia = ["0.7", "1"]


### PR DESCRIPTION
JSExpr v1 was yanked (because reasons) but yanking doesn't exist for Julia 1.0.

This should fix the compat so that only versions `[0.0, 1.0)` can be installed (please make sure that's what the bound is actually doing - I'm not 💯 percent certain).