### PR TITLE
CI: Temporarily disable CI on Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - '1.5'
           - '1.6'
           - '1'
-          - 'nightly'
+          # - 'nightly' # TODO: uncomment this line
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
CI is failing on Julia nightly because DelimitedFiles was removed from the standard library. This PR temporarily disables CI on Julia nightly. We will re-enable CI on Julia nightly once the underlying issue is fixed.