### PR TITLE
Widen Einsum's bounds on Compat

### DIFF
--- a/E/Einsum/Compat.toml
+++ b/E/Einsum/Compat.toml
@@ -1,3 +1,3 @@
 [0]
-Compat = "0-3"
+Compat = "0-4"
 julia = "0.6-1"


### PR DESCRIPTION
This is exactly like #7094 except for Compat 4 instead of 3.

Einsum.jl seems to be abandoned, but is still useful. It places no compat bounds on Compat (and in fact only needs the package on Julia 0.6) by itself, but at some point its registry entry had an upper bound added, which now prevents upgrades. 