### PR TITLE
Redirect PkgDeps to JuliaEcosystem org

### DIFF
--- a/P/PkgDeps/Package.toml
+++ b/P/PkgDeps/Package.toml
@@ -1,3 +1,3 @@
 name = "PkgDeps"
 uuid = "839e9fc8-855b-5b3c-a3b7-2833d3dd1f59"
-repo = "https://github.com/mattBrzezinski/PkgDeps.jl.git"
+repo = "https://github.com/JuliaEcosystem/PkgDeps.jl.git"


### PR DESCRIPTION
We have created a new GitHub organization [JuliaEcosystem](https://github.com/JuliaEcosystem), I'm wanting to move over the [PkgDeps.jl](https://github.com/mattBrzezinski/PkgDeps.jl) package into it.