### PR TITLE
Restore Singular_jll compatibility with Julia 1.6

### DIFF
--- a/S/Singular_jll/Compat.toml
+++ b/S/Singular_jll/Compat.toml
@@ -1,4 +1,3 @@
 [4]
-GMP_jll = "6.1.2"
 JLLWrappers = "1.1.0-1"
 julia = "1"


### PR DESCRIPTION
On the binary level, all versions of Singular_jll v4.1.3 are compatible with both GMP 6.1.2 and 6.2.0, *except* v4.1.3+4 which was GMP >=6.2.0 only, and was yanked. However, due to a bug, v4.1.3+5 specified that it requires precisely GMP_jll 6.1.2. That was wrong, however, and caused by a bug in BinaryBuilderBase.jl which since has been fixed. CC @giordano 

This patch now unblocks Singular_jll on Julia 1.6.

Of course that still leaves the questions as to whether there still is a bug in BinaryBuilder lurking here, which will cause the next update of this to add back the compat restriction. This ought to be researched, but I hope we can at least quickly unblock this one package.

Formally, I guess there should be three ranges, though: one each with all versions before resp. after v4.1.3+5, without a GMP_jll restriction; and one with exactly v4.1.3+5 in it. But I don't know how to make such a range resp. whether a range with a "+" in it is even supported? So I am hoping that we can just ignore this? Or perhaps v4.1.3+5 should be yanked, too?