### PR TITLE
Fix compat entry for LibOSXUnwind_jll

### DIFF
--- a/L/LibOSXUnwind_jll/Compat.toml
+++ b/L/LibOSXUnwind_jll/Compat.toml
@@ -3,4 +3,4 @@ julia = "1"
 
 ["0.0.6-0"]
 JLLWrappers = "1.1.0-1"
-julia = "1.6.0-1"
+julia = "1.5.1-1"

--- a/L/LibOSXUnwind_jll/Versions.toml
+++ b/L/LibOSXUnwind_jll/Versions.toml
@@ -6,3 +6,4 @@ git-tree-sha1 = "cded5b3cf1ce542fb1d322e9d1c5c488ba5725b0"
 
 ["0.0.6+1"]
 git-tree-sha1 = "4ad86f1d058c211e8916ceddf2404ea75b002e47"
+yanked = true


### PR DESCRIPTION
LibOSXUnwind_jll 0.0.6 is actually compatible with (and required by) Julia >= 1.5.1.
Since the Julia build system pins the JLL to 0.0.6+0 and doesn't use the registry, this
isn't obvious normally, but the incorrect compat entry prevents linking libjulia_jll 1.5
and derived JLLs correctly against libosxunwind.

For details see https://github.com/JuliaPackaging/Yggdrasil/pull/2190#issuecomment-735318854

Ping @giordano @staticfloat 