### PR TITLE
Revert "Update RegistryCI.jl by updating the .ci/Manifest.toml file"

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -125,9 +125,9 @@ version = "1.0.1"
 
 [[RegistryCI]]
 deps = ["Dates", "GitHub", "HTTP", "JSON", "LibGit2", "Pkg", "RegistryTools", "Test", "TimeZones"]
-git-tree-sha1 = "f59129bccb95c9fc4f2c7686c5c7d618847ee7b8"
+git-tree-sha1 = "45c9d86397d6c54acfd22498af3288ddee399f5e"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
-version = "2.5.0"
+version = "2.4.0"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]


### PR DESCRIPTION
Reverts JuliaRegistries/General#16130

2.5.0 is broken. I'm rolling back to 2.4.0 until I fix the bug.