### PR TITLE
New version: Glibc_jll v2.12.2+6

### DIFF
--- a/G/Glibc_jll/Versions.toml
+++ b/G/Glibc_jll/Versions.toml
@@ -1,6 +1,9 @@
 ["2.12.2+0"]
 git-tree-sha1 = "a99220cf40aebe227f13155308357f322732c0ec"
 
+["2.12.2+6"]
+git-tree-sha1 = "ce74e85d6feb1b58cb2515c6ca68ae639eb82078"
+
 ["2.17.0+0"]
 git-tree-sha1 = "68da2106e14ada8499a799f89417f6befd00a596"
 


### PR DESCRIPTION
Autogenerated JLL package registration

* Registering JLL package Glibc_jll.jl
* Repository: https://github.com/JuliaBinaryWrappers/Glibc_jll.jl
* Version: v2.12.2+6
* Commit: a35524d4cc28b31363d4063db188a5cabe8baad0
