### PR TITLE
SCIP.jl repo change (organization rename)

### DIFF
--- a/S/SCIP/Package.toml
+++ b/S/SCIP/Package.toml
@@ -1,3 +1,3 @@
 name = "SCIP"
 uuid = "82193955-e24f-5292-bf16-6f2c5261a85f"
-repo = "https://github.com/SCIP-Interfaces/SCIP.jl.git"
+repo = "https://github.com/scipopt/SCIP.jl.git"


### PR DESCRIPTION
The GitHub organization changed the name (from `SCIPInterfaces` to `scipopt`), so the `repo` URL should be updated.

While GitHub has forwarding on the old URL, the JuliaRegistrator bot [complained](https://github.com/scipopt/SCIP.jl/commit/5f4852720215bc0bfc8423c341266f3a4400b485#commitcomment-44708527) when I wanted to register a new version.