### PR TITLE
SIMDPirates does not work on Julia 1.6

### DIFF
--- a/L/LoopVectorization/Compat.toml
+++ b/L/LoopVectorization/Compat.toml
@@ -1,6 +1,6 @@
 ["0-0.1"]
 SIMDPirates = "0.1"
-julia = "1"
+julia = "1.0-1.5"
 
 ["0-0.1.2"]
 SLEEFPirates = "0.1"
@@ -35,7 +35,7 @@ VectorizationBase = "0.18.1-0.18"
 SIMDPirates = "0.1.1-0.1"
 
 ["0.2-0.5"]
-julia = "1.3.0-1"
+julia = "1.3.0-1.5"
 
 ["0.2.1-0.3.0"]
 VectorizationBase = "0.1.4-0.1"
@@ -82,7 +82,7 @@ SIMDPirates = "0.3"
 SLEEFPirates = "0.3"
 
 ["0.6-0.8"]
-julia = "1.1.0-1"
+julia = "1.1.0-1.5"
 
 ["0.6.0"]
 SIMDPirates = "0.3.1-0.5"

--- a/S/SIMDPirates/Compat.toml
+++ b/S/SIMDPirates/Compat.toml
@@ -1,5 +1,5 @@
 [0]
-julia = "1.0 - 1.5"
+julia = "1.0-1.5"
 
 ["0-0.1.3"]
 VectorizationBase = "0.1.1-0.1"

--- a/S/SIMDPirates/Compat.toml
+++ b/S/SIMDPirates/Compat.toml
@@ -1,5 +1,5 @@
 [0]
-julia = "1"
+julia = "1.0 - 1.5"
 
 ["0-0.1.3"]
 VectorizationBase = "0.1.1-0.1"


### PR DESCRIPTION
The package resolver likes to pick old versions of packages, even when newer ones exist.
SIMDPirates.jl is deprecated, and only works up through Julia 1.5.

LoopVectorization 0.8 used SIMDPirates and does not work on Julia 1.6, while 0.9 and newer do not and thus work. But sometimes Julia's package resolver feels nostalgic and picks old versions even in the absence of conflicts, so a PR to adjust compat is necessary.
I think this one line change should also be sufficient (i.e., I don't need to change the corresponding entries for LoopVectorization 0.8 and older), but I did update LoopVectorization's as well for good measure.