### PR TITLE
[MeshCatMechanisms.jl] Add upper bounds on historical compat entries

### DIFF
--- a/M/MeshCatMechanisms/Compat.toml
+++ b/M/MeshCatMechanisms/Compat.toml
@@ -1,8 +1,8 @@
 ["0-0.0.1"]
 FileIO = "0.1-1"
-GeometryTypes = "0.4-0"
+GeometryTypes = "0.4-0.7"
 LightXML = "0.4-0"
-MeshIO = "0.1-0"
+MeshIO = "0.1-0.3"
 
 ["0-0.0.2"]
 MeshCat = "0-0.5"
@@ -11,11 +11,11 @@ MeshCat = "0-0.5"
 julia = "0.6-1"
 
 ["0-0.2.0"]
-Interpolations = "0.3.6-0"
+Interpolations = "0.3.6-0.12"
 
 ["0-0.3"]
-ColorTypes = "0.2-0"
-CoordinateTransformations = "0.4.1-0"
+ColorTypes = "0.2-0.9"
+CoordinateTransformations = "0.4.1-0.5"
 LoopThrottle = "0"
 RigidBodyDynamics = "0.4-1"
 
@@ -26,54 +26,54 @@ MechanismGeometries = "0-0.1"
 MeshCat = "0.0.2-0.5"
 
 ["0.0.6-0.3"]
-GeometryTypes = "0.4-0"
+GeometryTypes = "0.4-0.7"
 
 ["0.1-0.2"]
 MeshCat = "0.2.1-0.5"
 
 ["0.1.0"]
-InteractBase = "0.3-0"
+InteractBase = "0.3"
 
 ["0.1.1-0.1"]
 Compat = "0.50-2"
-InteractBase = "0.5-0"
+InteractBase = "0.5"
 
 ["0.1.1-0.2.0"]
 DataStructures = "0.7-0"
 
 ["0.2-0.3"]
-InteractBase = "0.8-0"
+InteractBase = "0.8-0.10"
 julia = ["0.7", "1"]
 
 ["0.2.1-0.2"]
 MechanismGeometries = "0.1.2-0.1"
 
 ["0.2.1-0.3"]
-Interpolations = "0.9-0"
+Interpolations = "0.9-0.12"
 OrderedCollections = "1"
 
 ["0.3"]
-MechanismGeometries = "0.2-0"
-MeshCat = "0.6-0"
+MechanismGeometries = "0.2"
+MeshCat = "0.6"
 
 ["0.4"]
-MechanismGeometries = "0.2.0-*"
-MeshCat = "0.6.0-*"
-RigidBodyDynamics = "0.4.0-*"
+MechanismGeometries = "0.2"
+MeshCat = "0.6"
+RigidBodyDynamics = "0.4"
 julia = ["0.7.0", "1"]
 
 ["0.4-0.5"]
-ColorTypes = "0.2.0-*"
-CoordinateTransformations = "0.4.1-*"
-GeometryTypes = "0.4.0-*"
-InteractBase = "0.8.0-*"
-Interpolations = "0.9.0-*"
-LoopThrottle = "0.0.1-*"
-OrderedCollections = "1.0.0-*"
+ColorTypes = "0.2.0-0.9"
+CoordinateTransformations = "0.4.1-0.5"
+GeometryTypes = "0.4.0-0.7"
+InteractBase = "0.8.0-0.10"
+Interpolations = "0.9.0-0.12"
+LoopThrottle = "0.0.1-0.1"
+OrderedCollections = "1"
 
 ["0.5"]
-MechanismGeometries = "0.4.0-*"
-MeshCat = "0.7.0-*"
+MechanismGeometries = "0.4"
+MeshCat = "0.7"
 
 ["0.5-0"]
 RigidBodyDynamics = "2"


### PR DESCRIPTION
Several old versions of MeshCatMechanisms.jl had unbounded or overly broad restrictions on their dependency versions, resulting in weird choices by the package resolver. I *think* this is the right fix, although I'm not particularly confident that I understand the syntax of this file (ref: https://github.com/JuliaLang/Pkg.jl/issues/1190 ). 