### PR TITLE
Run the TagBot trigger cron every four hours

### DIFF
--- a/.github/workflows/TagBotTriggers.yml
+++ b/.github/workflows/TagBotTriggers.yml
@@ -1,7 +1,7 @@
 name: TagBot Triggers
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 * * * *
   pull_request:
     types:
       - closed

--- a/.github/workflows/TagBotTriggers.yml
+++ b/.github/workflows/TagBotTriggers.yml
@@ -1,7 +1,7 @@
 name: TagBot Triggers
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 */4 * * *
   pull_request:
     types:
       - closed


### PR DESCRIPTION
Currently, we have thousands of packages running a TagBot cron once per day. We are getting rid of that, so I feel less guilty about an hourly TagBot cron on a single repository (General registry)