### PR TITLE
Sync Mosek releases v0.9.12 and v0.9.13

### DIFF
--- a/M/Mosek/Versions.toml
+++ b/M/Mosek/Versions.toml
@@ -31,6 +31,12 @@ git-tree-sha1 = "eae97e18c971edfcb68af3e0c8c370af9ecc426f"
 ["0.9.11"]
 git-tree-sha1 = "032bd53d5d2c1a28ca4b684d0bcb43bf50ed1d5f"
 
+["0.9.12"]
+git-tree-sha1 = "e88c1d374ae25842d26debb991cfda7eec9c76be"
+
+["0.9.13"]
+git-tree-sha1 = "5f6244ebded09e55cda59969d07f4f74f8fc9eb1"
+
 ["1.0.2"]
 git-tree-sha1 = "e415ff8e3203e97ea0aeea8b64ec7373d3023fe8"
 


### PR DESCRIPTION
These two Github releases were not synced with this registry. They cannot be done with JuliaRegistrator because the package had no Project.toml at the time of the releases.
https://github.com/MOSEK/Mosek.jl/tree/v0.9.12
https://github.com/MOSEK/Mosek.jl/tree/v0.9.13