### PR TITLE
New version: LLVM_assert_jll v11.0.0+7

### DIFF
--- a/L/LLVM_assert_jll/Compat.toml
+++ b/L/LLVM_assert_jll/Compat.toml
@@ -1,4 +1,4 @@
 [11]
-JLLWrappers = "1.1.0-1"
+JLLWrappers = "1.2.0-1"
 julia = "1"
 libLLVM_assert_jll = "11.0.0"

--- a/L/LLVM_assert_jll/Versions.toml
+++ b/L/LLVM_assert_jll/Versions.toml
@@ -15,3 +15,6 @@ git-tree-sha1 = "93851af05c5aaa9d77338b3b43c6253e15013526"
 
 ["11.0.0+6"]
 git-tree-sha1 = "93851af05c5aaa9d77338b3b43c6253e15013526"
+
+["11.0.0+7"]
+git-tree-sha1 = "356c5b31de7a0289a6d9aa643f0ba1e72ea555aa"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package LLVM_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/LLVM_assert_jll.jl
* Version: v11.0.0+7
