### PR TITLE
Prevent dependency confusion with Holy Lab registry

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -73,6 +73,7 @@ jobs:
             suggest_onepointzero = false,
             additional_statuses = String[],
             additional_check_runs = String[],
+            public_registries = String["https://github.com/HolyLab/HolyLabRegistry"],
           )
         shell: julia --color=yes --project=.ci/ {0}
 


### PR DESCRIPTION
This adds the Holy lab registry to the new list of public registries checked via the new RegistryCI guideline @GunnarFarneback kindly contributed (https://github.com/JuliaRegistries/RegistryCI.jl/pull/348). What that means is that when automerge is checking the guidelines for a new package registration, it fails if the new package's UUID matches a UUID from the Holy lab registry and the (name, uuid, repo URL)-triple does not match that from the Holy lab registry, then the automerge guideline will fail and the package will not automerge.

In this way, an attacker shouldn't be able to automerge-register a package with the same (name, UUID) pair as a package from the Holy lab with a newer version number to trick Pkg clients with both registries to update to use the newer one.

This PR should only be merged once the RegistryCI version General uses has been bumped to 6.4.0.

If the remote registry (the Holy Lab registry in this case) cannot be reached, has an invalid TOML file, or something otherwise goes wrong, the guideline check will fail as well, which is unforunate for the package being registered and should be addressed ASAP.