### PR TITLE
Yank latest version of Poppler_jll

### DIFF
--- a/P/Poppler_jll/Versions.toml
+++ b/P/Poppler_jll/Versions.toml
@@ -3,3 +3,4 @@ git-tree-sha1 = "ef02d59bf6c0b6d00c5707ab73c5ec571a14051e"
 
 ["0.87.0+1"]
 git-tree-sha1 = "457c172979f6ab20ea4c2ed6e4ee25d8aa59f972"
+yanked = true


### PR DESCRIPTION
The tarballs contain a recursive `bin/` directory which symlinks to itself,
which on Windows becomes an infinite chain of nested directories