### PR TITLE
Add `stale-pr-message` to Action for stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request is inactive and will be closed'
         skip-stale-pr-message: true
         close-pr-message: 'This pull request has been inactive for more than 30 days and has been automatically closed. Feel free to register your package or version again once you fix AutoMerge issues'
         days-before-stale: 30


### PR DESCRIPTION
My understanding is that this key must be there even if the message will be skipped