### PR TITLE
Shorten the "new version" minimum waiting period to 10 minutes

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # The cron job is just a fallback.
     # The "stopwatch" functionality that we have implemented should
-    # ensure that an AutoMerge merge job is run at least every 15 minutes.
+    # ensure that an AutoMerge merge job is run at least every 8 minutes.
     # Therefore, it's sufficient for us to run the fallback job infrequently.
     # We will choose to run the fallback job every 4 hours.
     - cron:  '0 */4 * * *'
@@ -55,9 +55,9 @@ jobs:
             merge_new_packages = ENV["MERGE_NEW_PACKAGES"] == "true",
             merge_new_versions = ENV["MERGE_NEW_VERSIONS"] == "true",
             new_package_waiting_period = Day(3),
-            new_jll_package_waiting_period = Minute(15),
-            new_version_waiting_period = Minute(15),
-            new_jll_version_waiting_period = Minute(15),
+            new_jll_package_waiting_period = Minute(20),
+            new_version_waiting_period = Minute(10),
+            new_jll_version_waiting_period = Minute(10),
             registry = "JuliaRegistries/General",
             tagbot_enabled = true,
             authorized_authors = String["JuliaRegistrator"],


### PR DESCRIPTION
This pull request sets the AutoMerge minimum waiting periods to the following:

|                            | Regular packages | JLL packages (only if made by `@jlbuild`) |
| ---------------- | ----------------- | ----------------------------------------- |
| New packages   | 3 days                   | 20 minutes                                                    |
| New versions     | 10 minutes            | 10 minutes                                                     |