### PR TITLE
yank latest GDAL_jll build

### DIFF
--- a/G/GDAL_jll/Versions.toml
+++ b/G/GDAL_jll/Versions.toml
@@ -18,3 +18,4 @@ git-tree-sha1 = "7a2561bca66ff0bdfeecf1f65c90c725ecc7d326"
 
 ["3.0.4+4"]
 git-tree-sha1 = "598d552b31bb0c664865743dad9bbe52453d7777"
+yanked = true


### PR DESCRIPTION
It fails GDAL.jl CI in https://github.com/JuliaGeo/GDAL.jl/pull/99 with `Incompatible library version: libgdal.26.dylib requires version 12.0.0 or later, but libxml2.2.dylib provides version 10.0.0` It seems to be picking up a libxml2 that was not intended.