### PR TITLE
AutoMerge stopwatch: some fine tuning

### DIFF
--- a/.ci/stopwatch.jl
+++ b/.ci/stopwatch.jl
@@ -100,7 +100,7 @@ function trigger_new_automerge_if_necessary()
         auth,
     )
     @info "Time since last AutoMerge" t _canonicalize(t)
-    if t > Dates.Minute(15)
+    if t > Dates.Minute(8)
         @info "Attempting to trigger a new AutoMerge workflow dispatch job..."
         trigger_new_workflow_dispatch(
             registry;


### PR DESCRIPTION
Please note: this does NOT modify the waiting periods in any way. It only makes sure that we run the cron jobs more frequently.