### PR TITLE
Fix Microbiome package compats

### DIFF
--- a/B/BiobakeryUtils/Compat.toml
+++ b/B/BiobakeryUtils/Compat.toml
@@ -1,6 +1,6 @@
 [0]
 CSV = "0"
 DataFrames = "0"
-Microbiome = "0.3, 0.4"
+Microbiome = ["0.3", "0.4"]
 RCall = "0"
 julia = ["0.7", "1.0"]

--- a/B/BiobakeryUtils/Compat.toml
+++ b/B/BiobakeryUtils/Compat.toml
@@ -1,6 +1,6 @@
 [0]
 CSV = "0"
 DataFrames = "0"
-Microbiome = "0.3-0"
+Microbiome = "0.3, 0.4"
 RCall = "0"
-julia = ["0.7", "1"]
+julia = ["0.7", "1.0"]

--- a/M/Microbiome/Compat.toml
+++ b/M/Microbiome/Compat.toml
@@ -1,8 +1,8 @@
 [0]
 Clustering = "0"
-DataFrames = "0"
-Distances = "0"
+DataFrames = "0.15"
+Distances = "0.7"
 Reexport = "0"
-SpatialEcology = "0.4-0"
+SpatialEcology = "0.4"
 StatsBase = "0"
-julia = ["0.7", "1"]
+julia = ["0.7", "1.0"]

--- a/M/MicrobiomePlots/Compat.toml
+++ b/M/MicrobiomePlots/Compat.toml
@@ -1,6 +1,6 @@
 [0]
 Colors = "0"
-Microbiome = "0.3, 0.4"
+Microbiome = ["0.3", "0.4"]
 RecipesBase = "0"
 StatPlots = "0"
 julia = ["0.7", "1.0"]

--- a/M/MicrobiomePlots/Compat.toml
+++ b/M/MicrobiomePlots/Compat.toml
@@ -1,6 +1,6 @@
 [0]
 Colors = "0"
-Microbiome = "0.3-0"
+Microbiome = "0.3, 0.4"
 RecipesBase = "0"
 StatPlots = "0"
-julia = ["0.7", "1"]
+julia = ["0.7", "1.0"]


### PR DESCRIPTION
As of Julia 1.1, I moved my 3 Microbiome-related packages ([`Microbiome.jl`][1], [`MicrobiomePlots.jl`][2], and [`BiobakeryUtils.jl`][3]) to the BioJulia registry.

This adds more restrictive compatibility requirements. I'm not sure exactly what's correct for these, but I picked versions of DataFrames, Clustering and Distances that were out around the time of the last release for Microbiome, and then just made the other two packages depend on the last version of Microbiome available in General. 

I'm not 100% confident in how the compat boundaries work, please let me know if I need to fix anything.

[1]: https://github.com/BioJulia/Microbiome.jl
[2]: https://github.com/BioJulia/MicrobiomePlots.jl
[3]: https://github.com/BioJulia/BiobakeryUtils.jl