### PR TITLE
Yank some ArrayInterfaceStaticArrays

### DIFF
--- a/A/ArrayInterfaceStaticArrays/Versions.toml
+++ b/A/ArrayInterfaceStaticArrays/Versions.toml
@@ -1,8 +1,10 @@
 ["0.1.0"]
 git-tree-sha1 = "ee7cb552b8e073af0f1fdaabc0da7e104581df03"
+yanked = true
 
 ["0.1.1"]
 git-tree-sha1 = "8973a450b9963b6f5c7a85773d9ddb305ea8c2ac"
+yanked = true
 
 ["0.1.2"]
 git-tree-sha1 = "d7dc30474e73173a990eca86af76cae8790fa9f2"


### PR DESCRIPTION
These should have had a requirement on ArrayInterface v6 but did not, and so are non-functional. The package manager tries to give it some times to reduce dependencies anyways:

https://github.com/SciML/SciMLBase.jl/runs/6575690017?check_suite_focus=true#step:6:61

this improves safety.