### PR TITLE
Update repo url in Package.toml for MinimallyDisruptiveCurves.jl

### DIFF
--- a/M/MinimallyDisruptiveCurves/Package.toml
+++ b/M/MinimallyDisruptiveCurves/Package.toml
@@ -1,3 +1,3 @@
 name = "MinimallyDisruptiveCurves"
 uuid = "c6328df5-4af8-4637-a9e9-78ed74a2ae2b"
-repo = "https://github.com/Dhruva2/MinimallyDisruptiveCurves.jl.git"
+repo = "https://github.com/SciML/MinimallyDisruptiveCurves.jl.git"


### PR DESCRIPTION
The package MinimallyDisruptiveCurves was transferred into the SciML org from @Dhruva2 but was registered before the transfer so this PR updates the url for the package repo. 