### PR TITLE
Revert "New version: OutlierDetection v0.2.6"

### DIFF
--- a/O/OutlierDetection/Compat.toml
+++ b/O/OutlierDetection/Compat.toml
@@ -11,11 +11,11 @@ NearestNeighbors = "0.4"
 ROCAnalysis = "0.3"
 SpecialFunctions = "1.3.0-1"
 
+["0.2-0"]
+OutlierDetectionInterface = "0.1"
+
 ["0.2-0.2.4"]
 MLJBase = "0.18"
-
-["0.2-0.2.5"]
-OutlierDetectionInterface = "0.1"
 
 ["0.2.0"]
 SpecialFunctions = "1.0-1.6"
@@ -28,6 +28,3 @@ SpecialFunctions = "1-2"
 
 ["0.2.5-0"]
 MLJBase = ["0.18", "0.19.6-0.19"]
-
-["0.2.6-0"]
-OutlierDetectionInterface = "0.1.8-0.1"

--- a/O/OutlierDetection/Versions.toml
+++ b/O/OutlierDetection/Versions.toml
@@ -18,6 +18,3 @@ git-tree-sha1 = "820e663e2b8195dbab8feae362a2f2f8656544df"
 
 ["0.2.5"]
 git-tree-sha1 = "86ac5ee14dacd0371dc3904e254e0aaca395324f"
-
-["0.2.6"]
-git-tree-sha1 = "9b965d53f753064d4e6909c48659f7f95d7b0d3d"


### PR DESCRIPTION
Somehow TagBot cannot deal with this release, possibly because the last commit contains `[no ci]`? Reverts JuliaRegistries/General#57299

Would like to register again with an ammended commit message.