### PR TITLE
julia versions: remove all < v0.7, add all ≥ v0.7

### DIFF
--- a/J/julia/Versions.toml
+++ b/J/julia/Versions.toml
@@ -1,96 +1,3 @@
-["0.1.1"]
-git-tree-sha1 = "ef9dab73df8b626ccf8c882c57b39be5b381ede9"
-
-["0.1.2"]
-git-tree-sha1 = "efe2c73a989c98a6b234ce2362a5fee44c0f9cd1"
-
-["0.2.0"]
-git-tree-sha1 = "311d0a6a17feb7d78617f458057aa9ccfd8a8c74"
-
-["0.2.1"]
-git-tree-sha1 = "e9c9e57078d44dc7fbfc338b3e22c38c3c0163df"
-
-["0.3.0"]
-git-tree-sha1 = "12480857d6852be64452696cdde7b9bdb048c081"
-
-["0.3.1"]
-git-tree-sha1 = "936e336187794b7d3325db805fbf78d0061e6787"
-
-["0.3.2"]
-git-tree-sha1 = "4ea1bda7595a12d250ee813f32984788aa4c38ee"
-
-["0.3.3"]
-git-tree-sha1 = "ec537b264dd7da62f3ff7fb44deb444b06eac4f7"
-
-["0.3.4"]
-git-tree-sha1 = "f7d4ad08332bd05635435d5519528c00c4c6be09"
-
-["0.3.5"]
-git-tree-sha1 = "663180565cc308269d9467d572ebcfe85a4b06fd"
-
-["0.3.6"]
-git-tree-sha1 = "723936e336b5730037d80ee1e11d014bd00c3dc1"
-
-["0.3.7"]
-git-tree-sha1 = "518ef1c58630f81242c9ee56226a7fad86b21d7e"
-
-["0.3.8"]
-git-tree-sha1 = "2573a2c687ea64629534e78fdf7a9d75dfb27e4e"
-
-["0.3.9"]
-git-tree-sha1 = "f052e29e038b0f9049e77b7e1413564bcdd1b2df"
-
-["0.3.10"]
-git-tree-sha1 = "f673d35ac2190ddb29bbc86b6faaa7b2e7f4df1b"
-
-["0.3.11"]
-git-tree-sha1 = "bcefb95337d46b150717fe68d34d80f0e0024ad3"
-
-["0.3.12"]
-git-tree-sha1 = "b15b2df56b7c50555207c834559af449f4f356a8"
-
-["0.4.0"]
-git-tree-sha1 = "2c4a1ae8ab77958b6229f49826d85a324801faf8"
-
-["0.4.1"]
-git-tree-sha1 = "dab03ca4529608ef0c7fdc82cf7c0b2afcf0c53f"
-
-["0.4.2"]
-git-tree-sha1 = "840c9480b51eeba14e6ee69595aedf166273242f"
-
-["0.4.3"]
-git-tree-sha1 = "ba845b8e1cb72f76cc1e95bb2ba38c3ed849c45a"
-
-["0.4.4"]
-git-tree-sha1 = "013cdf9d7901fc890039dc2538022a0430e26164"
-
-["0.4.5"]
-git-tree-sha1 = "14c2871a2e50d084c5fbcd359520182fe5384869"
-
-["0.4.6"]
-git-tree-sha1 = "df196c24392c9fd29cda1301908b3db59510c23f"
-
-["0.4.7"]
-git-tree-sha1 = "05f73b87a46e170864a6b09d2f3ff475b9737efc"
-
-["0.5.0"]
-git-tree-sha1 = "fb187e13e6a459d879c3b1be879f8f699300cca6"
-
-["0.5.1"]
-git-tree-sha1 = "e33071ecc92c4f8a29ee3a7aefa7b94247e12fbc"
-
-["0.5.2"]
-git-tree-sha1 = "5ec2d66880c6372353cadca92d3447a224cccd54"
-
-["0.6.0"]
-git-tree-sha1 = "4a238dffa9ca2c49093951e23fe3f7d6e312d412"
-
-["0.6.1"]
-git-tree-sha1 = "ee8e72cdb2f09b7020d76215ac5a27f4041892f8"
-
-["0.6.2"]
-git-tree-sha1 = "f99623880b74ba75ee4b9913bd1d560bf3022036"
-
 ["0.7.0"]
 git-tree-sha1 = "5d7cd38907c5a2f13a91aef09a8a115af7d67cf6"
 
@@ -106,6 +13,12 @@ git-tree-sha1 = "3d25cb3688217b68e09d17b0ce66572beef468f3"
 ["1.0.3"]
 git-tree-sha1 = "9074b3b1fc77a40595e57a2734a76d0474743079"
 
+["1.0.4"]
+git-tree-sha1 = "73db820d31b42675e968dd03476633cc96fbfa8c"
+
+["1.0.5"]
+git-tree-sha1 = "9c9766c6114fc791204cf557187ea8c1031d6a12"
+
 ["1.1.0"]
 git-tree-sha1 = "cfc4dab5cf18a65cc66cb4532693464b8ec4fb16"
 
@@ -113,10 +26,13 @@ git-tree-sha1 = "cfc4dab5cf18a65cc66cb4532693464b8ec4fb16"
 git-tree-sha1 = "dd5052903f82991f6abf890807613c82f2764b94"
 
 ["1.2.0"]
-git-tree-sha1 = "6479347f6b59bcc46718951422fc0f84797ea60f"
+git-tree-sha1 = "78836c5411dbb845a2939b575636bec76af33750"
 
 ["1.3.0"]
-git-tree-sha1 = "2eeca35732d7d29de053cce73556c159c28e73fb"
+git-tree-sha1 = "7f3a3703801bf18110e153dba6d8ab13463104f1"
+
+["1.3.1"]
+git-tree-sha1 = "96289efc314f553d99ca59fe9c72aab3231ab93e"
 
 ["1.4.0"]
 git-tree-sha1 = "529cee90ffb6bfacfec2e2b9154107c8bc1268df"


### PR DESCRIPTION
Generated with:
```jl
versions = filter!(>=(v"0.7"), map(VersionNumber,
    filter!(contains(r"^v\d+\.\d+\.\d+$"), readlines(`git tag -l`))))

for v in versions
    sha1 = readchomp(`git rev-parse v$v^{tree}`)
    println("[\"$v\"]")
    println("git-tree-sha1 = ", repr(sha1))
    println()
end
```