### PR TITLE
Run CI on Julia 1.3, 1.4, 1.5, 1.6-beta1, and nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         version:
           - '1.3'
+          - '1.4'
+          - '1.5'
           - '^1.6.0-0' # TODO: remove this line once 1.6 is released
           # - '1.6'    # TODO: uncomment this line once 1.6 is released
           - '1'
@@ -41,7 +43,7 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - if: ${{ matrix.version }} == "1.3" || ${{ matrix.version }} == "1"
+      - if: ${{ matrix.version }} == "1" || ${{ matrix.version }} == "1.3" || ${{ matrix.version }} == "1.4" || ${{ matrix.version }} == "1.5"
         run: rm -f .ci/Manifest.toml && mv .ci/Manifest.1.5.3.toml .ci/Manifest.toml
       - run: .ci/travis_before_script.sh
       - run: julia --project=.ci/ --color=yes -e 'import RegistryCI; RegistryCI.test()'


### PR DESCRIPTION
The more Julia versions that we run CI on, the less likely it is that I'll merge a PR that breaks all the things.