### PR TITLE
Fix Singular_jll compat entry

### DIFF
--- a/L/libsingular_julia_jll/Compat.toml
+++ b/L/libsingular_julia_jll/Compat.toml
@@ -21,7 +21,7 @@ julia = "1.5.0-1"
 
 ["0.5-0"]
 JLLWrappers = "1.2.0-1"
-Singular_jll = "402.0.1"
+Singular_jll = "402.0.1-402.0"
 
 ["0.5-0.5.3"]
 julia = "1.3.0-1"


### PR DESCRIPTION
This is a stop-gap measure until we can properly fix the underlying problem, and teach BB to support VersionSpec for dependencies correctly. But it'll save me some headaches...

See also https://github.com/JuliaBinaryWrappers/libsingular_julia_jll.jl/pull/1