### PR TITLE
move NanoDates.jl to JuliaTime

### DIFF
--- a/N/NanoDates/Package.toml
+++ b/N/NanoDates/Package.toml
@@ -1,3 +1,3 @@
 name = "NanoDates"
 uuid = "46f1a544-deae-4307-8689-c12aa3c955c6"
-repo = "https://github.com/JeffreySarnoff/NanoDates.jl.git"
+repo = "https://github.com/JuliaTime/NanoDates.jl.git"


### PR DESCRIPTION
I have transferred the repo.  This is to update the registry to match fact, so additional development can happen.