### PR TITLE
Revert "New package: VectorExtension v0.1.0 (#48279)"

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -2464,7 +2464,6 @@ some amount of consideration when choosing package names.
 5d8bd718-bd84-11e8-3b40-ad14f4a32557 = { name = "Groups", path = "G/Groups" }
 5d8de97f-65f8-4dd6-a15b-0f89c36a43ce = { name = "KCenters", path = "K/KCenters" }
 5d9f57b1-d7b5-417c-8d79-eedbcaad0187 = { name = "EchelleCCFs", path = "E/EchelleCCFs" }
-5dc7f3b2-d000-489c-bcc0-daa77f8356fb = { name = "VectorExtension", path = "V/VectorExtension" }
 5dcf52e5-e2fb-48e0-b826-96f46d2e3e73 = { name = "Altro", path = "A/Altro" }
 5dd19120-8766-11e9-1ef9-27094038a7db = { name = "OpenQuantumBase", path = "O/OpenQuantumBase" }
 5dd3f0b1-72a9-48ad-ae6e-79f673da005f = { name = "MatchCore", path = "M/MatchCore" }

--- a/V/VectorExtension/Compat.toml
+++ b/V/VectorExtension/Compat.toml
@@ -1,4 +1,0 @@
-[0]
-BenchmarkTools = "1.2.0-1"
-Revise = "3.1.20-3"
-julia = "1.6.0-1"

--- a/V/VectorExtension/Deps.toml
+++ b/V/VectorExtension/Deps.toml
@@ -1,3 +1,0 @@
-[0]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/V/VectorExtension/Package.toml
+++ b/V/VectorExtension/Package.toml
@@ -1,3 +1,0 @@
-name = "VectorExtension"
-uuid = "5dc7f3b2-d000-489c-bcc0-daa77f8356fb"
-repo = "https://github.com/KwatMDPhD/VectorExtension.jl.git"

--- a/V/VectorExtension/Versions.toml
+++ b/V/VectorExtension/Versions.toml
@@ -1,2 +1,0 @@
-["0.1.0"]
-git-tree-sha1 = "f2a06d89db8b660ba92a8890c0fc9a58172b7e35"


### PR DESCRIPTION
This reverts commit 3876e7b670af56e8904068b74dc3a6f00305cf80.

This has the same issue as all the other *Extension packages recently added (https://github.com/JuliaRegistries/General/pull/48517, https://github.com/JuliaRegistries/General/pull/48516, https://github.com/JuliaRegistries/General/pull/48513).

The function https://github.com/KwatMDPhD/VectorExtension.jl#is_in is also a re-implementation of the Base `in` function

```
julia> in.(["A", "B", "C"], (["A", "B", "D"],))
3-element BitVector:
 1
 1
 0
```