### PR TITLE
Revert "Disable automerge"

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,10 +1,9 @@
 name: AutoMerge
 
 on:
-  # schedule:
-  #  - cron: '05,17,29,41,53 * * * *'
-  # pull_request:
-  repository_dispatch:
+  schedule:
+    - cron: '05,17,29,41,53 * * * *'
+  pull_request:
 
 jobs:
   AutoMerge:


### PR DESCRIPTION
Reverts JuliaRegistries/General#18993

GitHub Actions are still disabled for this repository, so this is safe to revert.

After this is merged, I will make a new PR that disables AutoMerge in a better way.