### PR TITLE
New version: LibCURL_jll v7.73.0+2

### DIFF
--- a/L/LibCURL_jll/Versions.toml
+++ b/L/LibCURL_jll/Versions.toml
@@ -24,3 +24,6 @@ git-tree-sha1 = "a5973e1ef7e3f87eed93c4049788d1b44a4fecfc"
 
 ["7.73.0+1"]
 git-tree-sha1 = "cc2151672d7e1bd4b99660d584ec5ab805da8749"
+
+["7.73.0+2"]
+git-tree-sha1 = "be0c60303ec6cd92c23648b6d84fa66e353fe604"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LibCURL_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LibCURL_jll.jl
* Version: v7.73.0+2
