### PR TITLE
[CI] Cache also packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
         env:
           cache-name: cache-artifacts
         with:
-          path: ~/.julia/artifacts
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/packages
           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/.ci/Manifest.toml') }}
           restore-keys: |
             ${{ runner.os }}-test-${{ env.cache-name }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - run: chmod 400 .ci/Project.toml
       - run: chmod 400 .ci/Manifest.toml
         if: ${{ matrix.version != 'nightly' }}
-      - name: Cache artifacts
+      - name: Cache artifacts and packages
         uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8 # v2.1.5
         env:
           cache-name: cache-artifacts


### PR DESCRIPTION
I'm seeing that also the instantiation step
https://github.com/JuliaRegistries/General/blob/2138ce38570edbae3825452b8450449982aaaebb/.github/workflows/ci.yml#L59
often gets stuck when there are connections problems.  See for example https://github.com/JuliaRegistries/General/runs/4641542758?check_suite_focus=true
```
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Installed Artifacts ────────────────── v1.3.0
  Installed LibCURL_jll ──────────────── v7.70.0+2
  Installed MozillaCACerts_jll ───────── v2021.1.19+0
  Installed LazyArtifacts ────────────── v1.3.0
  Installed Downloads ────────────────── v1.6.0
  Installed NetworkOptions ───────────── v1.2.0
  Installed Mocking ──────────────────── v0.7.3
  Installed RegistryCI ───────────────── v7.1.7
  Installed Tar ──────────────────────── v1.9.2
  Installed IniFile ──────────────────── v0.5.0
  Installed StatsAPI ─────────────────── v1.1.0
  Installed MbedTLS ──────────────────── v1.0.3
  Installed libsodium_jll ────────────── v1.0.19+0
  Installed VisualStringDistances ────── v0.1.1
  Installed nghttp2_jll ──────────────── v1.40.0+2
  Installed JLLWrappers ──────────────── v1.3.0
  Installed ExprTools ────────────────── v0.1.6
  Installed URIs ─────────────────────── v1.3.0
  Installed HTTP ─────────────────────── v0.9.17
  Installed StaticArrays ─────────────── v1.2.13
  Installed licensecheck_jll ─────────── v0.3.1+1
  Installed Parsers ──────────────────── v2.1.3
  Installed Preferences ──────────────── v1.2.2
  Installed Zlib_jll ─────────────────── v1.2.11+18
  Installed InlineStrings ────────────── v1.1.1
  Installed LibSSH2_jll ──────────────── v1.9.0+3
  Installed TimeZones ────────────────── v1.6.2
  Installed Compat ───────────────────── v3.41.0
  Installed GitHub ───────────────────── v5.7.0
  Installed RegistryTools ────────────── v1.7.0
  Installed TOML ─────────────────────── v1.0.3
  Installed SodiumSeal ───────────────── v0.1.1
  Installed Distances ────────────────── v0.10.7
  Installed JSON ─────────────────────── v0.21.2
  Installed LicenseCheck ─────────────── v0.2.2
  Installed RecipesBase ──────────────── v1.2.1
  Installed MbedTLS_jll ──────────────── v2.16.8+1
    Cloning [88034a9c-02f8-509d-84a9-84ec65e18404] StringDistances from matthieugomez/StringDistances.jl.git
25l25h25l    Fetching: [>                                        ]  0.0 %
  Installed StringDistances ──────────── v0.10.0
    Cloning [15f4f7f2-30c1-5605-9d31-71845cf9641f] AutoHashEquals from andrewcooke/AutoHashEquals.jl.git
Error: The operation was canceled.
```
The fact that this is trying to clone the Git repository instead of downloading the snapshot is another indication we're struggling with downloads from GitHub (and git clones are also _slow_).  caching packages in addition to artifacts should help with this step.