### PR TITLE
Update URL for GeoSimulation.jl

### DIFF
--- a/G/GeoSimulation/Package.toml
+++ b/G/GeoSimulation/Package.toml
@@ -1,3 +1,3 @@
 name = "GeoSimulation"
 uuid = "220efe8a-9139-4e14-a4fa-f683d572f4c5"
-repo = "https://github.com/JuliaEarth/GeoSimulation.jl.git"
+repo = "https://github.com/juliohm/GeoSimulation.jl.git"


### PR DESCRIPTION
The package has been deprecated and moved out of the organization.