### PR TITLE
Use CLI git in CI jobs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,6 +9,8 @@ on:
     # We will choose to run the fallback job every 4 hours.
     - cron:  '0 */4 * * *'
   workflow_dispatch:
+env:
+    JULIA_PKG_USE_CLI_GIT: true
 jobs:
   AutoMerge:
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
   workflow_dispatch:
+env:
+    JULIA_PKG_USE_CLI_GIT: true
 jobs:
   CI:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This should at least speed up jobs running with Julia v1.7+ when libgit2 is the culprit, although we see that even the initial checkout step is occasionally horribly slow, which also uses CLI git.