### PR TITLE
Adjust some bounds on ParquetFiles.jl

### DIFF
--- a/P/ParquetFiles/Compat.toml
+++ b/P/ParquetFiles/Compat.toml
@@ -1,9 +1,9 @@
 [0]
-DataValues = "0.4.5-0"
+DataValues = "0.4.5-0.4"
 FileIO = "1"
 IterableTables = "0.9-1"
 IteratorInterfaceExtensions = "0.1.1-1"
-Parquet = "0.2-0"
-TableShowUtils = "0.2-0"
+Parquet = "0.2-0.4"
+TableShowUtils = "0.2"
 TableTraits = "0.4-1"
 julia = ["0.7", "1"]


### PR DESCRIPTION
These bounds should never have been so wide.

Right now all of queryverse is broken because of the too wide bound on Parquet.jl, hopefully this can fix things for users.