### PR TITLE
Yank Pastebin 0.1.0

### DIFF
--- a/P/Pastebin/Versions.toml
+++ b/P/Pastebin/Versions.toml
@@ -1,5 +1,6 @@
 ["0.1.0"]
 git-tree-sha1 = "bfa35b8413858be9adf39485714641dc8e4b8492"
+yanked = true
 
 ["0.1.1"]
 git-tree-sha1 = "fe76e8764bdd25690676dd8b72fa4b03dd846884"


### PR DESCRIPTION
I made some changes in my git commit history by mistake and ended up losing the commit I registered as version 0.1.0.
So I'm yanking 0.1.0 from the general registry (and releasing v0.1.1 as replacement).