### PR TITLE
Manually propose ArrowTypes.jl 2.0.0 version bump

### DIFF
--- a/A/ArrowTypes/Versions.toml
+++ b/A/ArrowTypes/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "ac464acb43b227acf91e8f695fbfdbb1a37ce1e4"
 
 ["1.2.1"]
 git-tree-sha1 = "a0633b6d6efabf3f76dacd6eb1b3ec6c42ab0552"
+
+["2.0.0"]
+git-tree-sha1 = "4e7aa2021204bd9456ad3e87372237e84ee2c3c1"


### PR DESCRIPTION
Because the parent Arrow.jl package repo already has a 2.0.0 tag, we're unable to follow the normal process in using JuliaRegistrator to submit package updates for a subdirectory package ArrowTypes; for the git-tree-sha1 here, I checked out the latest `main` branch on the arrow-julia repository and ran `git rev-parse HEAD^{tree}`. Let me know if that's incorrect or what other process I should follow here.