### PR TITLE
Yank latest BLOSC release

### DIFF
--- a/B/Blosc/Versions.toml
+++ b/B/Blosc/Versions.toml
@@ -15,3 +15,4 @@ git-tree-sha1 = "575bdd70552dd9a7eaeba08ef2533226cdc50779"
 
 ["0.7.3"]
 git-tree-sha1 = "310b77648d38c223d947ff3f50f511d08690b8d5"
+yanked = true 


### PR DESCRIPTION
Non-backward compatible API change in exported function 