### PR TITLE
Run CI on the 1.7 release candidate (but do not make it a required status check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
+          # - '1.6' # TODO: uncomment this line once Julia 1.7.0 has been released
           - '1'
+          - '~1.7.0-0' # TODO: delete this line once Julia 1.7.0 has been released
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -22,7 +22,9 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
+          # - '1.6' # TODO: uncomment this line once Julia 1.7.0 has been released
           - '1'
+          - '~1.7.0-0' # TODO: delete this line once Julia 1.7.0 has been released
           - 'nightly'
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -65,7 +67,7 @@ jobs:
               if ispath(file)
                   include(file)
                   shorten_manifest_version_master(abspath(".ci"))
-              end              
+              end
           end
         shell: julia --color=yes {0}
       - run: mv .ci/Manifest.toml .ci/Manifest.${{ steps.manifest_version.outputs.manifest_version }}.toml


### PR DESCRIPTION
This PR runs CI on the 1.7 release candidate.

However, we do not make it a required status check. Therefore, pull requests can still be merged even if CI is failing on 1.7.