### PR TITLE
Manual tag a new version of X11_jll which makes the package inactive

### DIFF
--- a/X/X11_jll/Versions.toml
+++ b/X/X11_jll/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "201e3596e43c9240a46f99692d663e91ec172f2e"
 
 ["1.6.8+4"]
 git-tree-sha1 = "dbded9081d84be23bd31108e60ecac84f4e82e33"
+
+["1.6.8+5"]
+git-tree-sha1 = "dfadaea7e3fa9120b06824b634342fc6cba58109"


### PR DESCRIPTION
For reference:

* https://github.com/JuliaBinaryWrappers/X11_jll.jl/pull/1
* https://github.com/JuliaLang/Pkg.jl/issues/1631

`SDL2_jll` is the only package still depending only on `X11_jll`, but it'll be fixed by #8428