### PR TITLE
Revert "New package: ConstantExtension v0.1.0"

### DIFF
--- a/C/ConstantExtension/Compat.toml
+++ b/C/ConstantExtension/Compat.toml
@@ -1,4 +1,0 @@
-[0]
-BenchmarkTools = "1.2.0-1"
-Revise = "3.1.20-3"
-julia = "1.6.0-1"

--- a/C/ConstantExtension/Deps.toml
+++ b/C/ConstantExtension/Deps.toml
@@ -1,3 +1,0 @@
-[0]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/C/ConstantExtension/Package.toml
+++ b/C/ConstantExtension/Package.toml
@@ -1,3 +1,0 @@
-name = "ConstantExtension"
-uuid = "015e97f4-45c8-4214-a4dc-47accb159b32"
-repo = "https://github.com/KwatMDPhD/ConstantExtension.jl.git"

--- a/C/ConstantExtension/Versions.toml
+++ b/C/ConstantExtension/Versions.toml
@@ -1,2 +1,0 @@
-["0.1.0"]
-git-tree-sha1 = "1b540e8f0ad3c6ef029255cfce50a2ba0a44312c"

--- a/Registry.toml
+++ b/Registry.toml
@@ -58,7 +58,6 @@ some amount of consideration when choosing package names.
 0144022d-7626-48b7-867b-06d945449d75 = { name = "REoptLite", path = "R/REoptLite" }
 01453d9d-ee7c-5054-8395-0335cb756afa = { name = "DiffEqDiffTools", path = "D/DiffEqDiffTools" }
 014a38d5-7acb-4e20-b6c0-4fe5c2344fd1 = { name = "QuadraticToBinary", path = "Q/QuadraticToBinary" }
-015e97f4-45c8-4214-a4dc-47accb159b32 = { name = "ConstantExtension", path = "C/ConstantExtension" }
 01638602-6071-5c9b-be9d-28079212bf65 = { name = "DevIL", path = "D/DevIL" }
 0164281e-5792-487a-ab63-8965341cf816 = { name = "SharedMATLABEngine", path = "S/SharedMATLABEngine" }
 01680d73-4ee2-5a08-a1aa-533608c188bb = { name = "GenericSVD", path = "G/GenericSVD" }


### PR DESCRIPTION
Reverts JuliaRegistries/General#48327

I think this was a mistake to get registered.

The full content of the package is:

```
const CARD = collect("A23456789XJQK")
const GOLDEN_RATIO = 1.618
```

1.618 is not the even the golden ratio and Julia itself has it:

```
julia> MathConstants.golden
φ = 1.6180339887498...
```

cc @StefanKarpinski @DilumAluthge 

