### PR TITLE
Add compat upper bounds for Microbiome and friends

### DIFF
--- a/B/BiobakeryUtils/Compat.toml
+++ b/B/BiobakeryUtils/Compat.toml
@@ -1,4 +1,4 @@
-[0]
+["0-0.1"]
 CSV = "0"
 DataFrames = "0"
 Microbiome = ["0.3", "0.4"]

--- a/M/Microbiome/Compat.toml
+++ b/M/Microbiome/Compat.toml
@@ -1,4 +1,4 @@
-[0]
+["0-0.4"]
 Clustering = "0"
 DataFrames = "0.15"
 Distances = "0.7"

--- a/M/MicrobiomePlots/Compat.toml
+++ b/M/MicrobiomePlots/Compat.toml
@@ -1,4 +1,4 @@
-[0]
+["0-0.1"]
 Colors = "0"
 Microbiome = ["0.3", "0.4"]
 RecipesBase = "0"


### PR DESCRIPTION
The open-ended `[0]` from #10262 was causing weird conflicts with the BioJulia registry. This adds upper bounds for the last version of each package that was registered in General.