### PR TITLE
Add a stream to Zulip bot that tracks breaking changes to packages

### DIFF
--- a/.github/workflows/breaking_change_feed.yml
+++ b/.github/workflows/breaking_change_feed.yml
@@ -1,4 +1,4 @@
-# This workflow updates feeds when the label `new package` is applied to PRs.
+# This workflow updates feeds when the label `BREAKING` is applied to PRs.
 name: Send breaking to Zulip
 on:
   pull_request:

--- a/.github/workflows/breaking_change_feed.yml
+++ b/.github/workflows/breaking_change_feed.yml
@@ -38,3 +38,4 @@ jobs:
         type: 'stream'
         topic: 'Package breaking updates'
         content: ${{ steps.zulip.outputs.content }}
+        

--- a/.github/workflows/breaking_change_feed.yml
+++ b/.github/workflows/breaking_change_feed.yml
@@ -1,0 +1,40 @@
+# This workflow updates feeds when the label `new package` is applied to PRs.
+name: Send breaking to Zulip
+on:
+  pull_request:
+    types: [ labeled ]
+jobs:
+  update-zulip-breaking:
+    if: ${{ (github.event.label.name == 'BREAKING' || github.event.label.name == 'zulip test') && github.repository == github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@latest
+      with:
+        version: 1.6.2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+    - name: Collect Zulip info
+      id: zulip
+      shell: julia --color=yes {0}
+      run: |
+        include(joinpath(ENV["GITHUB_WORKSPACE"], ".ci", "parse_env.jl"))
+        text, pr_url = parse_env(ENV)
+        using Pkg
+        Pkg.activate(mktempdir())
+        Pkg.add(name="GitHubActions", version="0.1")
+        using GitHubActions
+        content = string("**", ENV["PR_NAME"], "**\n\n", text)
+        set_output("content", content)
+      env:
+        PR_NAME: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.number }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+    - name: Update Zulip feed
+      uses: zulip/github-actions-zulip/send-message@ba07b1eb3ba0d48430d111d1eb9bd0d25936a0f7
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'general-registry-announcer-bot@julialang.zulipchat.com'
+        organization-url: 'https://julialang.zulipchat.com'
+        to: 'breaking-changes-feed'
+        type: 'stream'
+        topic: 'Package breaking updates'
+        content: ${{ steps.zulip.outputs.content }}

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -82,38 +82,3 @@ jobs:
         type: 'stream'
         topic: 'New package registrations'
         content: ${{ steps.zulip.outputs.content }}
-
-  update-zulip-breaking:
-    if: ${{ (github.event.label.name == 'BREAKING' || github.event.label.name == 'zulip test') && github.repository == github.event.pull_request.head.repo.full_name }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: julia-actions/setup-julia@latest
-      with:
-        version: 1.6.2
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-    - name: Collect Zulip info
-      id: zulip
-      shell: julia --color=yes {0}
-      run: |
-        include(joinpath(ENV["GITHUB_WORKSPACE"], ".ci", "parse_env.jl"))
-        text, pr_url = parse_env(ENV)
-        using Pkg
-        Pkg.activate(mktempdir())
-        Pkg.add(name="GitHubActions", version="0.1")
-        using GitHubActions
-        content = string("**", ENV["PR_NAME"], "**\n\n", text)
-        set_output("content", content)
-      env:
-        PR_NAME: ${{ github.event.pull_request.title }}
-        PR_NUMBER: ${{ github.event.number }}
-        PR_BODY: ${{ github.event.pull_request.body }}
-    - name: Update Zulip feed
-      uses: zulip/github-actions-zulip/send-message@ba07b1eb3ba0d48430d111d1eb9bd0d25936a0f7
-      with:
-        api-key: ${{ secrets.ZULIP_API_KEY }}
-        email: 'general-registry-announcer-bot@julialang.zulipchat.com'
-        organization-url: 'https://julialang.zulipchat.com'
-        to: 'breaking-changes-feed'
-        type: 'stream'
-        topic: 'Package breaking updates'
-        content: ${{ steps.zulip.outputs.content }}

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -82,3 +82,38 @@ jobs:
         type: 'stream'
         topic: 'New package registrations'
         content: ${{ steps.zulip.outputs.content }}
+
+  update-zulip-breaking:
+    if: ${{ (github.event.label.name == 'BREAKING' || github.event.label.name == 'zulip test') && github.repository == github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@latest
+      with:
+        version: 1.6.2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+    - name: Collect Zulip info
+      id: zulip
+      shell: julia --color=yes {0}
+      run: |
+        include(joinpath(ENV["GITHUB_WORKSPACE"], ".ci", "parse_env.jl"))
+        text, pr_url = parse_env(ENV)
+        using Pkg
+        Pkg.activate(mktempdir())
+        Pkg.add(name="GitHubActions", version="0.1")
+        using GitHubActions
+        content = string("**", ENV["PR_NAME"], "**\n\n", text)
+        set_output("content", content)
+      env:
+        PR_NAME: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.number }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+    - name: Update Zulip feed
+      uses: zulip/github-actions-zulip/send-message@ba07b1eb3ba0d48430d111d1eb9bd0d25936a0f7
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'general-registry-announcer-bot@julialang.zulipchat.com'
+        organization-url: 'https://julialang.zulipchat.com'
+        to: 'breaking-changes-feed'
+        type: 'stream'
+        topic: 'Package breaking updates'
+        content: ${{ steps.zulip.outputs.content }}


### PR DESCRIPTION
I'm not sure how to check that this works, nor am I a GH actions expert (happy to learn ofc).

@DilumAluthge @ericphanson 

E: Also not sure if something has to be done on the Zulip end (create stream?).

Testing data:

- Registering package: TestPackage
- Repository: https://github.com/ericphanson/DoesNotExist.jl
- Version: v0.1.0
- Description: This is a test description.
- Commit: 976c26fc6165d5501fb765048fd18d2e30181a94
- Git reference: v0.1.0
- Release notes:
<!-- BEGIN RELEASE NOTES -->
> This is my awesome package!
> My release notes have multiple lines.
<!-- END RELEASE NOTES -->