### PR TITLE
Update repo of Corpuscles

### DIFF
--- a/C/Corpuscles/Package.toml
+++ b/C/Corpuscles/Package.toml
@@ -1,3 +1,3 @@
 name = "Corpuscles"
 uuid = "e78a0372-c628-4773-9c8d-eb17d149bf93"
-repo = "https://github.com/KM3NeT/Corpuscles.jl.git"
+repo = "https://github.com/JuliaPhysics/Corpuscles.jl.git"


### PR DESCRIPTION
We moved the `Corpuscles.jl` repository to a new group. This pull request changes the repo accordingly, as requested by the JuliaRegistrator bot.