### PR TITLE
Don't skip the stale message, and give the PR author 7 days between posting the stale message and closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,8 +10,8 @@ jobs:
     - uses: actions/stale@b12dccced80582bf8c52244f75838892ec5c1e82
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This pull request has been inactive for 30 days and will be automatically closed 7 days from now. If this pull request should not be closed, please either (1) fix the AutoMerge issues and re-trigger Registrator, which will automatically update the pull request, or (2) post a comment explaining why you would like this pull request to be manually merged.'
-        close-pr-message: 'This pull request has been inactive for more than 30 days and has automatically been closed. Feel free to register your package or version again once you fix AutoMerge issues.'
+        stale-pr-message: 'This pull request has been inactive for 30 days and will be automatically closed 7 days from now. If this pull request should not be closed, please either (1) fix the AutoMerge issues and re-trigger Registrator, which will automatically update the pull request, or (2) post a comment explaining why you would like this pull request to be manually merged. [noblock]'
+        close-pr-message: 'This pull request has been inactive for more than 30 days and has automatically been closed. Feel free to register your package or version again once you fix AutoMerge issues. [noblock]'
         days-before-stale: 30
         days-before-close: 7
         delete-branch: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@b12dccced80582bf8c52244f75838892ec5c1e82
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This pull request has been inactive for 30 days and will be automatically closed 7 days from now. Post a comment if this pull request should not be closed.'
+        stale-pr-message: 'This pull request has been inactive for 30 days and will be automatically closed 7 days from now. If this pull request should not be closed, please either (1) fix the AutoMerge issues and re-trigger Registrator, which will automatically update the pull request, or (2) post a comment explaining why you would like this pull request to be manually merged.'
         close-pr-message: 'This pull request has been inactive for more than 30 days and has automatically been closed. Feel free to register your package or version again once you fix AutoMerge issues.'
         days-before-stale: 30
         days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: "16 12 * * *"
   workflow_dispatch:
-
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -11,9 +10,8 @@ jobs:
     - uses: actions/stale@b12dccced80582bf8c52244f75838892ec5c1e82
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This pull request is inactive and will be closed'
-        skip-stale-pr-message: true
-        close-pr-message: 'This pull request has been inactive for more than 30 days and has been automatically closed. Feel free to register your package or version again once you fix AutoMerge issues'
+        stale-pr-message: 'This pull request has been inactive for 30 days and will be automatically closed 7 days from now. Post a comment if this pull request should not be closed.'
+        close-pr-message: 'This pull request has been inactive for more than 30 days and has automatically been closed. Feel free to register your package or version again once you fix AutoMerge issues.'
         days-before-stale: 30
-        days-before-close: 1
+        days-before-close: 7
         delete-branch: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This pull request has been inactive for 30 days and will be automatically closed 7 days from now. If this pull request should not be closed, please either (1) fix the AutoMerge issues and re-trigger Registrator, which will automatically update the pull request, or (2) post a comment explaining why you would like this pull request to be manually merged. [noblock]'
-        close-pr-message: 'This pull request has been inactive for more than 30 days and has automatically been closed. Feel free to register your package or version again once you fix AutoMerge issues. [noblock]'
+        close-pr-message: 'This pull request has been inactive for more than 30 days and has automatically been closed. Feel free to register your package or version again once you fix the AutoMerge issues. [noblock]'
         days-before-stale: 30
         days-before-close: 7
         delete-branch: true


### PR DESCRIPTION
Fixes https://github.com/JuliaRegistries/General/issues/28236

I think I prefer this. That way, it gives people the opportunity to keep the PR open by posting a comment.