### PR TITLE
Yank GMP_jll v6.1.2+9

### DIFF
--- a/G/GMP_jll/Versions.toml
+++ b/G/GMP_jll/Versions.toml
@@ -29,6 +29,7 @@ yanked = true
 
 ["6.1.2+9"]
 git-tree-sha1 = "40b069f884021e4a7aa78faeb69d5865e9d41c98"
+yanked = true
 
 ["6.2.0+0"]
 git-tree-sha1 = "1976f0824aa2a575d3c6e97b6afb8c5871672aa8"


### PR DESCRIPTION
This version contains unsupported aarch64-apple-darwin for julia < 1.5.
https://github.com/JuliaBinaryWrappers/GMP_jll.jl/tree/GMP-v6.1.2+9

```
julia> versioninfo()
Julia Version 1.4.2
Commit 44fa15b150* (2020-05-23 18:35 UTC)
...

(@v1.4) pkg> add GMP_jll
  Resolving package versions...
ERROR: ArgumentError: Unsupported architecture 'aarch64' for macOS
```