### PR TITLE
Manual fix - VideoIO: Retroactively add upper bound to FFMPEG compat

### DIFF
--- a/V/VideoIO/Compat.toml
+++ b/V/VideoIO/Compat.toml
@@ -29,7 +29,6 @@ FixedPointNumbers = "0.3.0-*"
 
 ["0.6.11-0"]
 ColorTypes = "0.9"
-FFMPEG = "0.2"
 Glob = "1.2.0-1"
 ImageCore = "0.8"
 ImageTransformations = "0.8"
@@ -37,5 +36,5 @@ ProgressMeter = "1.2.0-1"
 Requires = "1"
 julia = ["0.7", "1"]
 
-["0.6.8-0.6.10"]
-FFMPEG = "0.2.0-*"
+["0.6.8-0"]
+FFMPEG = "0.2"


### PR DESCRIPTION
This retroactively adds an upper bound to the FFMPEG compat that was in effect from 0.6.8-0.6.10 inclusive

Done because https://github.com/JuliaIO/VideoIO.jl/issues/227 is lingering