### PR TITLE
change URL for SubpixelRegistration.jl

### DIFF
--- a/S/SubpixelRegistration/Package.toml
+++ b/S/SubpixelRegistration/Package.toml
@@ -1,3 +1,3 @@
 name = "SubpixelRegistration"
 uuid = "97a7e826-69e2-510e-8af8-254736c4b599"
-repo = "https://github.com/romainFr/SubpixelRegistration.jl.git"
+repo = "https://github.com/JuliaHCI/SubpixelRegistration.jl.git"


### PR DESCRIPTION
This package has recently switched maintainers and requires a URL switch.