### PR TITLE
Yank GMP_jll v6.1.2+8

### DIFF
--- a/G/GMP_jll/Versions.toml
+++ b/G/GMP_jll/Versions.toml
@@ -25,6 +25,7 @@ yanked = true
 
 ["6.1.2+8"]
 git-tree-sha1 = "1427597355dceec378d3bec976ae702fdd392ac7"
+yanked = true
 
 ["6.2.0+0"]
 git-tree-sha1 = "1976f0824aa2a575d3c6e97b6afb8c5871672aa8"


### PR DESCRIPTION
This version accidentally introduced an aarch64-apple-darwin artifact to Julia 1.5.1-, which breaks `Pkg.add()`.