### PR TITLE
Constrain Flux for older versions of TextAnalysis

### DIFF
--- a/T/TextAnalysis/Compat.toml
+++ b/T/TextAnalysis/Compat.toml
@@ -2,7 +2,7 @@
 BSON = "0"
 BinaryProvider = "0"
 DataFrames = "0"
-Flux = "0"
+Flux = "0.9"
 JSON = "0"
 Languages = "0.4-0"
 WordTokenizers = "0"

--- a/T/TextAnalysis/Compat.toml
+++ b/T/TextAnalysis/Compat.toml
@@ -2,7 +2,7 @@
 BSON = "0"
 BinaryProvider = "0"
 DataFrames = "0"
-Flux = "0.9"
+Flux = "0.0-0.9"
 JSON = "0"
 Languages = "0.4-0"
 WordTokenizers = "0"


### PR DESCRIPTION
Older versions of TextAnalysis have a dependeny on flux, but do not specify an upper bound 😞. I am about to release a new version with flux dependency lower than latest Flux, and I do not want the resolver to downgrade TextAnalyis to provide a higher Flux .. that will break things. 

Hence this PR. Is this safe? 