### PR TITLE
Fix PhyloModels v0.3.2 release

### DIFF
--- a/P/PhyloModels/Versions.toml
+++ b/P/PhyloModels/Versions.toml
@@ -5,4 +5,4 @@ git-tree-sha1 = "579acbd917c2f2ab5c578ca2f1198602387fd926"
 git-tree-sha1 = "5fe18a6fad962b96aca35e8ab1164637f16ad175"
 
 ["0.3.2"]
-git-tree-sha1 = "db3635c0b7fec2bb460ccea524f6f6732c672d75"
+git-tree-sha1 = "4ba53447e5ca5013a93f9cc2e96bc9ca83358408"


### PR DESCRIPTION
I made a mindless error in v0.3.2 that I registered last night. I would like to change the commit association on the registry to the fixed version please.