### PR TITLE
Catlab.jl moved to AlgebraicJulia organization

### DIFF
--- a/C/Catlab/Package.toml
+++ b/C/Catlab/Package.toml
@@ -1,3 +1,3 @@
 name = "Catlab"
 uuid = "134e5e36-593f-5add-ad60-77f754baafbe"
-repo = "https://github.com/epatters/Catlab.jl.git"
+repo = "https://github.com/AlgebraicJulia/Catlab.jl.git"


### PR DESCRIPTION
I've made the change manually. I hope this is the right process. Apologies if not.