### PR TITLE
New version: Clang_assert_jll v11.0.0+7

### DIFF
--- a/C/Clang_assert_jll/Compat.toml
+++ b/C/Clang_assert_jll/Compat.toml
@@ -1,4 +1,4 @@
 [11]
-JLLWrappers = "1.1.0-1"
+JLLWrappers = "1.2.0-1"
 julia = "1"
 libLLVM_assert_jll = "11.0.0"

--- a/C/Clang_assert_jll/Versions.toml
+++ b/C/Clang_assert_jll/Versions.toml
@@ -15,3 +15,6 @@ git-tree-sha1 = "8c17517376c78c690a8222e8cf33e56a5348208f"
 
 ["11.0.0+6"]
 git-tree-sha1 = "8c17517376c78c690a8222e8cf33e56a5348208f"
+
+["11.0.0+7"]
+git-tree-sha1 = "e65d2db7ee31ae4070ee943e5b7aa62824734cda"


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package Clang_assert_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/Clang_assert_jll.jl
* Version: v11.0.0+7
