### PR TITLE
Further decrease timeout of CI and AutoMerge jobs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,8 +11,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Disable PkgServer to avoid random issues.
+# TODO: remove this when PkgServer feels better
+env:
+  JULIA_PKG_SERVER: ""
+
 jobs:
   AutoMerge:
+    timeout-minutes: 60
     if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,25 @@ on:
       - master
   schedule:
     - cron: 0 0 * * *
+
+# Disable PkgServer to avoid random issues.
+# TODO: remove this when PkgServer feels better
+env:
+  JULIA_PKG_SERVER: ""
+
 jobs:
   CI:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.3'
           - '1.4'
-          - '1.5'
+          - '1'
           - '^1.6.0-0' # TODO: remove this line once 1.6 is released
           # - '1.6'    # TODO: uncomment this line once 1.6 is released
-          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Also, disable PkgServer and remove redundant CI job (`1` is the same as `1.5`).