### PR TITLE
Reintroduce DataStructures bound

### DIFF
--- a/D/DiffEqBase/Compat.toml
+++ b/D/DiffEqBase/Compat.toml
@@ -135,7 +135,7 @@ ChainRulesCore = "0.4-0.9"
 ["6.44"]
 DataStructures = "0.17-0.18"
 
-["6.46.1-6"]
+["6.45-6"]
 DataStructures = "0.18"
 
 ["6.5-6"]


### PR DESCRIPTION
This PR reintroduces a bound for DataStructures in some recent releases of DiffEqBase.

DiffEqBase does not actually import DataStructures anymore (since `DataStructures.top` was changed to `Base.first`) but since other important packages have not released a version that is compatible with DataStructures 0.18 yet the DataStructures bound is still needed to avoid that users end up with a new version of DiffEqBase AND an old version of DataStructures (which are incompatible) (see, e.g., https://github.com/SciML/DiffEqBase.jl/issues/575#issuecomment-682214204 and https://github.com/SciML/DiffEqBase.jl/pull/576, and there was also a long discussion on Slack).