### PR TITLE
Yank TriangularSolve version 0.1.4

### DIFF
--- a/T/TriangularSolve/Versions.toml
+++ b/T/TriangularSolve/Versions.toml
@@ -12,3 +12,4 @@ git-tree-sha1 = "cb80cf5e0dfb1aedd4c6dbca09b5faaa9a300c62"
 
 ["0.1.4"]
 git-tree-sha1 = "fa55a12683362ea574cd0ca96936ab78cdb462a5"
+yanked = true


### PR DESCRIPTION
TriangularSolve 0.1.4 has an incorrect `[compat]` entry.