### PR TITLE
Javis.jl Changed from personal repo to organization

### DIFF
--- a/J/Javis/Package.toml
+++ b/J/Javis/Package.toml
@@ -1,3 +1,3 @@
 name = "Javis"
 uuid = "78b212ba-a7f9-42d4-b726-60726080707e"
-repo = "https://github.com/Wikunia/Javis.jl.git"
+repo = "https://github.com/JuliaAnimators/Javis.jl.git"


### PR DESCRIPTION
Would like to change the repository url for Javis.jl due to the transfer to the JuliaAnimators organization.