### PR TITLE
URL Update Request: BLIS

### DIFF
--- a/B/BLIS/Package.toml
+++ b/B/BLIS/Package.toml
@@ -1,3 +1,3 @@
 name = "BLIS"
 uuid = "32f2db32-628a-4fc2-9392-deeafdcf461f"
-repo = "https://github.com/xrq-phys/BLIS.jl.git"
+repo = "https://github.com/JuliaLinearAlgebra/BLIS.jl.git"


### PR DESCRIPTION
Hi.

`BLIS.jl` used to be under my personal account while it's now transferred to JuliaLinearAlgebra.

This PR is for that update.

Thank you.