### PR TITLE
Revert "New version: ModelingToolkit v1.5.0 (#12792)"

### DIFF
--- a/M/ModelingToolkit/Compat.toml
+++ b/M/ModelingToolkit/Compat.toml
@@ -65,8 +65,3 @@ julia = "1.2.0-1"
 
 ["1.2.7-1"]
 Latexify = "0.11-0.13"
-
-["1.5-1"]
-SafeTestsets = "0.0.1"
-TreeViews = "0.3"
-Unitful = "1.1.0-1"

--- a/M/ModelingToolkit/Deps.toml
+++ b/M/ModelingToolkit/Deps.toml
@@ -20,8 +20,3 @@ GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
 
 ["0.9-1"]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-
-["1.5-1"]
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/M/ModelingToolkit/Versions.toml
+++ b/M/ModelingToolkit/Versions.toml
@@ -129,6 +129,3 @@ git-tree-sha1 = "fbd6b367d0d37b1533f71a44c20abc237eab6bc6"
 
 ["1.4.3"]
 git-tree-sha1 = "f7252135b2a8d27800a04121e49aa0ac9128a626"
-
-["1.5.0"]
-git-tree-sha1 = "06d768c366ae5ace5310a6bea4624ac96ce1b0a5"


### PR DESCRIPTION
This MTK v1.5 tag since it was more breaking than I thought, and is replaced with a 2.0 tag.
