### PR TITLE
Move InverseFunctions to JuliaMath org

### DIFF
--- a/I/InverseFunctions/Package.toml
+++ b/I/InverseFunctions/Package.toml
@@ -1,3 +1,3 @@
 name = "InverseFunctions"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-repo = "https://github.com/oschulz/InverseFunctions.jl.git"
+repo = "https://github.com/JuliaMath/InverseFunctions.jl.git"


### PR DESCRIPTION
The package was moved to JuliaMath (https://github.com/JuliaMath/InverseFunctions.jl).