### PR TITLE
New version: libLLVM_assert_jll v11.0.0+7

### DIFF
--- a/L/libLLVM_assert_jll/Compat.toml
+++ b/L/libLLVM_assert_jll/Compat.toml
@@ -1,3 +1,3 @@
 [11]
-JLLWrappers = "1.1.0-1"
+JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"

--- a/L/libLLVM_assert_jll/Versions.toml
+++ b/L/libLLVM_assert_jll/Versions.toml
@@ -18,3 +18,6 @@ git-tree-sha1 = "98bd75109259dc11ac9ece7ea67ce3dcdce0855e"
 
 ["11.0.0+6"]
 git-tree-sha1 = "98bd75109259dc11ac9ece7ea67ce3dcdce0855e"
+
+["11.0.0+7"]
+git-tree-sha1 = "74304bef8079b813734da86e630dedf52f6d196c"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package libLLVM_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/libLLVM_assert_jll.jl
* Version: v11.0.0+7
