### PR TITLE
Update URL of Metatheory.jl repo (ownership transfer)

### DIFF
--- a/M/Metatheory/Package.toml
+++ b/M/Metatheory/Package.toml
@@ -1,3 +1,3 @@
 name = "Metatheory"
 uuid = "e9d8d322-4543-424a-9be4-0cc815abe26c"
-repo = "https://github.com/0x0f0f0f/Metatheory.jl.git"
+repo = "https://github.com/JuliaSymbolics/Metatheory.jl.git"


### PR DESCRIPTION
Metatheory.jl has been transfered to the JuliaSymbolics org