### PR TITLE
Fix SpecialFunctions compat entry for GaussQuadrature 0.5.2

### DIFF
--- a/G/GaussQuadrature/Compat.toml
+++ b/G/GaussQuadrature/Compat.toml
@@ -3,10 +3,9 @@ SpecialFunctions = "0.0.0 - 0.7"
 julia = ["0.7", "1"]
 
 ["0.5.2"]
-SpecialFunctions = "0.7.2-0.7"
 julia = "1.0.5-1"
 
-["0.5.3"]
+["0.5.2-0.5.3"]
 SpecialFunctions = "0.8"
 
 ["0.5.3-0"]


### PR DESCRIPTION
GaussQuadrature 0.5.2 has a wrong compat entry for SpecialFunctions, with the effect that it cannot be loaded. This PR fixes the compat entry.

Previous discussion: https://github.com/billmclean/GaussQuadrature.jl/issues/13