### PR TITLE
Remove a cron job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: 0 0 * * *
   workflow_dispatch:
 jobs:
   CI:


### PR DESCRIPTION
I don't think that we actually need this cron job, since we always run CI on every push to master.