### PR TITLE
Fix compat entry for polymake_jll

### DIFF
--- a/P/polymake_jll/Compat.toml
+++ b/P/polymake_jll/Compat.toml
@@ -1,4 +1,3 @@
 [4]
-FLINT_jll = "2.6.2"
 Perl_jll = "5.30.3"
 julia = "1"


### PR DESCRIPTION
Similar to #20453, that strict flint version requirement was removed in https://github.com/JuliaPackaging/Yggdrasil/pull/1614 (and was not really necessary).

@giordano 