### PR TITLE
Additional bounds on dependencies on old DataFrames.jl releases

### DIFF
--- a/D/DataFrames/Compat.toml
+++ b/D/DataFrames/Compat.toml
@@ -1,22 +1,22 @@
 ["0-0.11"]
-CategoricalArrays = "0.3.6-0"
+CategoricalArrays = "0.3.6-0.7"
 julia = "0.6-1"
 
 ["0-0.17"]
 CodecZlib = "0.4-0"
 DataStreams = "0.3-0"
-Reexport = "0"
-SortingAlgorithms = "0"
+Reexport = "0.1-0.2"
+SortingAlgorithms = "0.1-0.3"
 TranscodingStreams = "0"
 WeakRefStrings = "0.4-0.5"
 
 ["0-0.18.1"]
 Compat = "0.59-2"
-Missings = "0.2.3-0"
-StatsBase = "0.11-0"
+Missings = "0.2.3-0.4"
+StatsBase = "0.11-0.32"
 
 ["0.12-0.13"]
-CategoricalArrays = "0.3.11-0"
+CategoricalArrays = "0.3.11-0.7"
 
 ["0.12-0.17"]
 julia = ["0.7", "1"]
@@ -26,7 +26,7 @@ IteratorInterfaceExtensions = "0-1"
 TableTraits = "0-1"
 
 ["0.14-0.15"]
-CategoricalArrays = "0.3.14-0"
+CategoricalArrays = "0.3.14-0.7"
 
 ["0.14-0.16"]
 Tables = "0"
@@ -38,7 +38,7 @@ TableTraits = "0.4-1"
 IteratorInterfaceExtensions = "0.1.1-1"
 
 ["0.16-0.18.1"]
-CategoricalArrays = "0.5.2-0"
+CategoricalArrays = "0.5.2-0.7"
 
 ["0.17.0"]
 Tables = "0.1.14-0"
@@ -50,24 +50,24 @@ Tables = "0.1.15-0"
 julia = "1"
 
 ["0.18-0.18.1"]
-PooledArrays = "0.5-0"
+PooledArrays = "0.5"
 
 ["0.18.2"]
 TableTraits = "0.4.0-1"
 Tables = "0.1.15-0"
 
 ["0.18.2-0.18"]
-CategoricalArrays = "0.5.2-*"
-Compat = "0.59.0-*"
+CategoricalArrays = "0.5.2-0.7"
+Compat = "0.59.0-2"
 
 ["0.18.2-0.19"]
-PooledArrays = "0.5.0-*"
+PooledArrays = "0.5.0"
 
 ["0.18.2-0.19.0"]
-StatsBase = "0.11.0-*"
+StatsBase = "0.11.0-0.32"
 
 ["0.18.2-0.19.3"]
-Missings = "0.2.3-*"
+Missings = "0.2.3-0.4"
 
 ["0.18.3-0"]
 IteratorInterfaceExtensions = ["0.1.1-0.1", "1"]
@@ -77,7 +77,7 @@ TableTraits = ["0.4", "1"]
 Tables = "0.2.3-0"
 
 ["0.19"]
-CategoricalArrays = "0.5.4-*"
+CategoricalArrays = "0.5.4-0.7"
 Compat = "2"
 
 ["0.19-0"]
@@ -87,7 +87,7 @@ InvertedIndices = "1"
 DataAPI = "1.0.1-1"
 
 ["0.19.4-0.19"]
-Missings = "0.4.2-*"
+Missings = "0.4.2-0.4"
 
 ["0.20-0"]
 CategoricalArrays = "0.7"


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2137

The bounds are added in a way that the bounds are less or equal than the bounds on 0.20.2. In this way - if I understand things correctly - there should be no risk that an old version of DataFrames.jl will be installed instead of latest release because it has looser bounds.