### PR TITLE
don't allow VectorizationBase 0.20 with TriangularSolve 0.1.4

### DIFF
--- a/T/TriangularSolve/Compat.toml
+++ b/T/TriangularSolve/Compat.toml
@@ -21,4 +21,4 @@ Static = "0.2-0.3"
 ["0.1.4-0"]
 LayoutPointers = "0.1.2-0.1"
 Polyester = "0.3-0.4"
-VectorizationBase = "0.20-0.21"
+VectorizationBase = "0.21"


### PR DESCRIPTION
I'm not sure what the best solution is, but the compat was wrong for TriangularSolve 1.4, causing errors.
It dropped support for VectorizationBase 0.20, but this was still in the compat, causing test failures:
https://github.com/SciML/DiffEqSensitivity.jl/pull/486/checks?check_run_id=3461765302#step:6:805
and an issue:
https://github.com/JuliaSIMD/TriangularSolve.jl/issues/12