### PR TITLE
correct BlockMatching julia compat

### DIFF
--- a/B/BlockMatching/Compat.toml
+++ b/B/BlockMatching/Compat.toml
@@ -1,3 +1,3 @@
 [0]
 OffsetArrays = "1"
-julia = "1"
+julia = "1.6"


### PR DESCRIPTION
This package uses the fancy CartesianIndices introduced in Julia 1.6 so it should never be run successfully for old Julia versions.