### PR TITLE
Revert "New version: MicrosoftMPI_jll v10.1.2+4 (#28638)"

### DIFF
--- a/M/MicrosoftMPI_jll/Compat.toml
+++ b/M/MicrosoftMPI_jll/Compat.toml
@@ -1,3 +1,2 @@
 [10]
-JLLWrappers = "1.2.0-1"
 julia = "1"

--- a/M/MicrosoftMPI_jll/Deps.toml
+++ b/M/MicrosoftMPI_jll/Deps.toml
@@ -1,5 +1,3 @@
 [10]
-Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/M/MicrosoftMPI_jll/Versions.toml
+++ b/M/MicrosoftMPI_jll/Versions.toml
@@ -9,6 +9,3 @@ git-tree-sha1 = "b2cc58e3f4d08ea842993cf64d7a786e1db43b37"
 
 ["10.1.2+3"]
 git-tree-sha1 = "720de13004e416f2864c92593d3839e062703985"
-
-["10.1.2+4"]
-git-tree-sha1 = "eb8e7ff35b32ccb17947caaf05cea979aed5199e"


### PR DESCRIPTION
This reverts commit b1f050efa3f6f512e8a1b99bba8900ba49da9fb1.

This is the first part of fixing `MicrosoftMPI_jll` compat bounds, as reported by @sloede.  The second part will be re-registering this newer version as `v10.1.3`, given @simonbyrne's consent.