### PR TITLE
New version: LLVM_jll v8.0.1+1

### DIFF
--- a/L/LLVM_jll/Versions.toml
+++ b/L/LLVM_jll/Versions.toml
@@ -1,3 +1,6 @@
+["8.0.1+0"]
+git-tree-sha1 = "c037c15f36c185c613e5b2589d5833720dab3f76"
+
 ["9.0.1+0"]
 git-tree-sha1 = "3c5680e7644e230f7e3327ee0354f6a4fa75aaca"
 


### PR DESCRIPTION
Manual pull-request since I need to insert a version
of LLVM_jll before the earliest current registered.

x-ref https://github.com/JuliaRegistries/RegistryTools.jl/issues/6