### PR TITLE
New version: libLLVM_jll v9.0.1+2

### DIFF
--- a/L/libLLVM_jll/Versions.toml
+++ b/L/libLLVM_jll/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "3558af68de541268b450ffbef746ae807e284f94"
 
 ["9.0.1+1"]
 git-tree-sha1 = "a83706a333655a3f2ef6fc785191cbfff6b43806"
+
+["9.0.1+2"]
+git-tree-sha1 = "744581d8eef43947a0aed99afddeafa525602d53"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libLLVM_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libLLVM_jll.jl
* Version: v9.0.1+2
