### PR TITLE
Change SyncBarriers.jl repository URL

### DIFF
--- a/S/SyncBarriers/Package.toml
+++ b/S/SyncBarriers/Package.toml
@@ -1,3 +1,3 @@
 name = "SyncBarriers"
 uuid = "3986aa12-c984-439b-887a-f8545bea0e93"
-repo = "https://github.com/tkf/SyncBarriers.jl.git"
+repo = "https://github.com/JuliaConcurrent/SyncBarriers.jl.git"


### PR DESCRIPTION
SyncBarriers.jl was moved to https://github.com/JuliaConcurrent/SyncBarriers.jl

JuliaRegistrator was asking to create a PR https://github.com/JuliaConcurrent/SyncBarriers.jl/commit/051191ffa1d3c93efa4570567a1e223868d055b0#commitcomment-57271003