### PR TITLE
AlgebraicNumbers - change package location

### DIFF
--- a/A/AlgebraicNumbers/Package.toml
+++ b/A/AlgebraicNumbers/Package.toml
@@ -1,3 +1,3 @@
 name = "AlgebraicNumbers"
 uuid = "e86d093a-a386-599e-b7c7-df0420c8bcba"
-repo = "https://github.com/fkastner/AlgebraicNumbers.jl.git"
+repo = "https://github.com/anj1/AlgebraicNumbers.jl.git"


### PR DESCRIPTION
Point the registry to the original repository instead of a fork.