### PR TITLE
Yank MLJGLMInterface 0.3.2

### DIFF
--- a/M/MLJGLMInterface/Versions.toml
+++ b/M/MLJGLMInterface/Versions.toml
@@ -33,6 +33,7 @@ git-tree-sha1 = "3220b8002a451d2c9e55e61e9ebe6d6850568051"
 
 ["0.3.2"]
 git-tree-sha1 = "e455c45a30ebb95647796c17123572c86db23e79"
+yanked = true
 
 ["0.3.3"]
 git-tree-sha1 = "dd24688271c39996e3a605184299175d8587fc38"


### PR DESCRIPTION
This version added use of a method (`document_header`) from MLJModelInterface that did not become available until MLJModelInterface 1.4, but the [compat] entry for MLJModelInterface was not bumped to this level. The issue is resolved in MLJGLMInterface 0.3.3 now merged into General.jl.