### PR TITLE
LinearFractional repo URL change

### DIFF
--- a/L/LinearFractional/Package.toml
+++ b/L/LinearFractional/Package.toml
@@ -1,3 +1,3 @@
 name = "LinearFractional"
 uuid = "31851ddc-f9b7-5097-a470-69ef907d7682"
-repo = "https://github.com/focusenergy/LinearFractional.jl.git"
+repo = "https://github.com/nexteraanalytics/LinearFractional.jl.git"


### PR DESCRIPTION
We changed our github org name to reflect the company's updated name.