### PR TITLE
Lock version of GPUArraysCore.jl to exactly 0.1 for existing GPUArrays.jl versions

### DIFF
--- a/G/GPUArrays/Compat.toml
+++ b/G/GPUArrays/Compat.toml
@@ -66,5 +66,5 @@ julia = "1.6.0-1"
 LLVM = "3.9.0-4"
 
 ["8.4-8"]
-GPUArraysCore = "0.1"
+GPUArraysCore = "= 0.1"
 Reexport = "1"

--- a/G/GPUArrays/Compat.toml
+++ b/G/GPUArrays/Compat.toml
@@ -66,5 +66,5 @@ julia = "1.6.0-1"
 LLVM = "3.9.0-4"
 
 ["8.4-8"]
-GPUArraysCore = "= 0.1"
+GPUArraysCore = "0.1.0-0.1.0"
 Reexport = "1"


### PR DESCRIPTION
Right now there is exactly one version of GPUArraysCore.jl  added in https://github.com/JuliaRegistries/General/pull/62776, v0.1. 

This PR should change existing versions of GPUArrays.jl to use exactly this version forever.

As suggested here https://github.com/JuliaGPU/GPUArrays.jl/pull/417#issuecomment-1187014867 in order to allow a type to be moved from the big package to the Core package, without allowing any confusing states. 

~~I hope this is the right syntax, from https://pkgdocs.julialang.org/v1/compatibility/#Equality-specifier .~~
Edit: it's not! But `0.1.0-0.1.0` seems to work.