### PR TITLE
[polymake_jll] yank bad version 400.300.0+2

### DIFF
--- a/P/polymake_jll/Versions.toml
+++ b/P/polymake_jll/Versions.toml
@@ -21,3 +21,4 @@ git-tree-sha1 = "3bf841a6aab7aa10474f13dffce150176ae802b2"
 
 ["400.300.0+2"]
 git-tree-sha1 = "07b033f9e4e60ed49bf4ac72ba0e18b9b09cf0c9"
+yanked = true


### PR DESCRIPTION
Something is broken in this version (i.e. Polymake.jl does not load because it cannot find libpolymake.so.4.3) even though it should have just been a simple patch for an interpreted script:
https://github.com/JuliaPackaging/Yggdrasil/pull/2548

I need some more time to investigate and fix this.