### PR TITLE
New version: Clang_assert_jll v11.0.0+4

### DIFF
--- a/C/Clang_assert_jll/Versions.toml
+++ b/C/Clang_assert_jll/Versions.toml
@@ -7,3 +7,5 @@ git-tree-sha1 = "5e935547fa690fa541de4a476618bbbc59a0e22d"
 ["11.0.0+3"]
 git-tree-sha1 = "5e935547fa690fa541de4a476618bbbc59a0e22d"
 
+["11.0.0+4"]
+git-tree-sha1 = "8c17517376c78c690a8222e8cf33e56a5348208f"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package Clang_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/Clang_assert_jll.jl
* Version: v11.0.0+4
