### PR TITLE
Bound NLOpt < 0.6 to Julia < 1.5

### DIFF
--- a/N/NLopt/Compat.toml
+++ b/N/NLopt/Compat.toml
@@ -2,7 +2,7 @@
 BinaryProvider = "0.3.0 - 0.5"
 CMakeWrapper = "0.0.0 - 0.2"
 MathProgBase = "0.5.0 - 0.7"
-julia = ["0.7", "1"]
+julia = ["0.7", "1-1.4"]
 
 ["0.6-0"]
 MathProgBase = "0.5-0.8"

--- a/N/NLopt/Compat.toml
+++ b/N/NLopt/Compat.toml
@@ -2,7 +2,7 @@
 BinaryProvider = "0.3.0 - 0.5"
 CMakeWrapper = "0.0.0 - 0.2"
 MathProgBase = "0.5.0 - 0.7"
-julia = ["0.7", "1-1.4"]
+julia = ["0.7", "1.0.0-1.4"]
 
 ["0.6-0"]
 MathProgBase = "0.5-0.8"


### PR DESCRIPTION
On Julia 1.5+, NLOpt versions before https://github.com/JuliaOpt/NLopt.jl/pull/142 cause silent memory corruption.
Unfortunately, there are (older, unmaintained) packages in the Julia ecosystem that pin NLOpt 0.5, so they show up
as random failures in PkgEval. Try to improve the situation by explicitly marking the compatibility to prevent
installation of those older packages on recent Julia versions.

cc @stevengj 