### PR TITLE
Retry.jl, URL SamOConnor->JuliaWeb

### DIFF
--- a/R/Retry/Package.toml
+++ b/R/Retry/Package.toml
@@ -1,3 +1,3 @@
 name = "Retry"
 uuid = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
-repo = "https://github.com/samoconnor/Retry.jl.git"
+repo = "https://github.com/JuliaWeb/Retry.jl.git"


### PR DESCRIPTION
I'm attempting to register a new version of Retry.jl, however the URL is needed to be updated since the project was moved from Sam OConnors account to JuliaWeb.

> https://github.com/JuliaWeb/Retry.jl/commit/140ed832839cea8b0773de017f34107599359c56

```
JuliaRegistrator replied 3 minutes ago
Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.
```