### PR TITLE
New version: LLVM_full_assert_jll v11.0.0+7

### DIFF
--- a/L/LLVM_full_assert_jll/Versions.toml
+++ b/L/LLVM_full_assert_jll/Versions.toml
@@ -6,3 +6,6 @@ git-tree-sha1 = "0059b36c4073abfe2dd23c7e8c8865eae8e4d60c"
 
 ["11.0.0+6"]
 git-tree-sha1 = "3c80e92684a1b3a8060743858b0d154b84e043c5"
+
+["11.0.0+7"]
+git-tree-sha1 = "57e967da4c48c37838ad3fd558a6918bcde5296c"

--- a/L/LLVM_full_assert_jll/Versions.toml
+++ b/L/LLVM_full_assert_jll/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "3c80e92684a1b3a8060743858b0d154b84e043c5"
 
 ["11.0.0+7"]
 git-tree-sha1 = "57e967da4c48c37838ad3fd558a6918bcde5296c"
+
+["11.0.0+8"]
+git-tree-sha1 = "c2fb7b61ce4b359aac2bed5a849a260a4551b602"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LLVM_full_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LLVM_full_assert_jll.jl
* Version: v11.0.0+7
