### PR TITLE
Ownership transfer: update `repo` in Project.toml for DecisionTree.jl

### DIFF
--- a/D/DecisionTree/Package.toml
+++ b/D/DecisionTree/Package.toml
@@ -1,3 +1,3 @@
 name = "DecisionTree"
 uuid = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
-repo = "https://github.com/bensadeghi/DecisionTree.jl.git"
+repo = "https://github.com/JuliaAI/DecisionTree.jl.git"


### PR DESCRIPTION
DecisionTree.jl is now owned by JuliaAI: https://github.com/JuliaAI/DecisionTree.jl/issues/152

@DilumAluthge 