### PR TITLE
Graphs.jl: change repo location

### DIFF
--- a/G/Graphs/Package.toml
+++ b/G/Graphs/Package.toml
@@ -1,3 +1,3 @@
 name = "Graphs"
 uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-repo = "https://github.com/JuliaAttic/Graphs.jl.git"
+repo = "https://github.com/JuliaGraphs/Graphs.jl.git"


### PR DESCRIPTION
This is part of the process of forking LightGraphs back to the existing but abandoned Graphs package. Please hold off on merging this until I manually merge it when the upstream repo is available.