### PR TITLE
Update URL for MadNLP.jl and several packages

### DIFF
--- a/M/MadNLP/Package.toml
+++ b/M/MadNLP/Package.toml
@@ -1,3 +1,3 @@
 name = "MadNLP"
 uuid = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"

--- a/M/MadNLPGPU/Package.toml
+++ b/M/MadNLPGPU/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPGPU"
 uuid = "d72a61cc-809d-412f-99be-fd81f4b8a598"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPGPU"

--- a/M/MadNLPGraph/Package.toml
+++ b/M/MadNLPGraph/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPGraph"
 uuid = "2f590f30-ea46-438a-a78d-e5bfe3109704"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPGraph"

--- a/M/MadNLPHSL/Package.toml
+++ b/M/MadNLPHSL/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPHSL"
 uuid = "7fb6135f-58fe-4112-84ca-653cf5be0c77"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPHSL"

--- a/M/MadNLPKrylov/Package.toml
+++ b/M/MadNLPKrylov/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPKrylov"
 uuid = "1888cb03-ce40-4a36-8d45-ae8231a0e17c"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPKrylov"

--- a/M/MadNLPMumps/Package.toml
+++ b/M/MadNLPMumps/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPMumps"
 uuid = "3b83494e-c0a4-4895-918b-9157a7a085a1"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPMumps"

--- a/M/MadNLPPardiso/Package.toml
+++ b/M/MadNLPPardiso/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPPardiso"
 uuid = "312ee924-cb12-49df-b284-7304c3902fc0"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPPardiso"

--- a/M/MadNLPTests/Package.toml
+++ b/M/MadNLPTests/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPTests"
 uuid = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
-repo = "https://github.com/sshin23/MadNLP.jl.git"
+repo = "https://github.com/MadNLP/MadNLP.jl.git"
 subdir = "lib/MadNLPTests"


### PR DESCRIPTION
MadNLP.jl has moved to MadNLP organization. Due to this, the urls of several packages have changed:

MadNLP.jl
MadNLPGPU.jl
MadNLPGraph.jl
MadNLPHSL.jl
MadNLPKrylov.jl
MadNLPMumps.jl
MadNLPPardiso.jl
MadNLPTests.jl

This PR updates the URL of those packages