### PR TITLE
Cap the compatibility of all versions of StatPlots to Julia ≤ 1.6

### DIFF
--- a/S/StatPlots/Compat.toml
+++ b/S/StatPlots/Compat.toml
@@ -10,7 +10,7 @@ Reexport = "0.0.0 - 0.2"
 StatsBase = "0.0.0 - 0.33"
 TableTraits = "0-1"
 TableTraitsUtils = "0.1-1"
-julia = ["0.7", "1"]
+julia = ["0.7", "1 - 1.6"]
 
 ["0.8.1-0"]
 Observables = "0.2.2 - 0.3"


### PR DESCRIPTION
Fixes https://github.com/JuliaPlots/Plots.jl/issues/5518
Closes #38626 

This is an alternative to #38626.

This pull request caps the compatibility of all versions of `StatPlots` so that they are only compatible with Julia versions ≤ 1.6.