### PR TITLE
Temporarily disable CI on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - '1.3'
           - '1'
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
CI on nightly hangs until timeout, there is no value in running it.  This disables CI for the development version of Julia, until it gets back to a better state