### PR TITLE
Allow LibGit2_jll 1.0 on Julia 1.6

### DIFF
--- a/L/LibGit2_jll/Compat.toml
+++ b/L/LibGit2_jll/Compat.toml
@@ -5,4 +5,4 @@ julia = "1.3.0-1"
 julia = "1"
 
 ["1"]
-julia = "1.7"
+julia = "1.6"


### PR DESCRIPTION
Needed by https://github.com/JuliaLang/julia/pull/35233.

@giordano Is there a particular reason why you required Julia 1.7 when you registered the package (as mentioned [here](https://github.com/JuliaPackaging/Yggdrasil/pull/638#issuecomment-658317060))?