### PR TITLE
[DisjunctiveProgramming] retroactively fix compat bounds

### DIFF
--- a/D/DisjunctiveProgramming/Compat.toml
+++ b/D/DisjunctiveProgramming/Compat.toml
@@ -13,5 +13,5 @@ Symbolics = "4"
 JuMP = "0.22"
 
 ["0.1.5-0"]
-JuMP = "1"
+JuMP = "1.0.0-1.1.1"
 Suppressor = "0.2"


### PR DESCRIPTION
This package uses internal functionality of JuMP that will be removed in v1.2

Same as https://github.com/JuliaRegistries/General/pull/62984
x-ref https://github.com/hdavid16/DisjunctiveProgramming.jl/pull/48
x-ref https://github.com/jump-dev/JuMP.jl/pull/2955

cc @hdavid16