### PR TITLE
Add TagBot token to automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.5.2'
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 'nightly'
+          - '1.5.1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.5.1'
+          - '1.5.2'
         os:
           - ubuntu-latest
         arch:
@@ -39,6 +39,7 @@ jobs:
           MERGE_NEW_PACKAGES: true
           MERGE_NEW_VERSIONS: true
           AUTOMERGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOMERGE_TAGBOT_TOKEN: ${{ secrets.TAGBOT_TOKEN }}
           JULIA_DEBUG: RegistryCI,AutoMerge
         run: |
           using RegistryCI
@@ -52,6 +53,7 @@ jobs:
             new_version_waiting_period = Minute(15),
             new_jll_version_waiting_period = Minute(15),
             registry = "JuliaRegistries/General",
+            tagbot_enabled = true,
             authorized_authors = String["JuliaRegistrator"],
             authorized_authors_special_jll_exceptions = String["jlbuild"],
             suggest_onepointzero = false,


### PR DESCRIPTION
Needs RegistryCI 4.3.3 (https://github.com/JuliaRegistries/RegistryCI.jl/pull/289).


I also bumped the Julia version to a supported one, but really we could just get rid of the `setup-julia` step.