### PR TITLE
Reduce timeout of CI jobs to 60 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   CI:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The default timeout is 360 minutes (6 hours), but I've never seen packages taking more ~10 minutes in the very worst case.  Currently all CI jobs on nightly are hanging, creating a very long queue of jobs, waiting for them to be cancelled.  This change reduces the timeout in order to at least reduce the queue.

I wonder if it's the case to disable CI on nightly for the time being, it's simply useless at the moment.