### PR TITLE
SnoopCompileBot URL and git sha update

### DIFF
--- a/S/SnoopCompileBot/Package.toml
+++ b/S/SnoopCompileBot/Package.toml
@@ -1,4 +1,4 @@
 name = "SnoopCompileBot"
 uuid = "1d5e0e55-7d74-4714-b8d8-efa80e938cf7"
-repo = "https://github.com/timholy/SnoopCompile.jl.git"
+repo = "https://github.com/aminya/SnoopCompileBot.jl.git"
 subdir = "SnoopCompileBot"

--- a/S/SnoopCompileBot/Versions.toml
+++ b/S/SnoopCompileBot/Versions.toml
@@ -1,17 +1,17 @@
 ["1.6.0"]
-git-tree-sha1 = "e35f5e91b1278769549aecd7037ae0881eb266a4"
+git-tree-sha1 = "d7cbc3181fc7049cc622e5a4ae9ee37696753e66"
 
 ["1.6.1"]
-git-tree-sha1 = "478c59e4089eb268e712dcf55570ae9e6fc6576b"
+git-tree-sha1 = "d09c160284f01896a8bea8783dffb61beaa721f5"
 
 ["1.6.2"]
-git-tree-sha1 = "d3fd7766ae0398c9d64ba8f0ab451d741231b4d7"
+git-tree-sha1 = "1d406855ab1361a2853d34fa8e8103d0b255cd7d"
 
 ["1.7.0"]
-git-tree-sha1 = "6d7ebbac7d538ec8257cd05b7bbfd52a1e2c84a6"
+git-tree-sha1 = "3d588be60cfdc4196bfdc2f237e67329570e4a31"
 
 ["1.7.1"]
-git-tree-sha1 = "2490e6be0ef6f96ca81dfecb628d749da0976e71"
+git-tree-sha1 = "8cfc79c9e567fc2c8cd630772fb7fe8cc56aa548"
 
 ["1.7.2"]
-git-tree-sha1 = "f994e15ec3163a3a90895eb833736937be205d9f"
+git-tree-sha1 = "5b7ab15eccd3946fd47cb6ca016d9dc7f433c755"


### PR DESCRIPTION
Updated the URL and git sha

Based on @fredrikekre's suggestion in https://github.com/JuliaRegistries/General/pull/19557#issuecomment-674461349, I created branches resembling the original code: 
https://github.com/aminya/SnoopCompileBot.jl
