### PR TITLE
add `feed` workflow

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -27,7 +27,12 @@ jobs:
                           "title_link" => pr_url,
                           "text" => pr_url,
                       )])
-        response = sendattachmenttoslack(data, ENV["SLACK_ENDPOINT"])
+
+        endpoint = ENV["SLACK_ENDPOINT"]
+        if !startswith(endpoint, "/")
+            endpoint = string("/", endpoint)
+        end
+        response = sendattachmenttoslack(data, endpoint)
         @info "Slack said: $response"
       env:
         SLACK_ENDPOINT: ${{ secrets.JULIALANGSLACKENDPOINT }}

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [ labeled ]
 jobs:
-  build:
+  update-feed:
     if: ${{ github.event.label.name == 'new package' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -1,0 +1,35 @@
+# This workflow updates feeds when the label `new package` is applied to PRs.
+name: Send to feeds
+on:
+  pull_request:
+    types: [ labeled ]
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'new package' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@latest
+      with:
+        version: 1.6.2
+    - name: Send to Slack
+      shell: julia --color=yes {0}
+      run: |
+        using Pkg
+        Pkg.activate(mktempdir())
+        Pkg.add(name="Slack", version="0.1")
+        using Slack
+        pr_url = string("https://github.com/", ENV["GITHUB_REPOSITORY"], "/pull/", ENV["PR_NUMBER"])
+        @info "" pr_url
+        data = Dict("attachments" =>
+                    [Dict("fallback" => ENV["PR_NAME"],
+                          "color" => "#36a64f",
+                          "title" => ENV["PR_NAME"],
+                          "title_link" => pr_url,
+                          "text" => pr_url,
+                      )])
+        response = sendattachmenttoslack(data, ENV["SLACK_ENDPOINT"])
+        @info "Slack said: $response"
+      env:
+        SLACK_ENDPOINT: ${{ secrets.JULIALANGSLACKENDPOINT }}
+        PR_NAME: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
This adds a workflow that runs whenever a PR is labelled. If the label is "new package", then it uses a Slack endpoint kindly supplied by @logankilpatrick to update the `#new-packages-feed` channel (currently I believe the endpoint is pointed at `#stackoverflow-feed` but it's being updated). I want to also add a Zulip feed as a second job to this workflow (in a future PR).

I think this is useful for two reasons:

1. It provides a simple way for users on Slack/Zulip to keep up with all the awesome new packages being registered
2. It might help more folks get involved with the registry, to help chime in with ideas about names, contribute when they think a name-distance clash is OK or not, and help point new package devs towards [best practices](https://github.com/JuliaRegistries/General#should-i-register-my-package). This is why I want to trigger the update when the PR is created, not when it is merged.