### PR TITLE
Widen HTTPClient's bounds for Compat.jl

### DIFF
--- a/H/HTTPClient/Compat.toml
+++ b/H/HTTPClient/Compat.toml
@@ -1,4 +1,4 @@
 ["0.2"]
-Compat = "0.8-2"
+Compat = "0.8-3"
 LibCURL = "0"
 julia = "0.4-1"


### PR DESCRIPTION
In trying to update `add Compat@3.1`, I learned that

* MKL https://github.com/JuliaComputing/MKL.jl/blob/master/Project.toml needs PackageCompiler = "0.6.5"
* https://github.com/JuliaLang/PackageCompiler.jl/blob/master/Project.toml needs WinRPM = "0.4.3"
* https://github.com/JuliaPackaging/WinRPM.jl/blob/master/Project.toml needs HTTPClient = "0.1, 0.2"
* and https://github.com/JuliaWeb/HTTPClient.jl is an archived repository, and only has a REQUIRE file, but is listed here as needing Compat <= 2. 

So is this the right way to fix it? 

Had a similar problem in https://github.com/JuliaRegistries/General/pull/7094. Should there perhaps be some global change to all the registry's upper bounds on Compat.jl? These must all have been generated somehow. 