### PR TITLE
Update repo URL for ElectromagneticFields.jl

### DIFF
--- a/E/ElectromagneticFields/Package.toml
+++ b/E/ElectromagneticFields/Package.toml
@@ -1,3 +1,3 @@
 name = "ElectromagneticFields"
 uuid = "d6c1ba6f-ee03-53af-b876-68cefeb88ec8"
-repo = "https://github.com/DDMGNI/ElectromagneticFields.jl.git"
+repo = "https://github.com/JuliaPlasma/ElectromagneticFields.jl.git"


### PR DESCRIPTION
The package was moved from DDMGNI to JuliaPlasma.