### PR TITLE
Relax compatibility of DocStringExtensions for old Documenter versions

### DIFF
--- a/D/Documenter/Compat.toml
+++ b/D/Documenter/Compat.toml
@@ -5,7 +5,7 @@ julia = "0.6-1"
 Compat = "0.62-2"
 
 ["0-0.22.3"]
-DocStringExtensions = "0.2.0 - 0.7"
+DocStringExtensions = "0.2.0 - 0.8"
 
 ["0.19.3-0.19"]
 Compat = "0.70-2"


### PR DESCRIPTION
We are currently using Documenter v0.21.5 for docs for a package, while another dependency of the package is using DocStringExtensions 0.8. The retrocapping caused our documentation jobs to start breaking.