### PR TITLE
Yank ECOS@0.12.4

### DIFF
--- a/E/ECOS/Versions.toml
+++ b/E/ECOS/Versions.toml
@@ -36,6 +36,7 @@ git-tree-sha1 = "a7117f6f44a846b4cb4ae1b06d03807312e464b2"
 
 ["0.12.4"]
 git-tree-sha1 = "026ea1e29a4ba7237e09b5aa463021311e4dab02"
+yanked = true
 
 ["0.13.0"]
 git-tree-sha1 = "afa02821ff4d1cc33a20efb11e4a29b3eff8900d"


### PR DESCRIPTION
ECOS 0.12.4 was tagged as a patch release but it contained breaking changes. A new 0.13 has been released which should mean that this version isn't installed, but yanking for posterity.

x-ref: https://github.com/jump-dev/ECOS.jl/issues/123