### PR TITLE
Modify update_manifests.yml versions to match ci.yml (add 1.6)

### DIFF
--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -22,9 +22,8 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
-          # - '1.6' # TODO: uncomment this line once Julia 1.7.0 has been released
+          - '1.6'
           - '1'
-          - '~1.7.0-0' # TODO: delete this line once Julia 1.7.0 has been released
           - 'nightly'
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4


### PR DESCRIPTION
Modified the versions in `update_manifests.yml` to include 1.6, because 1.7 has been released.

https://github.com/JuliaRegistries/General/blob/master/.github/workflows/update_manifests.yml#L25