### PR TITLE
CI: Fix a major typo in the `.ci/instantiate.sh` shell script

### DIFF
--- a/.ci/instantiate.sh
+++ b/.ci/instantiate.sh
@@ -6,7 +6,7 @@ try_count=0
 while [ $try_count != 9 ]; do
     julia --color=yes --project=.ci/ -e 'import Pkg; Pkg.instantiate()'
     if [ $? = 0 ]; then exit 0; fi
-    try_count = `expr $try_count + 1`
+    try_count=`expr $try_count + 1`
     sleep 20
 done
 exit 1


### PR DESCRIPTION
See also: #38675