### PR TITLE
Bump lower bound of DiffEqBase to 6.48 in ModelingToolkit 3.21

### DIFF
--- a/M/ModelingToolkit/Compat.toml
+++ b/M/ModelingToolkit/Compat.toml
@@ -82,8 +82,11 @@ UnPack = "0.1"
 ["3-3.9"]
 DiffEqBase = "6.28.0-6"
 
-["3.10-3"]
+["3.10-3.20"]
 DiffEqBase = "6.38.0-6"
+
+["3.21-3"]
+DiffEqBase = "6.48.0-6"
 
 ["3.11-3"]
 Requires = "1"
@@ -134,3 +137,5 @@ DataStructures = "0.17"
 
 ["3.9-3.10"]
 SymbolicUtils = "0.3.3-0.3"
+
+


### PR DESCRIPTION
@DilumAluthge I am not quite sure how to use RegistryTools.jl to do this, so I did it by hand. Could this be checked? We missed an important lower bound:

https://github.com/SciML/DifferentialEquations.jl/issues/683
https://github.com/SciML/ModelingToolkit.jl/issues/601