### PR TITLE
Yank msolve_jll v0.2.5+0 from #63338

### DIFF
--- a/M/msolve_jll/Versions.toml
+++ b/M/msolve_jll/Versions.toml
@@ -39,6 +39,7 @@ git-tree-sha1 = "4ad5c167869c06eb3e9a05996601591ad5586bf1"
 
 ["0.2.5+0"]
 git-tree-sha1 = "e04bc5fd90d1d3553f2eab24003906a5b87839c3"
+yanked = true
 
 ["0.3.0+0"]
 git-tree-sha1 = "a4478646905cdf407167abb071a4920da64b08a6"


### PR DESCRIPTION
This version was binary incompatible with 0.2.3 and broken Oscar.jl.
The new release was renamed 0.3.0, but in the meantime, 0.2.5 breaks
things for anyone installing Oscar right now.
