### PR TITLE
Change URL for Phylo.jl

### DIFF
--- a/P/Phylo/Package.toml
+++ b/P/Phylo/Package.toml
@@ -1,3 +1,3 @@
 name = "Phylo"
 uuid = "aea672f4-3940-5932-aa44-993d1c3ff149"
-repo = "https://github.com/richardreeve/Phylo.jl.git"
+repo = "https://github.com/EcoJulia/Phylo.jl.git"


### PR DESCRIPTION
Phylo.jl is now part of EcoJulia - https://github.com/EcoJulia/Phylo.jl - so just switching the url over...