### PR TITLE
MIMEs.jl url change

### DIFF
--- a/M/MIMEs/Package.toml
+++ b/M/MIMEs/Package.toml
@@ -1,3 +1,3 @@
 name = "MIMEs"
 uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
-repo = "https://github.com/fonsp/MIMEs.git"
+repo = "https://github.com/fonsp/MIMEs.jl.git"


### PR DESCRIPTION
I renamed the repo from `MIMEs` to `MIMEs.jl` (sorry) JuliaRegistrator told me to make this PR: https://github.com/fonsp/MIMEs.jl/commit/257c6ba68f47be3b541aeed51da6971751927a45#commitcomment-69530940

