### PR TITLE
add upper bounds for packages in ImageBinarization

### DIFF
--- a/I/ImageBinarization/Compat.toml
+++ b/I/ImageBinarization/Compat.toml
@@ -1,8 +1,8 @@
 [0]
-ColorTypes = "0"
-HistogramThresholding = "0"
-ImageContrastAdjustment = "0"
-Polynomials = "0"
+ColorTypes = "0-0.9"
+HistogramThresholding = "0-0.2"
+ImageContrastAdjustment = "0-0.3"
+Polynomials = "0-0.6"
 julia = "1"
 
 ["0-0.1.0"]
@@ -11,11 +11,11 @@ FixedPointNumbers = "0-0.5"
 ImageCore = "0-0.7"
 
 ["0.1.1-0"]
-ColorVectorSpace = "0"
+ColorVectorSpace = "0-0.8"
 
 ["0.1.1-0.1"]
-FixedPointNumbers = "0"
-ImageCore = "0"
+FixedPointNumbers = "0-0.7"
+ImageCore = "0-0.8"
 
 ["0.2-0"]
-ImageCore = "0.8.3-*"
+ImageCore = "0.8.3-0.8"


### PR DESCRIPTION
This compat fix cooperates https://github.com/zygmuntszpak/ImageBinarization.jl/pull/55 to avoid old ImageBinarization versions being unexpectedly used.

cc: @zygmuntszpak 