### PR TITLE
[OrdinaryDiffEq] Restrict compat with `DiffEqBase` to `v6.84`

### DIFF
--- a/O/OrdinaryDiffEq/Compat.toml
+++ b/O/OrdinaryDiffEq/Compat.toml
@@ -128,7 +128,7 @@ DiffEqBase = "6"
 Parameters = "0.10-0.12"
 
 ["5.18-5.23"]
-DiffEqBase = "6.4.0-6"
+DiffEqBase = "6.4.0-6.84"
 
 ["5.19-5.22"]
 SparseDiffTools = "0.9-0.10"
@@ -143,7 +143,7 @@ StaticArrays = "0.11-0.12"
 SparseDiffTools = "0.10"
 
 ["5.24-5.26"]
-DiffEqBase = "6.5.0-6"
+DiffEqBase = "6.5.0-6.84"
 
 ["5.24-5.29"]
 SparseDiffTools = ["0.10", "1"]
@@ -152,22 +152,22 @@ SparseDiffTools = ["0.10", "1"]
 ArrayInterface = "1.1.0-2"
 
 ["5.27"]
-DiffEqBase = "6.11.0-6"
+DiffEqBase = "6.11.0-6.84"
 
 ["5.27-6.8"]
 RecursiveArrayTools = "2"
 
 ["5.28"]
-DiffEqBase = "6.13.0-6"
+DiffEqBase = "6.13.0-6.84"
 
 ["5.28-6"]
 FiniteDiff = "2"
 
 ["5.29"]
-DiffEqBase = "6.15.0-6"
+DiffEqBase = "6.15.0-6.84"
 
 ["5.30-5.31"]
-DiffEqBase = "6.21.0-6"
+DiffEqBase = "6.21.0-6.84"
 
 ["5.30-5.35"]
 UnPack = "0.1"
@@ -182,7 +182,7 @@ NLsolve = "4.3.0-4"
 ArrayInterface = "2.6.0-2"
 
 ["5.32-5.35.1"]
-DiffEqBase = "6.25.0-6"
+DiffEqBase = "6.25.0-6.84"
 
 ["5.32-5.51"]
 GenericSVD = "0.2-0.3"
@@ -194,19 +194,19 @@ julia = "1.3.0-1"
 ArrayInterface = "2.7.0-2"
 
 ["5.35.2-5.36"]
-DiffEqBase = "6.31.0-6"
+DiffEqBase = "6.31.0-6.84"
 
 ["5.36-6"]
 UnPack = ["0.1", "1"]
 
 ["5.37-5.38"]
-DiffEqBase = "6.33.0-6"
+DiffEqBase = "6.33.0-6.84"
 
 ["5.37-5.70"]
 SparseDiffTools = "1.8.0-1"
 
 ["5.39-5.41"]
-DiffEqBase = "6.36.0-6"
+DiffEqBase = "6.36.0-6.84"
 
 ["5.4"]
 DiffEqBase = "5.5.1-5"
@@ -221,7 +221,7 @@ ForwardDiff = "0.10.3-0.10"
 Adapt = "1.1.0-2"
 
 ["5.42-5.61"]
-DiffEqBase = "6.38.0-6"
+DiffEqBase = "6.38.0-6.84"
 
 ["5.42.1-6"]
 FastClosures = "0.3"
@@ -270,10 +270,10 @@ MuladdMacro = "0.2.1-0.2"
 LoopVectorization = "0.12"
 
 ["5.62"]
-DiffEqBase = "6.72.0-6"
+DiffEqBase = "6.72.0-6.84"
 
 ["5.63-5.64"]
-DiffEqBase = "6.73.0-6"
+DiffEqBase = "6.73.0-6.84"
 
 ["5.63.5-5.63"]
 Polyester = "0.3-0.4"
@@ -282,7 +282,7 @@ Polyester = "0.3-0.4"
 Polyester = "0.3-0.5"
 
 ["5.65-5.71.1"]
-DiffEqBase = "6.75.0-6"
+DiffEqBase = "6.75.0-6.84"
 
 ["5.66-6.10"]
 PreallocationTools = "0.2"
@@ -312,7 +312,7 @@ StaticArrays = "0.10.3-0.11"
 LinearSolve = "1"
 
 ["6-6.6.2"]
-DiffEqBase = "6.75.0-6"
+DiffEqBase = "6.75.0-6.84"
 
 ["6.0"]
 Polyester = "0.3-0.5"
@@ -357,7 +357,7 @@ LinearSolve = "1.9.0-1"
 NonlinearSolve = "0.3.14-0.3"
 
 ["6.6.3-6"]
-DiffEqBase = "6.81.3-6"
+DiffEqBase = "6.81.3-6.84"
 
 ["6.7"]
 SciMLBase = "1.28.0-1"


### PR DESCRIPTION
Ref: https://github.com/SciML/OrdinaryDiffEq.jl/issues/1679#issuecomment-1139503500