### PR TITLE
Update URL for GeoEstimation.jl

### DIFF
--- a/G/GeoEstimation/Package.toml
+++ b/G/GeoEstimation/Package.toml
@@ -1,3 +1,3 @@
 name = "GeoEstimation"
 uuid = "a4aa24f8-9f24-4d1a-b848-66d123bfa54d"
-repo = "https://github.com/JuliaEarth/GeoEstimation.jl.git"
+repo = "https://github.com/juliohm/GeoEstimation.jl.git"


### PR DESCRIPTION
The package has been deprecated and moved out of the organization.