### PR TITLE
Update URL for RankAggregation.jl

### DIFF
--- a/R/RankAggregation/Package.toml
+++ b/R/RankAggregation/Package.toml
@@ -1,3 +1,3 @@
 name = "RankAggregation"
 uuid = "ab9d97fe-b3f0-4ed5-83d9-5747a4381b0c"
-repo = "https://github.com/JuliaEarth/RankAggregation.jl.git"
+repo = "https://github.com/JuliaML/RankAggregation.jl.git"


### PR DESCRIPTION
Please update the URL of the package, which now lives in JuliaML.