### PR TITLE
Change the URL for SimpleWeightedGraphs.jl from "https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl.git" to "https://github.com/sbromberger/SimpleWeightedGraphs.jl.git

### DIFF
--- a/S/SimpleWeightedGraphs/Package.toml
+++ b/S/SimpleWeightedGraphs/Package.toml
@@ -1,3 +1,3 @@
 name = "SimpleWeightedGraphs"
 uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
-repo = "https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl.git"
+repo = "https://github.com/sbromberger/SimpleWeightedGraphs.jl.git"


### PR DESCRIPTION
SimpleWeightedGraphs.jl was moved from https://github.com/JuliaGraphs to https://github.com/sbromberger.

@DilumAluthge 