### PR TITLE
change url of Lattices.jl

### DIFF
--- a/L/Lattices/Package.toml
+++ b/L/Lattices/Package.toml
@@ -1,3 +1,3 @@
 name = "Lattices"
 uuid = "c21dee59-005f-55b6-acfd-94526b082a96"
-repo = "https://github.com/Roger-luo/Lattices.jl.git"
+repo = "https://github.com/JuliaPhysics/Lattices.jl.git"


### PR DESCRIPTION
I moved Lattices.jl to JuliaPhysics thus needs to update the URL. Thanks.