### PR TITLE
Yank v0.3.x of NamedDims.jl

### DIFF
--- a/N/NamedDims/Versions.toml
+++ b/N/NamedDims/Versions.toml
@@ -156,12 +156,15 @@ git-tree-sha1 = "cb8ebcee2b4e07b72befb9def593baef8aa12f07"
 
 ["0.3.0"]
 git-tree-sha1 = "6588288f18f5cf8c6192cb961375daf3f7a507fb"
+yanked=true
 
 ["0.3.1"]
 git-tree-sha1 = "2d569be6cc9a52f2d4b0b7600ae4b1c63d195b75"
+yanked=true
 
 ["0.3.2"]
 git-tree-sha1 = "8941cce26cea3be7502ba8a34bb7e19df54b8350"
+yanked=true
 
 ["1.0.0"]
 git-tree-sha1 = "e20b13bd9066361a7c695c56e00361d3068c7b3c"


### PR DESCRIPTION
v0.3.x was nonbreaking, and 0.3.2 was rereleased as v0.2.50, and also as v1.0.0
I  think this should mean noone ever gets bitten by getting v0.3.1 or v0.3.0 which are older releases.
But lets make it impossible by yanking them