### PR TITLE
Change package URL for NFFT.jl after move to JuliaMath

### DIFF
--- a/A/AbstractNFFTs/Package.toml
+++ b/A/AbstractNFFTs/Package.toml
@@ -1,4 +1,4 @@
 name = "AbstractNFFTs"
 uuid = "7f219486-4aa7-41d6-80a7-e08ef20ceed7"
-repo = "https://github.com/tknopp/NFFT.jl.git"
+repo = "https://github.com/JuliaMath/NFFT.jl.git"
 subdir = "AbstractNFFTs"

--- a/C/CuNFFT/Package.toml
+++ b/C/CuNFFT/Package.toml
@@ -1,4 +1,4 @@
 name = "CuNFFT"
 uuid = "a9291f20-7f4c-4d50-b30d-4e07b13252e1"
-repo = "https://github.com/tknopp/NFFT.jl.git"
+repo = "https://github.com/JuliaMath/NFFT.jl.git"
 subdir = "CuNFFT"

--- a/N/NFFT/Package.toml
+++ b/N/NFFT/Package.toml
@@ -1,3 +1,3 @@
 name = "NFFT"
 uuid = "efe261a4-0d2b-5849-be55-fc731d526b0d"
-repo = "https://github.com/tknopp/NFFT.jl.git"
+repo = "https://github.com/JuliaMath/NFFT.jl.git"


### PR DESCRIPTION
The repository has three packages and therefore the URL needed to be changes in all project files.