### PR TITLE
Fix Memento unbounded Compat

### DIFF
--- a/M/Memento/Compat.toml
+++ b/M/Memento/Compat.toml
@@ -1,15 +1,12 @@
 ["0.10"]
 Compat = "0.65-2"
-JSON = "0.16.1-0"
 Nullables = "0.0.3-1"
-Syslogs = "0"
-TimeZones = "0.7-0"
 julia = "0.6-1"
 
-["0.11-0.12"]
-JSON = "0.16.1-*"
-Syslogs = "0.0.1-*"
-TimeZones = "0.7.0-*"
+["0.10-0.12"]
+JSON = "0.16.1-0"
+Syslogs = "0"
+TimeZones = "0.7-1"
 
 ["0.11-0.12"]
 julia = ["0.7", "1"]

--- a/M/Memento/Compat.toml
+++ b/M/Memento/Compat.toml
@@ -1,12 +1,15 @@
 ["0.10"]
 Compat = "0.65-2"
-Nullables = "0.0.3-1"
-julia = "0.6-1"
-
-["0.10-0.12"]
 JSON = "0.16.1-0"
+Nullables = "0.0.3-1"
 Syslogs = "0"
 TimeZones = "0.7-0"
+julia = "0.6-1"
+
+["0.11-0.12"]
+JSON = "0.16.1-*"
+Syslogs = "0.0.1-*"
+TimeZones = "0.7.0-*"
 
 ["0.11-0.12"]
 julia = ["0.7", "1"]


### PR DESCRIPTION
The change that [removed packages which didn't support Julia 1.0](https://github.com/JuliaRegistries/General/pull/4169) caused this compat file to no longer reflect the requirements stated by the packages Project.toml.

The reason I want this change is currently these bounds are stopping Memento from using TimeZones 1.0. I've spoken to the @rofinn about releasing a new version of Memento which should be happening later this week but this will fix the problem right away.