### PR TITLE
New version: LLVM_full_assert_jll v11.0.0+5

### DIFF
--- a/L/LLVM_full_assert_jll/Versions.toml
+++ b/L/LLVM_full_assert_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["11.0.0+4"]
 git-tree-sha1 = "c6a9171d1136c60b1aeea4d46d306e4706a77175"
+
+["11.0.0+5"]
+git-tree-sha1 = "0059b36c4073abfe2dd23c7e8c8865eae8e4d60c"

--- a/L/LLVM_full_assert_jll/Versions.toml
+++ b/L/LLVM_full_assert_jll/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "c6a9171d1136c60b1aeea4d46d306e4706a77175"
 
 ["11.0.0+5"]
 git-tree-sha1 = "0059b36c4073abfe2dd23c7e8c8865eae8e4d60c"
+
+["11.0.0+6"]
+git-tree-sha1 = "3c80e92684a1b3a8060743858b0d154b84e043c5"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LLVM_full_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LLVM_full_assert_jll.jl
* Version: v11.0.0+5
