### PR TITLE
update URL for CodecZlib

### DIFF
--- a/C/CodecZlib/Package.toml
+++ b/C/CodecZlib/Package.toml
@@ -1,3 +1,3 @@
 name = "CodecZlib"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-repo = "https://github.com/bicycle1885/CodecZlib.jl.git"
+repo = "https://github.com/JuliaIO/CodecZlib.jl"


### PR DESCRIPTION
The package has been moved to https://github.com/JuliaIO/CodecZlib.jl