### PR TITLE
[NetworkDynamics] Update URL after moving the package to an Org

### DIFF
--- a/N/NetworkDynamics/Package.toml
+++ b/N/NetworkDynamics/Package.toml
@@ -1,3 +1,3 @@
 name = "NetworkDynamics"
 uuid = "22e9dc34-2a0d-11e9-0de0-8588d035468b"
-repo = "https://github.com/FHell/NetworkDynamics.jl.git"
+repo = "https://github.com/PIK-ICoN/NetworkDynamics.jl.git"


### PR DESCRIPTION
We have moved the packaged to a new Org, PIK-ICoN. Updating accordingly.