### PR TITLE
add upper bound for OptionalArgChecks.jl

### DIFF
--- a/O/OptionalArgChecks/Compat.toml
+++ b/O/OptionalArgChecks/Compat.toml
@@ -1,6 +1,6 @@
 [0]
 MacroTools = "0.5"
-julia = "1"
+julia = "1-1.4"
 
 ["0-0.3.0"]
 IRTools = "0.3"


### PR DESCRIPTION
This package was always experimental and is broken since 1.5 because it
does some invalid things with IR. Seems better to declare compat bounds
to prevent users from shooting themselves in the foot.

Ref JuliaCI/PkgEval.jl#100
cc @maleadt
