### PR TITLE
Fix DiffEqDiffTools package redirect

### DIFF
--- a/D/DiffEqDiffTools/Package.toml
+++ b/D/DiffEqDiffTools/Package.toml
@@ -1,3 +1,3 @@
 name = "DiffEqDiffTools"
 uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
-repo = "https://github.com/SciML/DiffEqDiffTools.jl.git"
+repo = "https://github.com/JuliaDiff/FiniteDiff.jl.git"


### PR DESCRIPTION
JuliaDiffEq/DiffEqDiffTools -> JuliaDiff/FiniteDiff.jl, and now it seems the link forwarding broke, so this should fix it again.