### PR TITLE
Update SHA.jl origin URL

### DIFF
--- a/S/SHA/Package.toml
+++ b/S/SHA/Package.toml
@@ -1,3 +1,3 @@
 name = "SHA"
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-repo = "https://github.com/staticfloat/SHA.jl.git"
+repo = "https://github.com/JuliaCrypto/SHA.jl.git"


### PR DESCRIPTION
The `SHA.jl` repository has moved to `JuliaCrypto`