### PR TITLE
Correct NIfTI repo url

### DIFF
--- a/N/NIfTI/Package.toml
+++ b/N/NIfTI/Package.toml
@@ -1,3 +1,3 @@
 name = "NIfTI"
 uuid = "a3a9e032-41b5-5fc4-967a-a6b7a19844d3"
-repo = "https://github.com/JuliaNeuroscience/NIfTI.jl"
+repo = "https://github.com/JuliaNeuroscience/NIfTI.jl.git"


### PR DESCRIPTION
Well, this is a bit embarrassing. My previous commit was directed to the web UI instead of the repo code.