### PR TITLE
remove upper bound on MozillaCACerts_jll

### DIFF
--- a/L/LibCURL/Compat.toml
+++ b/L/LibCURL/Compat.toml
@@ -16,5 +16,5 @@ BinaryProvider = "0.5"
 
 ["0.6-0"]
 LibCURL_jll = "7.68.0-7"
-MozillaCACerts_jll = "2020.0.0-*"
+MozillaCACerts_jll = ">= 2020"
 julia = "1.3.0-1"


### PR DESCRIPTION
Since it doesn't use semver.

Is already adjusted in LibCURL with this commit: https://github.com/JuliaWeb/LibCURL.jl/commit/e25de0d03133f76fc51c9f825c560819290f4d0a#diff-910a7b3ca0075d545dcec45cb7335ca9