### PR TITLE
Add a Travis badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # General
 
+[![Build Status](https://travis-ci.com/JuliaRegistries/General.svg?branch=master)](https://travis-ci.com/JuliaRegistries/General/branches)
 [![AutoMerge status](https://github.com/JuliaRegistries/General/workflows/AutoMerge/badge.svg?event=schedule)](https://github.com/JuliaRegistries/General/actions?query=workflow%3AAutoMerge+event%3Aschedule)
 
 General is the default Julia package registry. Package registries are used by Julia's


### PR DESCRIPTION
I’ve set Travis to run a daily cron job on master, just as a sanity check to make sure we haven’t introduced any semantic conflicts.

So we might as well put a Travis badge in the README.