### PR TITLE
Update the repo URL for MKL.jl

### DIFF
--- a/M/MKL/Package.toml
+++ b/M/MKL/Package.toml
@@ -1,3 +1,3 @@
 name = "MKL"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-repo = "https://github.com/JuliaComputing/MKL.jl.git"
+repo = "https://github.com/JuliaLinearAlgebra/MKL.jl.git"


### PR DESCRIPTION
Changing the URL since we moved MKL.jl to a new org. Is this the only place this is necessary? I am mainly doing this so that I can then use the web registrator on juliahub.com (which otherwise complains).

cc @giordano @DilumAluthge 