### PR TITLE
Fix repo URL for SEAL after transfer to JuliaCrypto organization

### DIFF
--- a/S/SEAL/Package.toml
+++ b/S/SEAL/Package.toml
@@ -1,3 +1,3 @@
 name = "SEAL"
 uuid = "bac81e26-86e4-4b48-8696-7d0406d5dbc1"
-repo = "https://github.com/sloede/SEAL.jl.git"
+repo = "https://github.com/JuliaCrypto/SEAL.jl.git"


### PR DESCRIPTION
Rename repo URL after transfer according to best practices outlined here: https://github.com/JuliaRegistries/General#how-do-i-transfer-a-package-to-an-organization-or-another-user