### PR TITLE
Update URL for DensityRatioEstimation.jl

### DIFF
--- a/D/DensityRatioEstimation/Package.toml
+++ b/D/DensityRatioEstimation/Package.toml
@@ -1,3 +1,3 @@
 name = "DensityRatioEstimation"
 uuid = "ab46fb84-d57c-11e9-2f65-6f72e4a7229f"
-repo = "https://github.com/JuliaEarth/DensityRatioEstimation.jl.git"
+repo = "https://github.com/JuliaML/DensityRatioEstimation.jl.git"


### PR DESCRIPTION
Please update the URL of the package, which now lives in JuliaML.