### PR TITLE
New version: LLVM_assert_jll v11.0.0+4

### DIFF
--- a/L/LLVM_assert_jll/Versions.toml
+++ b/L/LLVM_assert_jll/Versions.toml
@@ -7,3 +7,5 @@ git-tree-sha1 = "e53641456f1c1085f564287bdb62bfbaa15b916e"
 ["11.0.0+3"]
 git-tree-sha1 = "e53641456f1c1085f564287bdb62bfbaa15b916e"
 
+["11.0.0+4"]
+git-tree-sha1 = "93851af05c5aaa9d77338b3b43c6253e15013526"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LLVM_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LLVM_assert_jll.jl
* Version: v11.0.0+4
