### PR TITLE
New version: OpenBLASHighCoreCount_jll v0.3.7+1

### DIFF
--- a/O/OpenBLASHighCoreCount_jll/Versions.toml
+++ b/O/OpenBLASHighCoreCount_jll/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "139ca771e7745a7e90f7eb708fd794d96a372b85"
 
 ["0.3.7+0"]
 git-tree-sha1 = "cb32bd162b25b27c5cb8bb8cfc236365a586a80f"
+
+["0.3.7+1"]
+git-tree-sha1 = "9950aeaca1fec64d992eb9e1d39c6c050cebbfca"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package OpenBLASHighCoreCount_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/OpenBLASHighCoreCount_jll.jl
* Version: v0.3.7+1
