### PR TITLE
yank StructArrays v0.6.9

### DIFF
--- a/S/StructArrays/Versions.toml
+++ b/S/StructArrays/Versions.toml
@@ -84,3 +84,4 @@ git-tree-sha1 = "9abba8f8fb8458e9adf07c8a2377a070674a24f1"
 
 ["0.6.9"]
 git-tree-sha1 = "9097e2914e179ab1d45330403fae880630acea0b"
+yanked = true


### PR DESCRIPTION
The latest version accidentally caused some ambiguities not caught by tests https://github.com/JuliaArrays/StructArrays.jl/issues/234.