### PR TITLE
PicoSat.jl URL change

### DIFF
--- a/P/PicoSAT/Package.toml
+++ b/P/PicoSAT/Package.toml
@@ -1,3 +1,3 @@
 name = "PicoSAT"
 uuid = "ff2beb65-d7cd-5ff1-a187-74671133a339"
-repo = "https://github.com/jakebolewski/PicoSAT.jl.git"
+repo = "https://github.com/sisl/PicoSAT.jl.git"


### PR DESCRIPTION
Changing the URL of PicoSat.jl after change of ownership and because of this error when trying to register: 
https://github.com/sisl/PicoSAT.jl/commit/4017df3fa0a5f072bce2e4a3f655eb5a05484b0f#commitcomment-40609570

cc @CarloLucibello, @tomerarnon 
