### PR TITLE
Transferring 5 packages to MechanicalRabbit organization

### DIFF
--- a/D/DataKnots/Package.toml
+++ b/D/DataKnots/Package.toml
@@ -1,3 +1,3 @@
 name = "DataKnots"
 uuid = "f3f2b2ad-91c8-5588-b964-d77e2d3bb090"
-repo = "https://github.com/rbt-lang/DataKnots.jl.git"
+repo = "https://github.com/MechanicalRabbit/DataKnots.jl.git"

--- a/H/HypertextLiteral/Package.toml
+++ b/H/HypertextLiteral/Package.toml
@@ -1,3 +1,3 @@
 name = "HypertextLiteral"
 uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
-repo = "https://github.com/clarkevans/HypertextLiteral.jl.git"
+repo = "https://github.com/MechanicalRabbit/HypertextLiteral.jl.git"

--- a/N/NarrativeTest/Package.toml
+++ b/N/NarrativeTest/Package.toml
@@ -1,3 +1,3 @@
 name = "NarrativeTest"
 uuid = "9563631e-acd4-5dd8-bebb-4cf36518960d"
-repo = "https://github.com/rbt-lang/NarrativeTest.jl.git"
+repo = "https://github.com/MechanicalRabbit/NarrativeTest.jl.git"

--- a/P/PostgresCatalog/Package.toml
+++ b/P/PostgresCatalog/Package.toml
@@ -1,3 +1,3 @@
 name = "PostgresCatalog"
 uuid = "972fa324-5b21-11e9-38b2-934e41d705ec"
-repo = "https://github.com/rbt-lang/PostgresCatalog.jl.git"
+repo = "https://github.com/MechanicalRabbit/PostgresCatalog.jl.git"

--- a/P/PrettyPrinting/Package.toml
+++ b/P/PrettyPrinting/Package.toml
@@ -1,3 +1,3 @@
 name = "PrettyPrinting"
 uuid = "54e16d92-306c-5ea0-a30b-337be88ac337"
-repo = "https://github.com/rbt-lang/PrettyPrinting.jl.git"
+repo = "https://github.com/MechanicalRabbit/PrettyPrinting.jl.git"


### PR DESCRIPTION
We transferred 5 packages to a new GitHub organization. I'd like to update the URLs in the Julia registry:

- https://github.com/rbt-lang/DataKnots.jl.git -> https://github.com/MechanicalRabbit/DataKnots.jl.git
- https://github.com/clarkevans/HypertextLiteral.jl.git -> https://github.com/MechanicalRabbit/HypertextLiteral.jl.git
- https://github.com/rbt-lang/NarrativeTest.jl.git -> https://github.com/MechanicalRabbit/NarrativeTest.jl.git
- https://github.com/rbt-lang/PostgresCatalog.jl.git -> https://github.com/MechanicalRabbit/PostgresCatalog.jl.git
- https://github.com/rbt-lang/PrettyPrinting.jl.git -> https://github.com/MechanicalRabbit/PrettyPrinting.jl.git