### PR TITLE
update URL for TranscodingStreams

### DIFF
--- a/T/TranscodingStreams/Package.toml
+++ b/T/TranscodingStreams/Package.toml
@@ -1,3 +1,3 @@
 name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-repo = "https://github.com/bicycle1885/TranscodingStreams.jl.git"
+repo = "https://github.com/JuliaIO/TranscodingStreams.jl.git"


### PR DESCRIPTION
This package is moved to the JuliaIO organization, and the old URL has stopped the registering progress

https://github.com/JuliaIO/TranscodingStreams.jl/commit/e4b7e0f1823826ccf58182d54155ef4257b9f6ad