### PR TITLE
Update URL for ProximalOperators, ProximalAlgorithms, StructuredOptimization, AbstractOperators

### DIFF
--- a/A/AbstractOperators/Package.toml
+++ b/A/AbstractOperators/Package.toml
@@ -1,3 +1,3 @@
 name = "AbstractOperators"
 uuid = "d9c5613a-d543-52d8-9afd-8f241a8c3f1c"
-repo = "https://github.com/kul-forbes/AbstractOperators.jl.git"
+repo = "https://github.com/kul-optec/AbstractOperators.jl.git"

--- a/P/ProximalAlgorithms/Package.toml
+++ b/P/ProximalAlgorithms/Package.toml
@@ -1,3 +1,3 @@
 name = "ProximalAlgorithms"
 uuid = "140ffc9f-1907-541a-a177-7475e0a401e9"
-repo = "https://github.com/kul-forbes/ProximalAlgorithms.jl.git"
+repo = "https://github.com/JuliaFirstOrder/ProximalAlgorithms.jl.git"

--- a/P/ProximalOperators/Package.toml
+++ b/P/ProximalOperators/Package.toml
@@ -1,3 +1,3 @@
 name = "ProximalOperators"
 uuid = "a725b495-10eb-56fe-b38b-717eba820537"
-repo = "https://github.com/kul-optec/ProximalOperators.jl.git"
+repo = "https://github.com/JuliaFirstOrder/ProximalOperators.jl.git"

--- a/S/StructuredOptimization/Package.toml
+++ b/S/StructuredOptimization/Package.toml
@@ -1,3 +1,3 @@
 name = "StructuredOptimization"
 uuid = "46cd3e9d-64ff-517d-a929-236bc1a1fc9d"
-repo = "https://github.com/kul-forbes/StructuredOptimization.jl.git"
+repo = "https://github.com/JuliaFirstOrder/StructuredOptimization.jl.git"


### PR DESCRIPTION
Updating URLs not to rely on GitHub redirect. cc @ericphanson (apologies for the quick follow-up after #40192, I was waiting for a second change of org, which happened today, before opening the PR to the registry)