### PR TITLE
CI: In manifest files, in the `julia_version` field, record the Julia master version as `1.MINOR.0-DEV` (instead of e.g. `1.MINOR.0-DEV.59`, `1.MINOR.0-DEV.84`, etc.)

### DIFF
--- a/.ci/Manifest.1.8.toml
+++ b/.ci/Manifest.1.8.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.0-DEV.59"
+julia_version = "1.8.0-DEV"
 manifest_format = "2.0"
 
 [[deps.ArgTools]]

--- a/.ci/shorten_manifest_version_master.jl
+++ b/.ci/shorten_manifest_version_master.jl
@@ -1,0 +1,45 @@
+import Pkg
+import TOML
+
+function is_manifest_filename(file::AbstractString)
+    is_manifest = any(startswith.(Ref(file), first.(splitext.(Base.manifest_names))))
+    is_toml = endswith(lowercase(file), ".toml")
+    return is_manifest && is_toml
+end
+
+function _shorten_manifest_version_master(manifest_filename::AbstractString)
+    julia_version_key = "julia_version"
+    manifest_dict = TOML.parsefile(manifest_filename)
+    old_julia_version = get(manifest_dict, julia_version_key, nothing)
+    if old_julia_version !== nothing
+        m = match(
+            r"^([0-9]*?)\.([0-9]*?)\.([0-9]*?)\-DEV\.([0-9]*?)$",
+            old_julia_version,
+        )
+        if m !== nothing
+            major = m[1]
+            minor = m[2]
+            patch = m[3]
+            new_julia_version = "$(major).$(minor).$(patch)-DEV"
+            manifest_dict[julia_version_key] = new_julia_version
+            @info "Fixing manifest file at $(manifest_filename)" old_julia_version new_julia_version
+            Pkg.Types.write_manifest(manifest_dict, manifest_filename)
+        end
+    end
+    return nothing
+end
+
+function shorten_manifest_version_master(dir::AbstractString)
+    for (root, dirs, files) in walkdir(abspath(dir))
+        for file in files
+            if is_manifest_filename(file)
+                manifest_filename = joinpath(root, file)
+                @info "Checking manifest file at $(manifest_filename)"
+                _shorten_manifest_version_master(manifest_filename)
+            end
+        end
+    end
+    return nothing
+end
+
+shorten_manifest_version_master(@__DIR__)

--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -59,6 +59,10 @@ jobs:
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'
       - run: .ci/instantiate.sh
       - run: julia --color=yes --project=.ci/ -e 'import Pkg; Pkg.update()'
+      - run: |
+          file = abspath(".ci", "shorten_manifest_version_master.jl")
+          ispath(file) && include(file)
+        shell: julia --color=yes {0}
       - run: mv .ci/Manifest.toml .ci/Manifest.${{ steps.manifest_version.outputs.manifest_version }}.toml
       - run: git status
       - uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700 # v2.2.3


### PR DESCRIPTION
Closes #39745