### PR TITLE
Change repo url for TensorBoardLogger (change owner)

### DIFF
--- a/T/TensorBoardLogger/Package.toml
+++ b/T/TensorBoardLogger/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorBoardLogger"
 uuid = "899adc3e-224a-11e9-021f-63837185c80f"
-repo = "https://github.com/PhilipVinc/TensorBoardLogger.jl.git"
+repo = "https://github.com/JuliaLogging/TensorBoardLogger.jl.git"


### PR DESCRIPTION
The new home of the repository is the `JuliaLogging` organisation.