### PR TITLE
yank 1.0.0 of WeakRefStrings (wrong Julia compat)

### DIFF
--- a/W/WeakRefStrings/Versions.toml
+++ b/W/WeakRefStrings/Versions.toml
@@ -33,6 +33,7 @@ git-tree-sha1 = "28807f85197eaad3cbd2330386fac1dcb9e7e11d"
 
 ["1.0.0"]
 git-tree-sha1 = "d91296a3e5267c2eb09f270b8df4039d58710435"
+yanked = true
 
 ["1.1.0"]
 git-tree-sha1 = "9ef95db08bf767499a74586bcbd4b5df30c19b9f"


### PR DESCRIPTION
Closes https://github.com/JuliaData/WeakRefStrings.jl/issues/77

Compat was fixed in 1.0.1: https://github.com/JuliaData/WeakRefStrings.jl/commit/f97d612874c96b0ee2b8948a27ecc82b959531de

cc @quinnj 