### PR TITLE
Yank all registered versions of StatPlots.jl

### DIFF
--- a/S/StatPlots/Versions.toml
+++ b/S/StatPlots/Versions.toml
@@ -1,17 +1,23 @@
 ["0.8.0"]
 git-tree-sha1 = "6216b81c79889743254af713d8cb5f21a18efacd"
+yanked = true
 
 ["0.8.1"]
 git-tree-sha1 = "4555d876c4c2db293dc661c94f26679b788ccb13"
+yanked = true
 
 ["0.8.2"]
 git-tree-sha1 = "e35b968df3937eaee1c8df698bcfd7d047c45110"
+yanked = true
 
 ["0.9.0"]
 git-tree-sha1 = "0f741f9854516b6d8aec55c8c6b6b01805029eb0"
+yanked = true
 
 ["0.9.1"]
 git-tree-sha1 = "2087cd367b8481ace3841d67af708262234134e3"
+yanked = true
 
 ["0.9.2"]
 git-tree-sha1 = "245c50f8a6534bb16ada031e064363f8298b61b9"
+yanked = true


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Plots.jl/issues/5518

It's far too confusing to have both `StatPlots.jl` and `StatsPlots.jl` in the registry.