### PR TITLE
Move EllipticalSliceSampling to TuringLang

### DIFF
--- a/E/EllipticalSliceSampling/Package.toml
+++ b/E/EllipticalSliceSampling/Package.toml
@@ -1,3 +1,3 @@
 name = "EllipticalSliceSampling"
 uuid = "cad2338a-1db2-11e9-3401-43bc07c9ede2"
-repo = "https://github.com/devmotion/EllipticalSliceSampling.jl.git"
+repo = "https://github.com/TuringLang/EllipticalSliceSampling.jl.git"


### PR DESCRIPTION
I've transferred EllipticalSliceSampling to the TuringLang organization.