### PR TITLE
New version: GPMaxlik v0.14.1

### DIFF
--- a/G/GPMaxlik/Versions.toml
+++ b/G/GPMaxlik/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "bc6ede0470be6ba3668509fcf668a151de49c748"
 
 ["0.14.0"]
 git-tree-sha1 = "04128559b08d21d5249d3014bd36dbae0a2d3e69"
+
+["0.14.1"]
+git-tree-sha1 = "5c6db22069e13a156c50856493d9b4c2ade33296"


### PR DESCRIPTION
This PR to add a new version of `GPMaxlik.jl` was generated using `LocalRegistry.jl`, which I've done a handful of times and shouldn't make any issues.

UUID: 988d40dc-a58a-4803-bd2c-6d7438fe27fe
Repo:
Tree: 5c6db22069e13a156c50856493d9b4c2ade33296