### PR TITLE
Revert not setting Project.toml as read-only on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       - run: mv .ci/Manifest.${{ steps.manifest_version.outputs.manifest_version }}.toml .ci/Manifest.toml
       - run: rm -rf .ci/Manifest.*.toml
       - run: chmod 400 .ci/Project.toml
-        if: ${{ matrix.version != 'nightly' }}
       - run: chmod 400 .ci/Manifest.toml
         if: ${{ matrix.version != 'nightly' }}
       - name: Cache artifacts


### PR DESCRIPTION
@DilumAluthge this should be fixed now as https://github.com/JuliaLang/Pkg.jl/pull/2826 has hit the nightlies