### PR TITLE
New version: DataStructures v0.17.11

### DIFF
--- a/D/DataStructures/Versions.toml
+++ b/D/DataStructures/Versions.toml
@@ -60,3 +60,6 @@ git-tree-sha1 = "b7720de347734f4716d1815b00ce5664ed6bbfd4"
 
 ["0.17.10"]
 git-tree-sha1 = "5a431d46abf2ef2a4d5d00bd0ae61f651cf854c8"
+
+["0.17.11"]
+git-tree-sha1 = "73eb18320fe3ba58790c8b8f6f89420f0a622773"


### PR DESCRIPTION
release for v0.17.11, which was registered before as a skipped version, for a different `git-tree-sha1`