### PR TITLE
Delete branch when closing stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@b12dccced80582bf8c52244f75838892ec5c1e82
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This pull request is inactive and will be closed'
@@ -16,3 +16,4 @@ jobs:
         close-pr-message: 'This pull request has been inactive for more than 30 days and has been automatically closed. Feel free to register your package or version again once you fix AutoMerge issues'
         days-before-stale: 30
         days-before-close: 1
+        delete-branch: true


### PR DESCRIPTION
I want to automatically delete branches when the pull requests are closed with [`actions/stale`](https://github.com/actions/stale).  Today https://github.com/actions/stale/pull/190 was finally merged, but as far as I can see there is no new release, yet.  @SaschaMann can I use commit https://github.com/actions/stale/commit/b12dccced80582bf8c52244f75838892ec5c1e82 (currently the latest commit on `main`) as reference?  I'm always a bit confused about which branch to look at for GitHub Actions.