### PR TITLE
yank ArchGDAL 0.8.1

### DIFF
--- a/A/ArchGDAL/Versions.toml
+++ b/A/ArchGDAL/Versions.toml
@@ -63,6 +63,7 @@ git-tree-sha1 = "7a965b3c76b33737a7231ed0abaee596b5e4c57f"
 
 ["0.8.1"]
 git-tree-sha1 = "bed15550a6b817dac5940807647cadba35bf46ec"
+yanked = true
 
 ["0.8.2"]
 git-tree-sha1 = "e318528d43e9d8c3adeeca0b00bee1c55211b311"


### PR DESCRIPTION
Yank ArchGDAL 0.8.1, removing version allowing incompatible DiskArrays dependency:

https://github.com/yeesian/ArchGDAL.jl/issues/277