### PR TITLE
Yank Legolas 0.3.4

### DIFF
--- a/L/Legolas/Versions.toml
+++ b/L/Legolas/Versions.toml
@@ -30,3 +30,4 @@ git-tree-sha1 = "f24c128ff52feabaf65826ba7a0d9ab5f0ca8ff5"
 
 ["0.3.4"]
 git-tree-sha1 = "866a5454bb06d6de96ce726dd6b8b670ced15274"
+yanked = true


### PR DESCRIPTION
A breaking change was accidentally added in https://github.com/beacon-biosignals/Legolas.jl/pull/40 and left on the default branch. When another change was introduced the 0.3.4 was created accidentally releasing the breaking change to a non-breaking release.