### PR TITLE
Update repo URL for GeometricIntegrators.jl

### DIFF
--- a/G/GeometricIntegrators/Package.toml
+++ b/G/GeometricIntegrators/Package.toml
@@ -1,3 +1,3 @@
 name = "GeometricIntegrators"
 uuid = "dcce2d33-59f6-5b8d-9047-0defad88ae06"
-repo = "https://github.com/DDMGNI/GeometricIntegrators.jl.git"
+repo = "https://github.com/JuliaGNI/GeometricIntegrators.jl.git"


### PR DESCRIPTION
The package was moved from DDMGNI to JuliaGNI.