### PR TITLE
fix newline edge cases in feed

### DIFF
--- a/.ci/parse_env.jl
+++ b/.ci/parse_env.jl
@@ -25,15 +25,17 @@ function parse_env(env=ENV; verbose=true)
         elseif has_description
             println(io, strip(match_description[1]))
         end
+        
         if has_release
-            if has_description || has_name
-                println(io)
-            end
+            # Leave a gap if we've just printed something
+            has_description && println(io)
             println(io, "Release notes:")
             println(io, strip(match_release[1]))
         end
-        if has_name || has_description || has_release
-            println(io) # separate by an extra line
+
+        # Leave a gap if we've just printed something
+        if has_description || has_release
+            println(io)
         end
         println(io, "Registration: ", pr_url)
         if has_repo


### PR DESCRIPTION
This fixes some tiny edge cases around newlines. One of them it looks like Slack takes care of automatically--  I was accidentally starting the message with a newline in some cases: https://github.com/JuliaRegistries/General/pull/43802/checks?check_run_id=3477473278#step:4:102

But we can fix it anyway. The other one is if there are no release notes, there might be a double gap before the URLs.

edit: actually I guess that one Slack would take care of too, since it would again be a newline at the start of the message... so maybe it doesn't matter really.