### PR TITLE
Yank version 0.9.0 and 0.9.1 of LiveServer from registry

### DIFF
--- a/L/LiveServer/Versions.toml
+++ b/L/LiveServer/Versions.toml
@@ -108,6 +108,8 @@ git-tree-sha1 = "79783c2901a09bab202f55f24fe07a9a03b14e8a"
 
 ["0.9.0"]
 git-tree-sha1 = "3f31084145b121b1913894e20850f6e720df0cf2"
+yanked = true
 
 ["0.9.1"]
 git-tree-sha1 = "7a65cc672265049618c5227f58a07478109465a5"
+yanked = true


### PR DESCRIPTION
these versions include HTTP1 but HTTP1 seems to cause issues that are hard to track down so for now we'll yank those two versions and release another `0.9.0` without HTTP1.

cc @fredrikekre