### PR TITLE
Register fake LLVM_full_assert_jll.jl

### DIFF
--- a/L/LLVM_full_assert_jll/Versions.toml
+++ b/L/LLVM_full_assert_jll/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "57e967da4c48c37838ad3fd558a6918bcde5296c"
 
 ["11.0.0+8"]
 git-tree-sha1 = "c2fb7b61ce4b359aac2bed5a849a260a4551b602"
+
+["11.0.0+9"]
+git-tree-sha1 = "c2fb7b61ce4b359aac2bed5a849a260a4551b602"


### PR DESCRIPTION
This will cause the next registration to match up with its counterpart, `LLVM_full_jll.jl`