### PR TITLE
Update URL for ShfitedArrays

### DIFF
--- a/S/ShiftedArrays/Package.toml
+++ b/S/ShiftedArrays/Package.toml
@@ -1,3 +1,3 @@
 name = "ShiftedArrays"
 uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
-repo = "https://github.com/piever/ShiftedArrays.jl.git"
+repo = "https://github.com/JuliaArrays/ShiftedArrays.jl.git"


### PR DESCRIPTION
[ShiftedArrays](https://github.com/JuliaArrays/ShiftedArrays.jl) was moved to JuliaArrays a while back. From what I understood, the JuliaRegistrator bot requires to manually change the URL here before tagging a new version.