### PR TITLE
[libjulia_jll] Yank all old builds of Julia v1.7 and fix deps

### DIFF
--- a/L/libjulia_jll/Compat.toml
+++ b/L/libjulia_jll/Compat.toml
@@ -25,7 +25,7 @@ MPFR_jll = "4.1.0"
 OpenBLAS_jll = "0.3.9"
 libLLVM_jll = "9.0.1"
 
-["1.5.3-1"]
+["1.5.3-1.6"]
 LibOSXUnwind_jll = "0.0.6"
 
 ["1.5.4-1"]
@@ -42,4 +42,3 @@ libLLVM_jll = "11"
 
 ["1.7-1"]
 julia = "1.6.0-1"
-libLLVM_jll = "12.0.1-12"

--- a/L/libjulia_jll/Compat.toml
+++ b/L/libjulia_jll/Compat.toml
@@ -42,4 +42,4 @@ libLLVM_jll = "11"
 
 ["1.7-1"]
 julia = "1.6.0-1"
-libLLVM_jll = "11.0.1-11"
+libLLVM_jll = "12.0.1-12"

--- a/L/libjulia_jll/Deps.toml
+++ b/L/libjulia_jll/Deps.toml
@@ -25,12 +25,14 @@ dSFMT_jll = "05ff407c-b0c1-5878-9df8-858cc2e60c36"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 utf8proc_jll = "00992c89-a35c-5347-9984-e6609dacc59a"
 
-["1.4-1"]
+["1.4-1.6"]
 libLLVM_jll = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
 
 ["1.5.3-1"]
-LibOSXUnwind_jll = "a83860b7-747b-57cf-bf1f-3e79990d037f"
 LibUnwind_jll = "745a5e78-f969-53e9-954f-d19f2f74f4e3"
+
+["1.5.3-1.6"]
+LibOSXUnwind_jll = "a83860b7-747b-57cf-bf1f-3e79990d037f"
 
 ["1.6"]
 GMP_jll = "781609d7-10c4-51f6-84f2-b8444358ff6d"

--- a/L/libjulia_jll/Versions.toml
+++ b/L/libjulia_jll/Versions.toml
@@ -33,27 +33,35 @@ git-tree-sha1 = "15d2b430b04bea9fe77cbcdb4d8963108c47c6e9"
 
 ["1.7.0+0"]
 git-tree-sha1 = "0848c3821439e4e4494bde7015c109edc752bc16"
+yanked = true
 
 ["1.7.0+1"]
 git-tree-sha1 = "56805d687d965d672f36bbf36751758a692be741"
+yanked = true
 
 ["1.7.0+2"]
 git-tree-sha1 = "84fd6622a3a4fd262d4e8e317db629fc53e06901"
+yanked = true
 
 ["1.7.0+3"]
 git-tree-sha1 = "0bdb1ae0c3387684680933354fc14fcca82bae4e"
+yanked = true
 
 ["1.7.0+4"]
 git-tree-sha1 = "f170cae5ab7ecab419894623ba10ef19b1367779"
+yanked = true
 
 ["1.7.0+5"]
 git-tree-sha1 = "0d03a43df3c5c38d558de213343d594ce71ff40a"
+yanked = true
 
 ["1.7.0+6"]
 git-tree-sha1 = "a40c3fb65153b4db89ef8765345466288297cd4e"
+yanked = true
 
 ["1.7.0+7"]
 git-tree-sha1 = "9fea66443b5960b97c229e5a0e1a26899b97ab53"
+yanked = true
 
 ["1.7.0+8"]
 git-tree-sha1 = "525ccaa295967df2b8ff724664e6b9f2c31eb138"


### PR DESCRIPTION
At the moment, with Julia v1.7 we get:
```
(jl_h4pidc) pkg> add libjulia_jll
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package libjulia_jll [5ad3ddd2]:
 libjulia_jll [5ad3ddd2] log:
 ├─possible versions are: 1.3.1-1.7.0 or uninstalled
 ├─restricted to versions * by an explicit requirement, leaving only versions 1.3.1-1.7.0
 ├─restricted by compatibility requirements with GMP_jll [781609d7] to versions: [1.3.1, 1.5.1-1.7.0] or uninstalled, leaving only versions: [1.3.1, 1.5.1-1.7.0]
 │ └─GMP_jll [781609d7] log:
 │   └─possible versions are: 6.2.1 or uninstalled
 ├─restricted by compatibility requirements with PCRE2_jll [efcefdf7] to versions: 1.5.4-1.7.0 or uninstalled, leaving only versions: 1.5.4-1.7.0
 │ └─PCRE2_jll [efcefdf7] log:
 │   └─possible versions are: 10.36.0 or uninstalled
 └─restricted by compatibility requirements with libLLVM_jll [8f36deef] to versions: 1.3.1 or uninstalled — no versions left
   └─libLLVM_jll [8f36deef] log:
     └─possible versions are: 12.0.1 or uninstalled
```
The problem is that `libjulia_jll` v1.7 says it's compatible with libLLVM_jll 11:
https://github.com/JuliaRegistries/General/blob/1bef9ca01489022d8065aa3d8fe86bbc835a11bd/L/libjulia_jll/Compat.toml#L45
but this is wrong, because Julia v1.7 eventually had LLVM 12: https://github.com/JuliaRegistries/General/blob/1bef9ca01489022d8065aa3d8fe86bbc835a11bd/L/libLLVM_jll/Compat.toml#L7-L8

I'm not sure what's the best fix: fixing compatibility with `libLLVM_jll` (but older builds `libjulia_jll` will likely not work anymore) or yank old builds of `libjulia_jll` v1.7.0 and just remove dependency on `libLLVM_jll`, since `libjulia_jll` v1.7 doesn't actually depend on `libLLVM_jll`.  CC @fingolfin who I think may have useful ideas