### PR TITLE
New version: libLLVM_assert_jll v11.0.0+4

### DIFF
--- a/L/libLLVM_assert_jll/Versions.toml
+++ b/L/libLLVM_assert_jll/Versions.toml
@@ -10,3 +10,5 @@ git-tree-sha1 = "50aac6b7ec79eebc975ed41ee52f2aa25c37f2d8"
 ["11.0.0+3"]
 git-tree-sha1 = "50aac6b7ec79eebc975ed41ee52f2aa25c37f2d8"
 
+["11.0.0+4"]
+git-tree-sha1 = "98bd75109259dc11ac9ece7ea67ce3dcdce0855e"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libLLVM_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libLLVM_assert_jll.jl
* Version: v11.0.0+4
