### PR TITLE
Move Nonconvex to organization

### DIFF
--- a/N/Nonconvex/Package.toml
+++ b/N/Nonconvex/Package.toml
@@ -1,3 +1,3 @@
 name = "Nonconvex"
 uuid = "01bcebdf-4d21-426d-b5c4-6132c1619978"
-repo = "https://github.com/mohamed82008/Nonconvex.jl.git"
+repo = "https://github.com/JuliaNonconvex/Nonconvex.jl.git"


### PR DESCRIPTION
This package fixes the URL of Nonconvex.jl since I moved it to JuliaNonconvex.