### PR TITLE
Update repository URL of HybridArrays.jl

### DIFF
--- a/H/HybridArrays/Package.toml
+++ b/H/HybridArrays/Package.toml
@@ -1,3 +1,3 @@
 name = "HybridArrays"
 uuid = "1baab800-613f-4b0a-84e4-9cd3431bfbb9"
-repo = "https://github.com/mateuszbaran/HybridArrays.jl.git"
+repo = "https://github.com/JuliaArrays/HybridArrays.jl.git"


### PR DESCRIPTION
Repository of HybridArrays.jl has been moved to JuliaArrays organization.