### PR TITLE
Upper bound Memento to 1.2 for CloudWatchLogs

### DIFF
--- a/C/CloudWatchLogs/Compat.toml
+++ b/C/CloudWatchLogs/Compat.toml
@@ -42,7 +42,7 @@ Memento = "0.12"
 MbedTLS = "0.5-0.7"
 
 ["1.2-1"]
-Memento = ["0.13", "1"]
+Memento = ["0.13", "1-1.2"]
 
 ["1.2.1-1"]
 MbedTLS = ["0.5-0.7", "1"]
@@ -50,6 +50,6 @@ MbedTLS = ["0.5-0.7", "1"]
 [2]
 AWS = "1"
 MbedTLS = "1"
-Memento = "1"
+Memento = "1-1.2"
 TimeZones = "1"
 julia = "1.3.0-1"


### PR DESCRIPTION
I'm not sure if I'm doing this right, but my understanding is that retroactively upperbound dependencies for a package requires manually editing the Compat.toml?