### PR TITLE
Update URL for GeoLearning.jl

### DIFF
--- a/G/GeoLearning/Package.toml
+++ b/G/GeoLearning/Package.toml
@@ -1,3 +1,3 @@
 name = "GeoLearning"
 uuid = "90c4468e-a93e-43b4-8fb5-87d804bc629f"
-repo = "https://github.com/JuliaEarth/GeoLearning.jl.git"
+repo = "https://github.com/juliohm/GeoLearning.jl.git"


### PR DESCRIPTION
The package has been deprecated and moved out of the organization.