### PR TITLE
Use custom shell to tidy up AutoMerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -37,4 +37,22 @@ jobs:
           MERGE_NEW_VERSIONS: false
           AUTOMERGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JULIA_DEBUG: RegistryCI,AutoMerge
-        run: julia --project=.ci/ -e 'using RegistryCI; using Dates; RegistryCI.AutoMerge.run(merge_new_packages = ENV["MERGE_NEW_PACKAGES"] == "true", merge_new_versions = ENV["MERGE_NEW_VERSIONS"] == "true", new_package_waiting_period = Day(3), new_jll_package_waiting_period = Minute(15), new_version_waiting_period = Minute(15), new_jll_version_waiting_period = Minute(15), registry = "JuliaRegistries/General", authorized_authors = String["JuliaRegistrator"], authorized_authors_special_jll_exceptions = String["jlbuild"], suggest_onepointzero = false, additional_statuses = String[], additional_check_runs = String["Travis CI - Pull Request"])'
+        run: |
+          using RegistryCI
+          using Dates
+          
+          RegistryCI.AutoMerge.run(
+            merge_new_packages = ENV["MERGE_NEW_PACKAGES"] == "true",
+            merge_new_versions = ENV["MERGE_NEW_VERSIONS"] == "true",
+            new_package_waiting_period = Day(3),
+            new_jll_package_waiting_period = Minute(15),
+            new_version_waiting_period = Minute(15),
+            new_jll_version_waiting_period = Minute(15),
+            registry = "JuliaRegistries/General",
+            authorized_authors = String["JuliaRegistrator"],
+            authorized_authors_special_jll_exceptions = String["jlbuild"],
+            suggest_onepointzero = false,
+            additional_statuses = String[],
+            additional_check_runs = String["Travis CI - Pull Request"]
+          )
+        shell: julia --color=yes --project=.ci/ {0}


### PR DESCRIPTION
The multiline string of the `run` key will be saved to a file. The filename will be inserted in place of the `{0}`.

ref. https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#custom-shell

~(needs to be tested, but I don't know how)~ Seems to run as expected on this PR

@DilumAluthge 