### PR TITLE
move HypertextLiteral to JuliaPluto organization

### DIFF
--- a/H/HypertextLiteral/Package.toml
+++ b/H/HypertextLiteral/Package.toml
@@ -1,3 +1,3 @@
 name = "HypertextLiteral"
 uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
-repo = "https://github.com/MechanicalRabbit/HypertextLiteral.jl.git"
+repo = "https://github.com/JuliaPluto/HypertextLiteral.jl.git"


### PR DESCRIPTION
https://github.com/MechanicalRabbit/HypertextLiteral.jl => https://github.com/JuliaPluto/HypertextLiteral.jl 

So that HypertextLiteral can be maintained by a broader community of Julia contributors, it is being moved to the JuliaPluto organization.  Thank you.