### PR TITLE
Change repo URLs for components of DiffinDiffs

### DIFF
--- a/D/DiffinDiffsBase/Package.toml
+++ b/D/DiffinDiffsBase/Package.toml
@@ -1,3 +1,4 @@
 name = "DiffinDiffsBase"
 uuid = "7fc23ce2-6e83-4e3c-822f-a79085ccb3e8"
-repo = "https://github.com/JuliaDiffinDiffs/DiffinDiffsBase.jl.git"
+repo = "https://github.com/JuliaDiffinDiffs/DiffinDiffs.jl.git"
+subdir = "lib/DiffinDiffsBase"

--- a/I/InteractionWeightedDIDs/Package.toml
+++ b/I/InteractionWeightedDIDs/Package.toml
@@ -1,3 +1,4 @@
 name = "InteractionWeightedDIDs"
 uuid = "4fda0319-85a0-4a01-849e-821b918731ee"
-repo = "https://github.com/JuliaDiffinDiffs/InteractionWeightedDIDs.jl.git"
+repo = "https://github.com/JuliaDiffinDiffs/DiffinDiffs.jl.git"
+subdir = "lib/InteractionWeightedDIDs"


### PR DESCRIPTION
I wish to move two packages to subfolders of another [repo](https://github.com/JuliaDiffinDiffs/DiffinDiffs.jl).

I have made the following check following other developers:
1) Clone the new repo and cd to that.
2) In Julia, I do:

```julia
julia> using TOML

julia> packages = ["DiffinDiffsBase", "InteractionWeightedDIDs"]
2-element Vector{String}:
 "DiffinDiffsBase"
 "InteractionWeightedDIDs"

julia> for pkg in packages
           versions = TOML.parsefile(joinpath(first(DEPOT_PATH), "registries",
                                     "General", pkg[1:1], pkg, "Versions.toml"))

           found = all(sort(collect(keys(versions)))) do version
               tree_sha = versions[version]["git-tree-sha1"]
               try
                   readchomp(`git rev-parse -q --verify "$(tree_sha)^{tree}"`)
                   return true
               catch
                   false
               end
           end
           println(pkg, ": ", found ? "all versions found!" : "ney")
       end
DiffinDiffsBase: all versions found!
InteractionWeightedDIDs: all versions found!
```
