### PR TITLE
Fix unbounded compatibilities of old Turing versions

### DIFF
--- a/T/Turing/Compat.toml
+++ b/T/Turing/Compat.toml
@@ -78,26 +78,26 @@ MCMCChains = "0.3.4-0.3.6"
 Tracker = "0.2-0"
 
 ["0.6.18-0.6.21"]
-AdvancedHMC = "0.1.8-*"
+AdvancedHMC = "0.1.8-0.1"
 
 ["0.6.18-0.7.1"]
 julia = "1.0.0-1"
 
 ["0.6.22"]
-AdvancedHMC = "0.2.1-*"
+AdvancedHMC = "0.2.1-0.2"
 
 ["0.6.23-0.6"]
-AdvancedHMC = "0.2.2-*"
+AdvancedHMC = "0.2.2-0.2"
 
 ["0.6.9-0.6.14"]
 Libtask = "0.2.5-0.2.7"
 
 ["0.7-0.7.1"]
-AdvancedHMC = "0.2.4-*"
-MCMCChains = "0.3.12-*"
+AdvancedHMC = "0.2.4-0.2"
+MCMCChains = "0.3.12-0.3"
 
 ["0.7.1"]
-Zygote = "0.3.4-*"
+Zygote = "0.3.4-0.3"
 
 ["0.7.2"]
 MCMCChains = "0.3.12-0.3"


### PR DESCRIPTION
A common issue with Turing seem to be downgrades when upgrading dependencies such as MCMCChains (see, e.g., https://github.com/TuringLang/Turing.jl/issues/1292, https://github.com/TuringLang/Turing.jl/issues/1211, https://discourse.julialang.org/t/issues-importing-turing-linux/37132?u=devmotion, https://discourse.julialang.org/t/updating-to-mcmcchains-v4-0-0-results-in-turing-downgrade/41463?u=devmotion). This PR fixes the unbounded compatibilities of Turing, and hence should fix these problems at least when upgrading MCMCChains and AdvancedHMC (Zygote is not a dependency of Turing anymore). 