### PR TITLE
Fix release, version is actually backwards compatible

### DIFF
--- a/B/Blosc/Versions.toml
+++ b/B/Blosc/Versions.toml
@@ -15,4 +15,3 @@ git-tree-sha1 = "575bdd70552dd9a7eaeba08ef2533226cdc50779"
 
 ["0.7.3"]
 git-tree-sha1 = "310b77648d38c223d947ff3f50f511d08690b8d5"
-yanked = true 


### PR DESCRIPTION
@DilumAluthge 

Apologies for the noise, but the release is actually safe. I misread a method causing me to be preemptively concerned. I should've double checked. 