### PR TITLE
[tectonic_jll] Fix compatibility with HarfBuzz

### DIFF
--- a/T/tectonic_jll/Compat.toml
+++ b/T/tectonic_jll/Compat.toml
@@ -1,3 +1,4 @@
 [0]
+HarfBuzz_jll = "2.6.1"
 ICU_jll = "67.1.0"
 julia = "1"


### PR DESCRIPTION
New versions of `HarfBuzz_jll` will move ICU-stuff into `HarfBuzz_ICU_jll`.  `tectonic_jll` needs it, so for the time being we make it require the old version of `HarfBuzz_jll`