### PR TITLE
Update send to twitter to add debug lines

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -104,10 +104,11 @@ jobs:
           twitterauth(ENV["API_Key"], ENV["API_Key_Secret"], ENV["Access_Token"], ENV["Access_Token_Secret"])
           
           myStatus = string("New #JuliaLang package announced: ", ENV["PR_NAME"],  "\n$text \nLearn more: $pr_url")
-          
+          @info "Tweet to be sent: $myStatus"
+          @info "Tweet length: $length(myStatus)"
+
           response = post_status_update(status=myStatus)
           
-          @info "Told Twitter: $myStatus"
           @info "Twitter said: $response"
         env:
           SLACK_ENDPOINT: ${{ secrets.JULIALANGSLACKENDPOINT }}


### PR DESCRIPTION
The previous run failed since the tweet was too long but it seemed like it should have been short enough so adding some debug statements before the request to twitter is made