### PR TITLE
Yank LoggingExtras v0.5.0

### DIFF
--- a/L/LoggingExtras/Versions.toml
+++ b/L/LoggingExtras/Versions.toml
@@ -36,3 +36,4 @@ git-tree-sha1 = "5d4d2d9904227b8bd66386c1138cf4d5ffa826bf"
 
 ["0.5.0"]
 git-tree-sha1 = "42d6de660ef0f2771a12f021686c286481723dd7"
+yanked = true


### PR DESCRIPTION
v0.5.0 was tagged by mistake.
It was nonbreaking
v0.4.9 is further advanced.

The next release will be 1.0.0