### PR TITLE
Change package source repository

### DIFF
--- a/P/PopGen/Package.toml
+++ b/P/PopGen/Package.toml
@@ -1,3 +1,3 @@
 name = "PopGen"
 uuid = "af524d12-c74b-11e9-22a8-3b091653023f"
-repo = "https://github.com/pdimens/PopGen.jl.git"
+repo = "https://github.com/BioJulia/PopGen.jl.git"


### PR DESCRIPTION
PopGen.jl is back into BioJulia, and we would like future releases to occur on that repo instead of my fork.