### PR TITLE
New repo URL: KissABC url needs change

### DIFF
--- a/K/KissABC/Package.toml
+++ b/K/KissABC/Package.toml
@@ -1,3 +1,3 @@
 name = "KissABC"
 uuid = "9c9dad79-530a-4643-a18b-2704674d4108"
-repo = "https://github.com/francescoalemanno/KissABC.jl.git"
+repo = "https://github.com/JuliaApproxInference/KissABC.jl.git"


### PR DESCRIPTION
https://github.com/JuliaApproxInference/KissABC.jl/issues/18
can it be fixed with this PR?