### PR TITLE
Update ProximalOperators URL

### DIFF
--- a/P/ProximalOperators/Package.toml
+++ b/P/ProximalOperators/Package.toml
@@ -1,3 +1,3 @@
 name = "ProximalOperators"
 uuid = "a725b495-10eb-56fe-b38b-717eba820537"
-repo = "https://github.com/kul-forbes/ProximalOperators.jl.git"
+repo = "https://github.com/kul-optec/ProximalOperators.jl.git"


### PR DESCRIPTION
since it was moved to a different GitHub organization. This way we don't need to rely on GitHub redirects. cc @lostella

ref https://github.com/JuliaRegistries/General/pull/40171#issuecomment-873480346