### PR TITLE
Updating repo directory for ClimateEasy.

### DIFF
--- a/C/ClimateEasy/Package.toml
+++ b/C/ClimateEasy/Package.toml
@@ -1,3 +1,3 @@
 name = "ClimateEasy"
 uuid = "47ceb0c8-0fe6-4c49-a4a1-92bc59187c00"
-repo = "https://github.com/natgeo-wong/ClimateEasy.jl.git"
+repo = "https://github.com/JuliaClimate/ClimateEasy.jl.git"


### PR DESCRIPTION
ClimateEasy has been transferred to the JuliaClimate organization and therefore has a different repo address.