### PR TITLE
url change for LocalCoverage.jl

### DIFF
--- a/L/LocalCoverage/Package.toml
+++ b/L/LocalCoverage/Package.toml
@@ -1,3 +1,3 @@
 name = "LocalCoverage"
 uuid = "5f6e1e16-694c-5876-87ef-16b5274f298e"
-repo = "https://github.com/tpapp/LocalCoverage.jl.git"
+repo = "https://github.com/JuliaCI/LocalCoverage.jl.git"


### PR DESCRIPTION
The package LocalCoverage has been moved to the JuliaCI github org.

Not totally confident that this is the correct process for changing the URL, please let me know if there's something else I need to do for this.