### PR TITLE
Slightly widen some `[compat]` ranges for packages that depend on SimpleGraphs

### DIFF
--- a/S/SimpleGraphAlgorithms/Compat.toml
+++ b/S/SimpleGraphAlgorithms/Compat.toml
@@ -1,7 +1,7 @@
 [0]
 Cbc = "0.0.0 - 0.7"
 JuMP = "0.0.0 - 0.21"
-SimpleGraphs = "0.0.0 - 0.5"
+SimpleGraphs = "0.0.0 - 0.6"
 SimplePartitions = "0.0.0 - 0.3"
 
 ["0-0.2"]

--- a/S/SimplePosetAlgorithms/Compat.toml
+++ b/S/SimplePosetAlgorithms/Compat.toml
@@ -1,6 +1,6 @@
 [0]
 SimpleGraphAlgorithms = "0.0.0 - 0.4"
-SimpleGraphs = "0.0.0 - 0.5"
+SimpleGraphs = "0.0.0 - 0.6"
 SimplePosets = "0.0.0 - 0.1"
 
 ["0-0.3"]

--- a/S/SimplePosets/Compat.toml
+++ b/S/SimplePosets/Compat.toml
@@ -1,7 +1,7 @@
 [0]
 FlexLinearAlgebra = "0.0.0 - 0.1"
 Primes = "0.0.0 - 0.5"
-SimpleGraphs = "0.0.0 - 0.5"
+SimpleGraphs = "0.0.0 - 0.6"
 SimplePartitions = "0.0.0 - 0.3"
 
 ["0.0"]


### PR DESCRIPTION
This pull request widens a few `[compat]` ranges to allow SimpleGraphs version 0.6.

Please note that this is really more of a one-time fix. The best long-term solution is to fix the `[compat]` entries in the `Project.toml` files of packages that depend on SimpleGraphs. Note that `[compat]` entries that look like this are not good:
```toml
PkgA = "0"
```

This `[compat]` entries applies to an infinite number of breaking releases of PkgA. Therefore, it is not a good `[compat]` entry.

@scheinerman I have made a few pull requests to fix some of the `[compat]` entries in your packages. Examples include (but are not limited to):
1. https://github.com/scheinerman/SimpleGraphAlgorithms.jl/pull/3
2. https://github.com/scheinerman/SimpleGraphRepresentations.jl/pull/1

After you merge those pull requests, you should register new versions of your packages that include the new fixed `[compat]` entries.