### PR TITLE
Fix GaussianFilters dependency requirements

### DIFF
--- a/G/GaussianFilters/Compat.toml
+++ b/G/GaussianFilters/Compat.toml
@@ -1,4 +1,2 @@
 [0]
-Distributions = "0.0.0 - 0.23"
-ForwardDiff = "0.0.0 - 0.10"
 julia = "1"


### PR DESCRIPTION
GaussianFilters had a compatibility entry for its "Distributions" dependency that was NOT specified in the package itself,
but ONLY in G/GaussianFilters/Compat.toml.

AFAICT this had been automatically added.
This needs to be removed so that GaussianFilters can coexist e.g. with Distributions@0.24.15

On a sidenote:
This was incredibly frustrating to hunt down because GaussianFilters itself DOES not require any specific "Distributions" version.
It took forever to trace this back to the registry itself.

/rant
Dependency requirement management is just fundamentally broken (by concept) whenever packages use pre-1.0.0 versions, because it becomes impossible to express forward compatibility ("we need Distributions@v0.X, with X >= 23"), and thus requires ALL dependents to change with EVERY minor release of EVERY dependency (or to not specify dependency requirements at all).
I realise that this is how semantic versioning semantics **are**, but the resulting workflow is just broken.