### PR TITLE
Change repo url for DataRegistryUtils (change owner)

### DIFF
--- a/D/DataRegistryUtils/Package.toml
+++ b/D/DataRegistryUtils/Package.toml
@@ -1,3 +1,3 @@
 name = "DataRegistryUtils"
 uuid = "1a5903ec-9658-4297-bb6d-314c615f2e02"
-repo = "https://github.com/ScottishCovidResponse/DataRegistryUtils.jl.git"
+repo = "https://github.com/FAIRDataPipeline/DataPipeline.jl.git"


### PR DESCRIPTION
We've moved this package to a new repository in different organisation.