### PR TITLE
Update URL for OSQP package

### DIFF
--- a/O/OSQP/Package.toml
+++ b/O/OSQP/Package.toml
@@ -1,3 +1,3 @@
 name = "OSQP"
 uuid = "ab2f91bb-94b4-55e3-9ba0-7f65df51de79"
-repo = "https://github.com/oxfordcontrol/OSQP.jl.git"
+repo = "https://github.com/osqp/OSQP.jl.git"


### PR DESCRIPTION
The OSQP project moved from the `oxfordcontrol` organization to the `osqp` GitHub organization.