### PR TITLE
Use `check_license=true` with RegistryCI

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -73,6 +73,7 @@ jobs:
             suggest_onepointzero = false,
             additional_statuses = String[],
             additional_check_runs = String[],
+            check_license = true,
             public_registries = String["https://github.com/HolyLab/HolyLabRegistry"],
           )
         shell: julia --color=yes --project=.ci/ {0}


### PR DESCRIPTION
This should only be merged **after** we update the version of RegistryCI used by automerge to 6.5.0+, otherwise the keyword argument won't exist yet.

Merging this will turn on license checking introduced in https://github.com/JuliaRegistries/RegistryCI.jl/pull/344. In short, the new AutoMerge guideline checks that every new package registration and every new version corresponds to a package directory with a top-level file containing the text of an OSI-approved software license, as identified by LicenseCheck.jl, a wrapper around the `licensecheck` go library.

It is already the policy of General to require such a license, but it wasn't being automatically checked.