### PR TITLE
Update ClickHouse.jl URL

### DIFF
--- a/C/ClickHouse/Package.toml
+++ b/C/ClickHouse/Package.toml
@@ -1,3 +1,3 @@
 name = "ClickHouse"
 uuid = "82f2e89e-b495-11e9-1d9d-fb40d7cf2130"
-repo = "https://github.com/athre0z/ClickHouse.jl.git"
+repo = "https://github.com/JuliaDatabases/ClickHouse.jl.git"


### PR DESCRIPTION
This package was moved from my private account to the JuliaDatabases organization.

New URL: https://github.com/JuliaDatabases/ClickHouse.jl