### PR TITLE
XMLDict: Update URL from samoconnor->JuliaCloud

### DIFF
--- a/X/XMLDict/Package.toml
+++ b/X/XMLDict/Package.toml
@@ -1,3 +1,3 @@
 name = "XMLDict"
 uuid = "228000da-037f-5747-90a9-8195ccbf91a5"
-repo = "https://github.com/samoconnor/XMLDict.jl.git"
+repo = "https://github.com/JuliaCloud/XMLDict.jl.git"


### PR DESCRIPTION
Need to update the repo URL for XMLDict so that I can release a new version, [here](https://github.com/JuliaCloud/XMLDict.jl/commit/438624af9b91feefef0e4ebabf4a5e99f84089c7#commitcomment-36800418)