### PR TITLE
Update package URL for OutlierDetection.jl

### DIFF
--- a/O/OutlierDetection/Package.toml
+++ b/O/OutlierDetection/Package.toml
@@ -1,3 +1,3 @@
 name = "OutlierDetection"
 uuid = "262411bb-c475-4342-ba9e-03b8c0183ca6"
-repo = "https://github.com/davnn/OutlierDetection.jl.git"
+repo = "https://github.com/OutlierDetectionJL/OutlierDetection.jl.git"

--- a/O/OutlierDetectionData/Package.toml
+++ b/O/OutlierDetectionData/Package.toml
@@ -1,3 +1,3 @@
 name = "OutlierDetectionData"
 uuid = "128abb87-8f03-48fe-b7ad-0e2a52164fda"
-repo = "https://github.com/davnn/OutlierDetectionData.jl.git"
+repo = "https://github.com/OutlierDetectionJL/OutlierDetectionData.jl.git"


### PR DESCRIPTION
The package now belongs to an org instead of an individual contributor.