### PR TITLE
Yank GeoData.jl 0.4.0-0.4.4

### DIFF
--- a/G/GeoData/Versions.toml
+++ b/G/GeoData/Versions.toml
@@ -36,18 +36,23 @@ git-tree-sha1 = "42c206ff46c9b44197d5845fd2b1963798fbfe2a"
 
 ["0.4.0"]
 git-tree-sha1 = "6fcc36c8fe8aeb74435ba956205b5e2b2b52cb6f"
+yanked = true
 
 ["0.4.1"]
 git-tree-sha1 = "51a8d8da773df15ed97411c8e4ddfc549224207e"
+yanked = true
 
 ["0.4.2"]
 git-tree-sha1 = "0bfc9d4d3fa6ed43eb4f33ecd8aa19f40fc0c523"
+yanked = true
 
 ["0.4.3"]
 git-tree-sha1 = "4b38c37a8ba922ba3a28bf4589ad93058cd21a6e"
+yanked = true
 
 ["0.4.4"]
 git-tree-sha1 = "cc335b3d23091fc602b66f55323f5feca99b1339"
+yanked = true
 
 ["0.4.5"]
 git-tree-sha1 = "d10da312fb34fbb7cf24c31b0ebf69ffcaf11214"


### PR DESCRIPTION
These versions were broken unintentionally by an upstream change with a patch bump.