### PR TITLE
[LibUV_jll] Yank borked version

### DIFF
--- a/L/LibUV_jll/Versions.toml
+++ b/L/LibUV_jll/Versions.toml
@@ -33,6 +33,7 @@ git-tree-sha1 = "5e34e2d61898ea8b696491789c1a6a1c3653282e"
 
 ["2.0.0+11"]
 git-tree-sha1 = "e5a3c7ad85dc4621422072e186c7b2d6461b0305"
+yanked = true
 
 ["2.0.1+0"]
 git-tree-sha1 = "3c2837160dc2a9b9eda97f33856caf6e9dd0cc07"


### PR DESCRIPTION
`v2.0.0+11` provides artifacts for the new experimental architectures
(`aarch64-apple-darwin` and `armv6l-linux-*`) which old Julia versions
can't deal with, without the appropriate compat bounds.

Ref #25308