### PR TITLE
Fix compat bounds of libraries depending on GSL_jll

### DIFF
--- a/F/FastANI_jll/Compat.toml
+++ b/F/FastANI_jll/Compat.toml
@@ -1,3 +1,4 @@
 [1]
+GSL_jll = "2.7.1"
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"

--- a/H/HMMER_jll/Compat.toml
+++ b/H/HMMER_jll/Compat.toml
@@ -1,3 +1,4 @@
 [3]
+GSL_jll = "2.7.1"
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"

--- a/H/HelFEM_jll/Compat.toml
+++ b/H/HelFEM_jll/Compat.toml
@@ -15,7 +15,7 @@ JLLWrappers = "1.2.0-1"
 julia = "1.5.0-1"
 
 ["0.1.6-0"]
-GSL_jll = "2.6.0-2"
+GSL_jll = "2.6.0-2.6"
 OpenBLAS_jll = "0.3.10-0.3"
 armadillo_jll = "9.850.1-9"
 julia = "1.6.0-1"

--- a/I/Infernal_jll/Compat.toml
+++ b/I/Infernal_jll/Compat.toml
@@ -1,3 +1,4 @@
 [1]
+GSL_jll = "2.7.1"
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"

--- a/R/raptor_jll/Compat.toml
+++ b/R/raptor_jll/Compat.toml
@@ -1,3 +1,4 @@
 [0]
+GSL_jll = "2.6.0-2.6"
 JLLWrappers = "1.2.0-1"
 julia = "1"

--- a/V/ViennaRNA_jll/Compat.toml
+++ b/V/ViennaRNA_jll/Compat.toml
@@ -1,3 +1,4 @@
 [2]
+GSL_jll = "2.7.1"
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"


### PR DESCRIPTION
Upstream GSL breaks the ABI at every minor release, but they forgot to change
the soversion in v2.7 (corresponding to v2.7.0 and v2.7.1 of `GSL_jll`) and
remembered to change that in v2.7.1 (corresponding to v2.7.2 of `GSL_jll`):
<https://git.savannah.gnu.org/cgit/gsl.git/commit/configure.ac?id=77e7c7d008707dace56626020eaa6181912e9841>.
This resulted in breaking libraries that had been previously built against GSL
2.7.

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/5019#issuecomment-1152965185