### PR TITLE
Update Package.toml for github ownership transfer

### DIFF
--- a/C/CompositeGrids/Package.toml
+++ b/C/CompositeGrids/Package.toml
@@ -1,3 +1,3 @@
 name = "CompositeGrids"
 uuid = "b5136c89-beeb-4521-9139-60d2cac8be56"
-repo = "https://github.com/quantumstatistics/CompositeGrids.jl.git"
+repo = "https://github.com/numericalEFT/CompositeGrids.jl.git"


### PR DESCRIPTION
The repo url is changed to the latest one.