### PR TITLE
Allow DilumAluthgeBot to automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -54,7 +54,7 @@ jobs:
             new_jll_version_waiting_period = Minute(15),
             registry = "JuliaRegistries/General",
             tagbot_enabled = true,
-            authorized_authors = String["JuliaRegistrator"],
+            authorized_authors = String["JuliaRegistrator", "DilumAluthgeBot"],
             authorized_authors_special_jll_exceptions = String["jlbuild"],
             suggest_onepointzero = false,
             additional_statuses = String[],


### PR DESCRIPTION
This is a temporary change. Once the serverless Registrator is completed, we can switch it to use a PAT from the JuliaRegistrator GitHub account. This PR can then be reverted.