### PR TITLE
Avoid some unnecessary GitHub API calls.

### DIFF
--- a/.ci/stopwatch.jl
+++ b/.ci/stopwatch.jl
@@ -87,12 +87,8 @@ end
 
 function trigger_new_automerge_if_necessary()
     api = GitHub.DEFAULT_API
-    auth = GitHub.authenticate(ENV["AUTOMERGE_TAGBOT_TOKEN"])
-    registry = GitHub.repo(
-        api,
-        "JuliaRegistries/General";
-        auth = auth,
-    )
+    auth = GitHub.OAuth2(ENV["AUTOMERGE_TAGBOT_TOKEN"])
+    registry = GitHub.Repo("JuliaRegistries/General")
     t = time_since_last_automerge(
         registry;
         api,


### PR DESCRIPTION
No need to verify the token, it will fail in the actual API calls anyway if it is incorrect.

See https://github.com/JuliaWeb/GitHub.jl/blob/4bcd93d7d856e47d2f582adbe660427207f8a39a/src/utils/auth.jl#L56