### PR TITLE
Loosen Requires compat for ROCAnalysis

### DIFF
--- a/R/ROCAnalysis/Compat.toml
+++ b/R/ROCAnalysis/Compat.toml
@@ -1,5 +1,5 @@
 ["0.3"]
 DataFrames = "0"
-Requires = "0"
+Requires = "0-1"
 SpecialFunctions = "0"
 julia = ["0.7", "1"]


### PR DESCRIPTION
(This is fine because Requires 1.0 was not a breaking release.)