### PR TITLE
Fix DataFrames' bounds on Tables

### DIFF
--- a/D/DataFrames/Compat.toml
+++ b/D/DataFrames/Compat.toml
@@ -54,7 +54,7 @@ PooledArrays = "0.5-0"
 
 ["0.18.2"]
 TableTraits = "0.4.0-1"
-Tables = "0.1.15-*"
+Tables = "0.1.15-0"
 
 ["0.18.2-0.18"]
 CategoricalArrays = "0.5.2-*"
@@ -74,7 +74,7 @@ IteratorInterfaceExtensions = ["0.1.1-0.1", "1"]
 TableTraits = ["0.4", "1"]
 
 ["0.18.3-0.19"]
-Tables = "0.2.3-*"
+Tables = "0.2.3-0"
 
 ["0.19"]
 CategoricalArrays = "0.5.4-*"


### PR DESCRIPTION
This is a pretty minimal change, it fixes the situation that right now some of these older DataFrame versions declare themselves compatible with Tables 1.0.x, when they are actually not.

Right now this is creating havoc in a lot of places, so it would be good if we could fix/merge this ASAP.

CC @quinnj, @bkamins, @nalimilan