### PR TITLE
Transfer MCMCDiagnosticTools to TuringLang

### DIFF
--- a/M/MCMCDiagnosticTools/Package.toml
+++ b/M/MCMCDiagnosticTools/Package.toml
@@ -1,3 +1,3 @@
 name = "MCMCDiagnosticTools"
 uuid = "be115224-59cd-429b-ad48-344e309966f0"
-repo = "https://github.com/devmotion/MCMCDiagnosticTools.jl.git"
+repo = "https://github.com/TuringLang/MCMCDiagnosticTools.jl.git"


### PR DESCRIPTION
The package was transferred from my user account to TuringLang: https://github.com/TuringLang/MCMCDiagnosticTools.jl