### PR TITLE
New version: libjulia_jll v1.7.0+8

### DIFF
--- a/L/libjulia_jll/Versions.toml
+++ b/L/libjulia_jll/Versions.toml
@@ -54,3 +54,6 @@ git-tree-sha1 = "a40c3fb65153b4db89ef8765345466288297cd4e"
 
 ["1.7.0+7"]
 git-tree-sha1 = "9fea66443b5960b97c229e5a0e1a26899b97ab53"
+
+["1.7.0+8"]
+git-tree-sha1 = "525ccaa295967df2b8ff724664e6b9f2c31eb138"


### PR DESCRIPTION
UUID: 5ad3ddd2-0711-543a-b040-befd59781bbf
Repo: https://github.com/JuliaBinaryWrappers/libjulia_jll.jl.git
Tree: 525ccaa295967df2b8ff724664e6b9f2c31eb138

Registrator tree SHA: 8e1a5ac2695627143951512d700c7e3c445102ec