### PR TITLE
Add upper-bounded `[compat]` entries for all non-stdlib `[deps]` in the `.ci/Project.toml` project file

### DIFF
--- a/.ci/Project.toml
+++ b/.ci/Project.toml
@@ -6,4 +6,8 @@ RegistryCI = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
+GitHub = "5"
+HTTP = "0.9"
+RegistryCI = "7"
+TimeZones = "1"
 julia = "1.3"


### PR DESCRIPTION
Closes #38313 
Closes #38314 
Closes #38315 
Closes #38316 