### PR TITLE
[rename] Move FluxTraining.jl to FluxML organization

### DIFF
--- a/F/FluxTraining/Package.toml
+++ b/F/FluxTraining/Package.toml
@@ -1,3 +1,3 @@
 name = "FluxTraining"
 uuid = "7bf95e4d-ca32-48da-9824-f0dc5310474f"
-repo = "https://github.com/lorenzoh/FluxTraining.jl.git"
+repo = "https://github.com/FluxML/FluxTraining.jl.git"


### PR DESCRIPTION
https://github.com/lorenzoh/FluxTraining.jl has been moved to https://github.com/FluxML/FluxTraining.jl