### PR TITLE
Update Snappy URL to point to JuliaIO

### DIFF
--- a/S/Snappy/Package.toml
+++ b/S/Snappy/Package.toml
@@ -1,3 +1,3 @@
 name = "Snappy"
 uuid = "59d4ed8c-697a-5b28-a4c7-fe95c22820f9"
-repo = "https://github.com/bicycle1885/Snappy.jl.git"
+repo = "https://github.com/JuliaIO/Snappy.jl.git"


### PR DESCRIPTION
The repo was transferred from Kenta's personal account to the JuliaIO organization.