### PR TITLE
Fix SPIRV_LLVM_Translator_jll's compat bounds.

### DIFF
--- a/S/SPIRV_LLVM_Translator_jll/Compat.toml
+++ b/S/SPIRV_LLVM_Translator_jll/Compat.toml
@@ -1,17 +1,17 @@
 [8]
-julia = "1.4.0-1"
+julia = "1.4"
 
 [9]
-julia = "1.5.0-1"
+julia = "1.5"
 
 [10-11]
-julia = "1.6.0-1"
+julia = "1.6"
 
 [12]
-julia = "1.7.0-1"
+julia = "1.7"
 
 [13]
-julia = "1.8.0-1"
+julia = "1.8"
 
 [8-13]
 JLLWrappers = "1.2.0-1"


### PR DESCRIPTION
Versions should be locked to a single Julia version.

We won't have to do this anymore once we have https://github.com/JuliaPackaging/Yggdrasil/pull/4291.