### PR TITLE
Widen GraphPlot's compat: Compose = ["0.7", "0.8"]

### DIFF
--- a/G/GraphPlot/Compat.toml
+++ b/G/GraphPlot/Compat.toml
@@ -13,6 +13,6 @@ VisualRegressionTests = "0.2.2-0"
 ArnoldiMethod = "0.0.4"
 ColorTypes = "0.9"
 Colors = "0.11"
-Compose = "0.7"
+Compose = ["0.7", "0.8"]
 LightGraphs = "1.1.0-1"
 julia = "1"


### PR DESCRIPTION
Since GraphPlot 0.4 works with Compose 0.8, this is fine.

This should tide us over until the next registration of GraphPlot.

cc: @KristofferC 