### PR TITLE
Change repo URL: Scats

### DIFF
--- a/S/Scats/Package.toml
+++ b/S/Scats/Package.toml
@@ -1,3 +1,3 @@
 name = "Scats"
 uuid = "a40fd361-391c-496e-af78-06d474f782f1"
-repo = "https://github.com/Paveloom/Scats.jl.git"
+repo = "https://github.com/paveloom-j/Scats.jl"


### PR DESCRIPTION
The repository has been transfered to [paveloom-j](https://github.com/paveloom-j/Scats.jl).