### PR TITLE
AutoMerge: ask for fewer runs per hour

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: AutoMerge
 
 on:
   schedule:
-    - cron: '0,20,40 * * * *'
+    - cron:  '*/20 * * * *'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: AutoMerge
 
 on:
   schedule:
-    - cron: '05,17,29,41,53 * * * *'
+    - cron: '0,20,40 * * * *'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
In reality, we only get approx 1-3 runs per hour anyway. So there's no sense in asking for 5 runs per hour if we know GitHub won't give them to us.