### PR TITLE
[SCS] fix compat with SCS_jll

### DIFF
--- a/S/SCS/Compat.toml
+++ b/S/SCS/Compat.toml
@@ -50,7 +50,7 @@ MathOptInterface = "0.10.5-0.10"
 
 ["0.9-0"]
 MathOptInterface = "0.10.8-0.10"
-SCS_jll = "3"
+SCS_jll = "3.0.0-3.0.1"
 
 ["0.9-1"]
 SCS_GPU_jll = "3.0.0-3.0.1"
@@ -58,9 +58,3 @@ julia = "1.6.0-1"
 
 [1]
 MathOptInterface = "1"
-
-["1.0.0"]
-SCS_jll = "3"
-
-["1.0.1-1"]
-SCS_jll = "3.0.0-3.0.1"

--- a/S/SCS/Compat.toml
+++ b/S/SCS/Compat.toml
@@ -50,10 +50,10 @@ MathOptInterface = "0.10.5-0.10"
 
 ["0.9-0"]
 MathOptInterface = "0.10.8-0.10"
-SCS_jll = "3.0.0-3.0.1"
 
 ["0.9-1"]
 SCS_GPU_jll = "3.0.0-3.0.1"
+SCS_jll = "3.0.0-3.0.1"
 julia = "1.6.0-1"
 
 [1]


### PR DESCRIPTION
SCS_jll broke our C API usage between 3.0.0 and 3.2.0. For now, I just want to pin all usages to `=3.0.0` or `=3.0.1`.