### PR TITLE
New version: LLVM_full_assert_jll v11.0.0+10

### DIFF
--- a/L/LLVM_full_assert_jll/Compat.toml
+++ b/L/LLVM_full_assert_jll/Compat.toml
@@ -1,3 +1,3 @@
 [11]
-JLLWrappers = "1.1.0-1"
+JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"

--- a/L/LLVM_full_assert_jll/Versions.toml
+++ b/L/LLVM_full_assert_jll/Versions.toml
@@ -15,3 +15,6 @@ git-tree-sha1 = "c2fb7b61ce4b359aac2bed5a849a260a4551b602"
 
 ["11.0.0+9"]
 git-tree-sha1 = "c2fb7b61ce4b359aac2bed5a849a260a4551b602"
+
+["11.0.0+10"]
+git-tree-sha1 = "a8f9b3975f53ea30ea5d326002b50bc4919d6322"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LLVM_full_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LLVM_full_assert_jll.jl
* Version: v11.0.0+10
