### PR TITLE
[Ipopt_jll] manually enforce older compat on MUMPS

### DIFF
--- a/I/Ipopt_jll/Compat.toml
+++ b/I/Ipopt_jll/Compat.toml
@@ -1,11 +1,9 @@
 [3]
+MUMPS_seq_jll = "5.2.1"
 julia = "1"
 
 ["3.13.2"]
 JLLWrappers = "1.1.0-1"
-
-["3.13.2-3"]
-MUMPS_seq_jll = "5.2.1"
 
 ["3.13.4-3"]
 JLLWrappers = "1.2.0-1"


### PR DESCRIPTION
Tested locally that Ipopt 0.6.3 is compatible with MUMPS_seq_jll@5.2.1
```julia
(ipopt) pkg> add MUMPS_seq_jll
   Resolving package versions...
    Updating `/private/tmp/ipopt/Project.toml`
  [d7ed1dd3] + MUMPS_seq_jll v400.1000.0+0
  No Changes to `/private/tmp/ipopt/Manifest.toml`

(ipopt) pkg> st
      Status `/private/tmp/ipopt/Project.toml`
  [b6b21f68] Ipopt v0.6.3
  [d7ed1dd3] MUMPS_seq_jll v400.1000.0+0

julia> using Ipopt
[ Info: Precompiling Ipopt [b6b21f68-93f8-5de0-b562-5493be1d77c9]
ERROR: LoadError: InitError: could not load library "/Users/oscar/.julia/artifacts/801365da4ca9cd4b8da525642ca38b37d9c0333f/lib/libipopt.3.dylib"
dlopen(/Users/oscar/.julia/artifacts/801365da4ca9cd4b8da525642ca38b37d9c0333f/lib/libipopt.3.dylib, 1): Library not loaded: @rpath/libdmumps.dylib
  Referenced from: /Users/oscar/.julia/artifacts/801365da4ca9cd4b8da525642ca38b37d9c0333f/lib/libipopt.3.dylib
  Reason: image not found
Stacktrace:
  [1] dlopen(s::String, flags::UInt32; throw_error::Bool)
    @ Base.Libc.Libdl ./libdl.jl:114
  [2] dlopen (repeats 2 times)
    @ ./libdl.jl:114 [inlined]
  [3] __init__()
    @ Ipopt_jll ~/.julia/packages/Ipopt_jll/ZudKO/src/wrappers/x86_64-apple-darwin14-libgfortran5-cxx11.jl:79
  [4] _include_from_serialized(path::String, depmods::Vector{Any})
    @ Base ./loading.jl:696
  [5] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String)
    @ Base ./loading.jl:782
  [6] _require(pkg::Base.PkgId)
    @ Base ./loading.jl:1020
  [7] require(uuidkey::Base.PkgId)
    @ Base ./loading.jl:936
  [8] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:923
  [9] top-level scope
    @ ~/.julia/packages/Ipopt/bYzBL/src/Ipopt.jl:26
 [10] include
    @ ./Base.jl:386 [inlined]
 [11] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
    @ Base ./loading.jl:1235
 [12] top-level scope
    @ none:1
 [13] eval
    @ ./boot.jl:360 [inlined]
 [14] eval(x::Expr)
    @ Base.MainInclude ./client.jl:446
 [15] top-level scope
    @ none:1
during initialization of module Ipopt_jll
in expression starting at /Users/oscar/.julia/packages/Ipopt/bYzBL/src/Ipopt.jl:1
ERROR: Failed to precompile Ipopt [b6b21f68-93f8-5de0-b562-5493be1d77c9] to /Users/oscar/.julia/compiled/v1.6/Ipopt/jl_mKuSdz.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::Base.TTY, internal_stdout::Base.TTY, ignore_loaded_modules::Bool)
   @ Base ./loading.jl:1385
 [3] compilecache(pkg::Base.PkgId, path::String)
   @ Base ./loading.jl:1329
 [4] _require(pkg::Base.PkgId)
   @ Base ./loading.jl:1043
 [5] require(uuidkey::Base.PkgId)
   @ Base ./loading.jl:936
 [6] require(into::Module, mod::Symbol)
   @ Base ./loading.jl:923

julia> exit()
(base) oscar@Oscars-MBP /tmp % ~/julia --project=ipopt
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.2 (2021-07-14)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

]st
(ipopt) pkg> st
      Status `/private/tmp/ipopt/Project.toml`
  [b6b21f68] Ipopt v0.6.3
  [d7ed1dd3] MUMPS_seq_jll v400.1000.0+0

(ipopt) pkg> add MUMPS_seq_jll@5.2.1
    Updating registry at `~/.julia/registries/General`
    Updating git-repo `https://github.com/JuliaRegistries/General.git`
   Resolving package versions...
    Updating `/private/tmp/ipopt/Project.toml`
  [d7ed1dd3] ↓ MUMPS_seq_jll v400.1000.0+0 ⇒ v5.2.1+4
    Updating `/private/tmp/ipopt/Manifest.toml`
  [d00139f3] + METIS_jll v5.1.1+0
  [d7ed1dd3] ↓ MUMPS_seq_jll v400.1000.0+0 ⇒ v5.2.1+4
Precompiling project...
  3 dependencies successfully precompiled in 7 seconds (26 already precompiled)

julia> using Ipopt
```

The problem in https://discourse.julialang.org/t/failed-to-precompile-ipopt/80758 was that Ipopt_jll@3.13.1 (used by Ipopt@0.6.3) was installing with an incompatible version of MUMPS.