### PR TITLE
Don't run Automerge jobs on PRs from forks (since they will fail anyway)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   AutoMerge:
+    if: github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -69,6 +70,7 @@ jobs:
           )
         shell: julia --color=yes --project=.ci/ {0}
   AutoMerge-stopwatch:
+    if: github.repository == github.event.pull_request.head.repo.full_name
     environment: stopwatch
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This concerns the two AutoMerge jobs that run on pull requests:
1. The AutoMerge PR job
2. The AutoMerge PR stopwatch job

The AutoMerge PR job requires a GitHub token with write access, which it uses to create/update the `automerge/decision` commit status and to create/update PR comments. Both of these features are required for AutoMerge to function.

The AutoMerge stopwatch job requires a GitHub personal access token with write access, which it uses to trigger a new `workflow_dispatch` run.

For security reasons, GitHub does not make these secrets available to PRs made from forks.

Therefore, the aforementioned AutoMerge jobs will **always** fail on PRs made from forks.

If we know that those jobs are going to fail, we can just save time and skip those jobs to begin with.