### PR TITLE
Fix rename

### DIFF
--- a/F/Firefly/Package.toml
+++ b/F/Firefly/Package.toml
@@ -1,3 +1,3 @@
 name = "Firefly"
 uuid = "38d273ff-5bca-42e1-8e07-0e7ae0d15fdd"
-repo = "https://github.com/juliahci/Firefly.jl.git"
+repo = "https://github.com/JuliaHCI/Firefly.jl.git"

--- a/F/Firefly/Package.toml
+++ b/F/Firefly/Package.toml
@@ -1,3 +1,3 @@
 name = "Firefly"
 uuid = "38d273ff-5bca-42e1-8e07-0e7ae0d15fdd"
-repo = "https://github.com/mileslucas/Firefly.jl.git"
+repo = "https://github.com/juliahci/Firefly.jl.git"


### PR DESCRIPTION
From PR #11253 I have, in less than a day, transferred the repo. I read through the official docs on renaming, but given the short lifetime and the guarantee that there are 0 downstream users of this, could the simple rename be authorized?