### PR TITLE
[DEDataArrays] Remove `DiffEqBase` from dependencies

### DIFF
--- a/D/DEDataArrays/Compat.toml
+++ b/D/DEDataArrays/Compat.toml
@@ -1,6 +1,5 @@
 [0]
 ArrayInterface = "3"
-DiffEqBase = "6"
 DocStringExtensions = "0.8"
 RecursiveArrayTools = "2"
 SciMLBase = "1"

--- a/D/DEDataArrays/Deps.toml
+++ b/D/DEDataArrays/Deps.toml
@@ -1,6 +1,5 @@
 [0]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"


### PR DESCRIPTION
This isn't actually used and it causes a circular dependency in
https://github.com/SciML/DiffEqBase.jl/pull/690.  See also
https://github.com/SciML/DEDataArrays.jl/pull/4.  CC: @ChrisRackauckas.