### PR TITLE
[finufft_jll] Yank `v2.0.4+1`

### DIFF
--- a/F/finufft_jll/Versions.toml
+++ b/F/finufft_jll/Versions.toml
@@ -18,3 +18,4 @@ git-tree-sha1 = "88ccdadf1fbc0f09b1cd9199a80a3fb22060b8a5"
 
 ["2.0.4+1"]
 git-tree-sha1 = "02bcc3d29761a0e10b6d5396a7275a12ad3da95f"
+yanked = true


### PR DESCRIPTION
Selection of the artifact on AVX512 systems doesn't work correctly