### PR TITLE
Org rename for JuliaQuantumControl

### DIFF
--- a/K/Krotov/Package.toml
+++ b/K/Krotov/Package.toml
@@ -1,3 +1,3 @@
 name = "Krotov"
 uuid = "b05dcdc7-62f6-4360-bf2c-0898bba419de"
-repo = "https://github.com/QuantumControl-jl/Krotov.jl.git"
+repo = "https://github.com/JuliaQuantumControl/Krotov.jl.git"

--- a/Q/QuantumControl/Package.toml
+++ b/Q/QuantumControl/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumControl"
 uuid = "8a270532-f23f-47a8-83a9-b33d10cad486"
-repo = "https://github.com/QuantumControl-jl/QuantumControl.jl.git"
+repo = "https://github.com/JuliaQuantumControl/QuantumControl.jl.git"

--- a/Q/QuantumControlBase/Package.toml
+++ b/Q/QuantumControlBase/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumControlBase"
 uuid = "f10a33bc-5a64-497c-be7b-6f86b4f0c2aa"
-repo = "https://github.com/QuantumControl-jl/QuantumControlBase.jl.git"
+repo = "https://github.com/JuliaQuantumControl/QuantumControlBase.jl.git"

--- a/Q/QuantumPropagators/Package.toml
+++ b/Q/QuantumPropagators/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumPropagators"
 uuid = "7bf12567-5742-4b91-a078-644e72a65fc1"
-repo = "https://github.com/QuantumControl-jl/QuantumPropagators.jl.git"
+repo = "https://github.com/JuliaQuantumControl/QuantumPropagators.jl.git"


### PR DESCRIPTION
The Github Org name for several packages related to quantum optimal
control theory was changed from "QuantumControl-jl" to
"JuliaQuantumControl". The `JuliaRegistrator` insists that I make a
manual pull request:
https://github.com/JuliaQuantumControl/QuantumPropagators.jl/commit/bc66f681156a2282c802464152d63bfa854c0a37#commitcomment-57382818