### PR TITLE
Joseki was moved to a github org, updating remote

### DIFF
--- a/J/Joseki/Package.toml
+++ b/J/Joseki/Package.toml
@@ -1,3 +1,3 @@
 name = "Joseki"
 uuid = "b588beb9-536a-5a7d-a241-c127386fde06"
-repo = "https://github.com/amellnik/Joseki.jl.git"
+repo = "https://github.com/Joseki-jl/Joseki.jl.git"


### PR DESCRIPTION
I ran into this while trying to register a new release [here](https://github.com/Joseki-jl/Joseki.jl/commit/84ca857088d02e532b3e58912f7a8c15df00b9bf).  Looks like everything was working fine thanks to github redirects but it wouldn't let me automatically register a new release via the bot.  