### PR TITLE
Fiddle with bounds to avoid problems with Optim on Julia v1.0

### DIFF
--- a/O/Optim/Compat.toml
+++ b/O/Optim/Compat.toml
@@ -23,11 +23,8 @@ PositiveFactorizations = "0.2.1 - 0.2"
 ["0.16-0.19.3"]
 StatsBase = "0.0.0 - 0.32"
 
-["0.17-0.22"]
+["0.17-0"]
 julia = "1"
-
-["1"]
-julia = "1.2"
 
 ["0.19"]
 ForwardDiff = "0.10.3-0.10"
@@ -39,16 +36,13 @@ Calculus = "0.4"
 FillArrays = "0.6.2-0.6"
 Parameters = "0.10"
 
-["0.19-0.22"]
+["0.19-0"]
 NLSolversBase = "7.3.1-7.5"
 
 ["0.19-1"]
 LineSearches = "7.0.1-7"
 NaNMath = "0.3.2-0.3"
 PositiveFactorizations = "0.2.2-0.2"
-
-["1"]
-NLSolversBase = "7.7-7"
 
 ["0.19.0"]
 DiffEqDiffTools = "0.12-0.13"
@@ -86,3 +80,5 @@ StatsBase = "0.29-0.33"
 
 [1]
 FillArrays = "0.6.2-0.9"
+NLSolversBase = "7.7-7"
+julia = "1.2"

--- a/O/Optim/Compat.toml
+++ b/O/Optim/Compat.toml
@@ -23,8 +23,11 @@ PositiveFactorizations = "0.2.1 - 0.2"
 ["0.16-0.19.3"]
 StatsBase = "0.0.0 - 0.32"
 
-["0.17-1"]
+["0.17-0.22"]
 julia = "1"
+
+["1"]
+julia = "1.2"
 
 ["0.19"]
 ForwardDiff = "0.10.3-0.10"
@@ -36,11 +39,16 @@ Calculus = "0.4"
 FillArrays = "0.6.2-0.6"
 Parameters = "0.10"
 
+["0.19-0.22"]
+NLSolversBase = "7.3.1-7.5"
+
 ["0.19-1"]
 LineSearches = "7.0.1-7"
-NLSolversBase = "7.3.1-7"
 NaNMath = "0.3.2-0.3"
 PositiveFactorizations = "0.2.2-0.2"
+
+["1"]
+NLSolversBase = "7.7-7"
 
 ["0.19.0"]
 DiffEqDiffTools = "0.12-0.13"


### PR DESCRIPTION
I messed up which resulted in https://github.com/JuliaNLSolvers/Optim.jl/issues/863 . I don't want Optim v1+ to be installed on Julia versions below v1.2 and I don't want versions of NLSolversBase below v7.7  to be installed for any Optim versions v1+ . I know this (changing General after tagging) is not optimal, but the current situation isn't either.