### PR TITLE
Force downgrade version of SpelledOut.jl

### DIFF
--- a/F/FaceDetection/Versions.toml
+++ b/F/FaceDetection/Versions.toml
@@ -5,7 +5,4 @@ git-tree-sha1 = "ee1a70cea64e3f7ac6f9223f8c8755de6fd5e974"
 git-tree-sha1 = "adb5035421f95d18370dc1434c7705c370af6add"
 
 ["0.2.0"]
-git-tree-sha1 = "7dfad5d1272eb19609174f069cbd68f5ae9578a5"
-
-["1.0.0"]
 git-tree-sha1 = "b4012532d309d4e304abeed026b04079b2d7c93d"


### PR DESCRIPTION
Sorry for the manual PR.  I accidentally updated the version number to be a major release when it shouldn't be.  I cannot fix this via the Registrator.