### PR TITLE
Only run the Manifest Updater one time per week

### DIFF
--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -1,7 +1,7 @@
 name: Update Manifests
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 0
   workflow_dispatch:
 jobs:
   update_manifests:


### PR DESCRIPTION
Before this PR, we run the Manifest Updater one time per day.

After this PR, we run the Manifest Updater one time per week.

We also have a `workflow_dispatch` trigger that allows users with commit access to manually trigger a run if they want to get immediate manifest updates.