### PR TITLE
Yank the prerelease version of LightLearn (specifically, yank LightLearn version `1.0.0-alpha`)

### DIFF
--- a/L/LightLearn/Versions.toml
+++ b/L/LightLearn/Versions.toml
@@ -1,5 +1,6 @@
 ["1.0.0-alpha"]
 git-tree-sha1 = "f9065b7d00db5b2ae6bac276b74cb6b50884bd04"
+yanked = true
 
 ["1.1.0"]
 git-tree-sha1 = "a240830b29c58b531ce937adcc5a4fd82f6134e0"


### PR DESCRIPTION
As a matter of policy, we have never allowed packages to register prerelease versions in the General registry. This one slipped past AutoMerge due to a technical bug that has since been fixed.

---

<details>

<summary>The following script can be used to find all prerelease versions in the registry: (click to expand)</summary>

```julia
import TOML

function find_prerelease_versions()
    mktempdir() do dir
        cd(dir) do
            run(`git clone https://github.com/JuliaRegistries/General.git`)
            cd("General") do
                registry = TOML.parsefile("Registry.toml")
                packages = registry["packages"]
                for package in pairs(packages)
                    uuid = package[1]
                    pkginfo = package[2]
                    name = pkginfo["name"]
                    path = pkginfo["path"]
                    versions = TOML.parsefile(joinpath(path, "Versions.toml"))
                    for v in pairs(versions)
                        version = VersionNumber(v[1])
                        verinfo = v[2]
                        has_prerelease_data = !isempty(version.prerelease)
                        yanked = get(verinfo, "yanked", nothing)
                        if has_prerelease_data
                            if endswith(name, "_jll")
                            else
                                @info "" name uuid path version yanked
                            end
                        end
                    end
                end
            end
        end
    end
    return nothing
end

find_prerelease_versions()
```

</details>