### PR TITLE
[KaHyPar_jll] Fix compat of `boost_jll`

### DIFF
--- a/K/KaHyPar_jll/Compat.toml
+++ b/K/KaHyPar_jll/Compat.toml
@@ -3,3 +3,4 @@ julia = "1"
 
 ["1.2-1"]
 JLLWrappers = "1.2.0-1"
+boost_jll = "1.71.0"


### PR DESCRIPTION
Boost breaks ABI in every single version, so we must always specify the compat
bounds with it.  See https://github.com/kahypar/KaHyPar.jl/issues/19.