### PR TITLE
Fix version requirements for Cbc_jll

### DIFF
--- a/C/Cbc_jll/Compat.toml
+++ b/C/Cbc_jll/Compat.toml
@@ -1,17 +1,12 @@
 [2]
 julia = "1"
-
-["2-2.10.3"]
 Cgl_jll = "0.60.2"
 Clp_jll = "1.17.6"
 CoinUtils_jll = "2.11.3"
-JLLWrappers = "1.1.0-1"
 Osi_jll = "0.108.5"
 
+["2-2.10.3"]
+JLLWrappers = "1.1.0-1"
+
 ["2.10.5-2"]
-Cgl_jll = "0.60.3"
-Clp_jll = "1.17.5"
-CoinUtils_jll = "2.11.4"
 JLLWrappers = "1.2.0-1"
-METIS_jll = "4.0.3"
-Osi_jll = "0.108.6"

--- a/C/Cbc_jll/Deps.toml
+++ b/C/Cbc_jll/Deps.toml
@@ -9,7 +9,3 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 Osi_jll = "7da25872-d9ce-5375-a4d3-7a845f58efdd"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-["2.10.5-2"]
-ASL_jll = "ae81ac8f-d209-56e5-92de-9978fef736f9"
-METIS_jll = "d00139f3-1899-568f-a2f0-47f597d42d70"

--- a/C/Cbc_jll/Versions.toml
+++ b/C/Cbc_jll/Versions.toml
@@ -18,9 +18,11 @@ git-tree-sha1 = "aac604eecf9d882ae72f192e3ba2c1594a62f5ea"
 
 ["2.10.5+0"]
 git-tree-sha1 = "453ab175ac066798886ff91cd262280014801a3b"
+yanked = true
 
 ["2.10.5+1"]
 git-tree-sha1 = "aee8f49c0defdda32e3af41bccd4667039e55ca6"
+yanked = true
 
 ["2.10.5+2"]
 git-tree-sha1 = "5d24ea46edebb4f067b180cfc092a45d4d2c48b3"


### PR DESCRIPTION
# The problem

The issue arose because Cbc_jll@2.10.5+1 was previously released,
but due to some compatibility issues, the next version released
was 2.10.3.

We recently re-compiled Cbc pointing at the upstream 2.10.5, which
got released as 2.10.5+2
https://github.com/JuliaRegistries/General/pull/31558
https://github.com/JuliaPackaging/Yggdrasil/pull/2668
We deemed this okay because the only consumer of Cbc_jll is Cbc.jl, 
which pinned Cbc_jll@2.10.3.

However, we didn't account for the version incompatibilities (it seems like
`[Compat]` can't handle `+N` version revisions).

I think this PR makes `2.10.5+0` and `2.10.5+1` un-installable, but no one 
should be using it.

# Alternatives

If modifying versions like this is unacceptable, an alternative is to release new 
versions of the dependencies using the "multiply the version number by 100" trick 
so we can install `Clp@100.1700.600` etc.

I've verified that this allows Cbc.jl to work on Linux: https://github.com/jump-dev/Cbc.jl/pull/160

cc @giordano 