### PR TITLE
New package: Clang_assert_jll v11.0.0+0

### DIFF
--- a/C/Clang_assert_jll/Compat.toml
+++ b/C/Clang_assert_jll/Compat.toml
@@ -1,0 +1,4 @@
+[11]
+JLLWrappers = "1.1.0-1"
+julia = "1"
+libLLVM_assert_jll = "11.0.0"

--- a/C/Clang_assert_jll/Deps.toml
+++ b/C/Clang_assert_jll/Deps.toml
@@ -1,0 +1,6 @@
+[11]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+libLLVM_assert_jll = "393490a8-41a6-5dea-8ab1-81a396b80891"

--- a/C/Clang_assert_jll/Package.toml
+++ b/C/Clang_assert_jll/Package.toml
@@ -1,0 +1,3 @@
+name = "Clang_assert_jll"
+uuid = "72d370af-b0e4-5787-9b36-2e8c6f54fb93"
+repo = "https://github.com/JuliaBinaryWrappers/Clang_assert_jll.jl.git"

--- a/C/Clang_assert_jll/Versions.toml
+++ b/C/Clang_assert_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["11.0.0+0"]
 git-tree-sha1 = "89c28e3a3733f6af1815f6b5dfe7b31e1dbc3e1b"
+
+["11.0.0+2"]
+git-tree-sha1 = "5e935547fa690fa541de4a476618bbbc59a0e22d"

--- a/C/Clang_assert_jll/Versions.toml
+++ b/C/Clang_assert_jll/Versions.toml
@@ -1,0 +1,2 @@
+["11.0.0+0"]
+git-tree-sha1 = "89c28e3a3733f6af1815f6b5dfe7b31e1dbc3e1b"

--- a/Registry.toml
+++ b/Registry.toml
@@ -2193,6 +2193,7 @@ some amount of consideration when choosing package names.
 728887dd-28ad-4880-9c43-8461f4f025ea = { name = "ZonalFlow", path = "Z/ZonalFlow" }
 72aeabae-b714-56e8-bb55-1d7ed6f48f02 = { name = "Qemu_jll", path = "Q/Qemu_jll" }
 72ce6e51-3f7f-5ebd-8e88-b86aa3e31c30 = { name = "MCMCBenchmarks", path = "M/MCMCBenchmarks" }
+72d370af-b0e4-5787-9b36-2e8c6f54fb93 = { name = "Clang_assert_jll", path = "C/Clang_assert_jll" }
 72e9ff3b-fbb7-4ec3-b65d-9c3416869820 = { name = "MixedAnova", path = "M/MixedAnova" }
 72f80fcb-8c52-57d9-aff0-40c1a3526986 = { name = "VoronoiDelaunay", path = "V/VoronoiDelaunay" }
 731186ca-8d62-57ce-b412-fbd966d074cd = { name = "RecursiveArrayTools", path = "R/RecursiveArrayTools" }
@@ -2503,6 +2504,7 @@ some amount of consideration when choosing package names.
 839f1b1b-eafa-4394-a1a1-3d47d8821c5e = { name = "BigMacro", path = "B/BigMacro" }
 83a1bcd9-a884-567d-b532-90bac4ae8d51 = { name = "SimradRaw", path = "S/SimradRaw" }
 83b8d07e-fbc4-11e9-24cb-23d125ee72bd = { name = "BridgeLandmarks", path = "B/BridgeLandmarks" }
+83bcdc74-1232-581c-948a-f29122bf8259 = { name = "AWSTools", path = "A/AWSTools" }
 83cf0ae4-8bfa-5275-b23c-08ca25417759 = { name = "SimpleCarModels", path = "S/SimpleCarModels" }
 83e47e11-4a7a-5bf8-892c-11f81bf9b223 = { name = "Vinyl", path = "V/Vinyl" }
 83e8ac13-25f8-5344-8a64-a9f2b223428f = { name = "IniFile", path = "I/IniFile" }
@@ -4733,4 +4735,3 @@ ffc61752-8dc7-55ee-8c37-f3e9cdd09e70 = { name = "Mustache", path = "M/Mustache" 
 ffd25f8a-64ca-5728-b0f7-c24cf3aae800 = { name = "XZ_jll", path = "X/XZ_jll" }
 ffdd8e40-dc34-5919-9e87-c8f182d9ad02 = { name = "TableSchema", path = "T/TableSchema" }
 fff527a3-8410-504e-9ca3-60d5e79bb1e4 = { name = "SimpleANOVA", path = "S/SimpleANOVA" }
-83bcdc74-1232-581c-948a-f29122bf8259 = { name = "AWSTools", path = "A/AWSTools"}


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package Clang_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/Clang_assert_jll.jl
* Version: v11.0.0+0
