### PR TITLE
Make NDTensors a subdir package of ITensors repository

### DIFF
--- a/N/NDTensors/Package.toml
+++ b/N/NDTensors/Package.toml
@@ -1,3 +1,4 @@
 name = "NDTensors"
 uuid = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
-repo = "https://github.com/ITensor/NDTensors.jl.git"
+repo = "https://github.com/ITensor/ITensors.jl.git"
+subdir = "NDTensors"


### PR DESCRIPTION
Hopefully this is correct. I bumped the version of NDTensors from the last time it was registered, should I include that change in this PR as well?