### PR TITLE
Change location of RedPitayaDAQServer

### DIFF
--- a/R/RedPitayaDAQServer/Package.toml
+++ b/R/RedPitayaDAQServer/Package.toml
@@ -1,3 +1,4 @@
 name = "RedPitayaDAQServer"
 uuid = "c544963a-496b-56d4-a5fe-f99a3f174c8f"
-repo = "https://github.com/tknopp/RedPitayaDAQServer.jl.git"
+repo = "https://github.com/tknopp/RedPitayaDAQServer.git"
+subdir = "src/client/julia"


### PR DESCRIPTION
Hi, I am not sure if this is correct what I am trying here. I want to move this package into its main repository into a subfolder. So there is RedPitayaDAQServer and there is RedPitayaDAQServer.jl, which is only a language binding to the former.