### PR TITLE
Adjust PrettyPrint bound

### DIFF
--- a/N/NameResolution/Compat.toml
+++ b/N/NameResolution/Compat.toml
@@ -3,4 +3,4 @@ julia = "1"
 
 ["0.1.3-0"]
 DataStructures = "0.17"
-PrettyPrint = "0"
+PrettyPrint = "0.1"


### PR DESCRIPTION
The existing bound wasn't correct as the newly released version 0.2 of PrettyPrint broke NameResolution.

cc @thautwarm