### PR TITLE
Delete v0.5.11 due to error

### DIFF
--- a/D/DirectSum/Versions.toml
+++ b/D/DirectSum/Versions.toml
@@ -63,6 +63,3 @@ git-tree-sha1 = "711759ac9ba8d41300c99f34935dd319faa97898"
 
 ["0.5.10"]
 git-tree-sha1 = "aca1ad81d01d0dbcc8722b5cddb7de490fd4b491"
-
-["0.5.11"]
-git-tree-sha1 = "6b30a0c3e75949e242f7709a81d8f34482c95766"


### PR DESCRIPTION
The commit for v0.5.11 doesn't exist anymore and was overwritten by accident, so it must be removed from the registry.

I was talking on the phone and accidentally messed up my commits