### PR TITLE
NetworkDynamics Org Rename

### DIFF
--- a/N/NetworkDynamics/Package.toml
+++ b/N/NetworkDynamics/Package.toml
@@ -1,3 +1,3 @@
 name = "NetworkDynamics"
 uuid = "22e9dc34-2a0d-11e9-0de0-8588d035468b"
-repo = "https://github.com/PIK-ICoN/NetworkDynamics.jl.git"
+repo = "https://github.com/PIK-ICoNe/NetworkDynamics.jl.git"


### PR DESCRIPTION
Due to an internal naming conflict we had to rename the org from PIK-ICoN to PIK-ICoNe, update accordingly.