### PR TITLE
Mark MeshCat v0.14.2 as requiring Rotations v1.1

### DIFF
--- a/M/MeshCat/Compat.toml
+++ b/M/MeshCat/Compat.toml
@@ -27,10 +27,12 @@ GeometryTypes = "0.6-0.8"
 Cassette = "0.2.5-0.3"
 Colors = "0.9-0.12"
 CoordinateTransformations = "0.5-0.6"
-Rotations = "1"
 
 ["0.11.1-0.13"]
 Blink = "0.12"
+
+["0.11-0.14.1"]
+Rotations = "1"
 
 ["0.12"]
 GeometryBasics = "0.2"
@@ -55,6 +57,7 @@ GeometryBasics = "0.3"
 
 ["0.14.2-0"]
 GeometryBasics = "0.3-0.4"
+Rotations = "1.1"
 
 ["0.2-0.3"]
 BinDeps = "0.8.7 - 0.8"


### PR DESCRIPTION
This updates the registry compat entries to match the changes made in https://github.com/rdeits/MeshCat.jl/pull/213

I've made this change by hand, but I'm not sure if there's some automated tool I should be using to canonicalize the order of the entries or anything. Please let me know if this change looks ok. 