### PR TITLE
[Cuba] Restrict compat for Cuba_jll to v4.2.0 only

### DIFF
--- a/C/Cuba/Compat.toml
+++ b/C/Cuba/Compat.toml
@@ -7,5 +7,5 @@ BinaryProvider = "0.3.0 - 0.5"
 julia = "1"
 
 ["2.1-2"]
-Cuba_jll = "4.2.0-4"
+Cuba_jll = "4.2.0"
 julia = "1.3.0-1"


### PR DESCRIPTION
The upstream C library introduced an API-breaking change in a patch version