### PR TITLE
Update send to twitter with new formatting

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -103,7 +103,7 @@ jobs:
           using Twitter
           twitterauth(ENV["API_Key"], ENV["API_Key_Secret"], ENV["Access_Token"], ENV["Access_Token_Secret"])
           
-          myStatus = string(ENV["PR_NAME"],  " announced #JuliaLang\n$text")
+          myStatus = string(ENV["PR_NAME"],  " is being registered #JuliaLang\n$text")
           @info "Tweet to be sent: $myStatus"
           @info "Tweet length: $(length(myStatus))"
 

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -103,7 +103,7 @@ jobs:
           using Twitter
           twitterauth(ENV["API_Key"], ENV["API_Key_Secret"], ENV["Access_Token"], ENV["Access_Token_Secret"])
           
-          myStatus = string("New #JuliaLang package announced: ", ENV["PR_NAME"],  "\n$text \nLearn more: $pr_url")
+          myStatus = string(ENV["PR_NAME"],  " announced #JuliaLang\n$text")
           @info "Tweet to be sent: $myStatus"
           @info "Tweet length: $(length(myStatus))"
 


### PR DESCRIPTION
It looks like the parsed text already has the URL in it: https://twitter.com/JuliaPackages/status/1528796254783696896?s=20&t=PU0OPO_0hdi13CKdT7QzSg so this update condenses what we tweet to remove redundant info.