### PR TITLE
New version: LLVM_jll v9.0.1+5

### DIFF
--- a/L/LLVM_jll/Compat.toml
+++ b/L/LLVM_jll/Compat.toml
@@ -3,3 +3,6 @@ julia = "1"
 
 [8-9]
 julia = "1"
+
+[9]
+libLLVM_jll = "9.0.1"

--- a/L/LLVM_jll/Deps.toml
+++ b/L/LLVM_jll/Deps.toml
@@ -5,3 +5,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 [8-9]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[9]
+libLLVM_jll = "8f36deef-c2a5-5394-99ed-8e07531fb29a"

--- a/L/LLVM_jll/Versions.toml
+++ b/L/LLVM_jll/Versions.toml
@@ -18,3 +18,6 @@ git-tree-sha1 = "2254cd6378b178ab445c0504a2ace5bb4457d0bb"
 
 ["9.0.1+4"]
 git-tree-sha1 = "69a69b17c4ab4fc60e96830e58cb9847b5f2be6b"
+
+["9.0.1+5"]
+git-tree-sha1 = "48e16483d67cff21b936a2edfedaed0642a070f2"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LLVM_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LLVM_jll.jl
* Version: v9.0.1+5
