### PR TITLE
Update Slack.jl repo URL

### DIFF
--- a/S/Slack/Package.toml
+++ b/S/Slack/Package.toml
@@ -1,3 +1,3 @@
 name = "Slack"
 uuid = "40bba58d-c7f1-4fe3-926e-2f246c890c3c"
-repo = "https://github.com/logankilpatrick/Slack.jl.git"
+repo = "https://github.com/JuliaLangSlack/Slack.jl.git"


### PR DESCRIPTION
since it was moved to a different GitHub organization. This way we don't need to rely on GitHub redirects. cc @logankilpatrick

ref https://github.com/JuliaRegistries/General/pull/40171#issuecomment-873480346