### PR TITLE
Revert incomplete CSL registration

### DIFF
--- a/C/CompilerSupportLibraries_jll/Versions.toml
+++ b/C/CompilerSupportLibraries_jll/Versions.toml
@@ -41,5 +41,3 @@ git-tree-sha1 = "9b1dfece9e9d101ecb59a1cf319c07430d2c598c"
 ["0.4.1+0"]
 git-tree-sha1 = "dd12c2da706574620b5fa4468ec5dc0016eb3517"
 
-["0.4.1+1"]
-git-tree-sha1 = "2012c428a408a092d1525e77e1426991f9ceb4f5"


### PR DESCRIPTION
BB locally didn't run properly, so this version is incomplete and erroneous.  Sorry, I didn't realize that this PR was actually opened by BB since it errored out halfway through a build.