### PR TITLE
Update `Jusdl` URL to post-rename repo

### DIFF
--- a/J/Jusdl/Package.toml
+++ b/J/Jusdl/Package.toml
@@ -1,3 +1,3 @@
 name = "Jusdl"
 uuid = "5fb878b0-68d2-11e9-223c-0f99f93215f8"
-repo = "https://github.com/zekeriyasari/Jusdl.jl.git"
+repo = "https://github.com/zekeriyasari/Causal.jl.git"


### PR DESCRIPTION
The package was renamed (https://github.com/JuliaRegistries/General/pull/19977#issuecomment-678628582) from Jusdl to Causal, and the repo URL for the old package should be changed to that of the new repo, so that we don't need to rely on GitHub redirects in order to retrieve the code for Jusdl.

cc @zekeriyasari