### PR TITLE
Yank oneAPI_Support 2022.*.

### DIFF
--- a/O/oneAPI_Support_jll/Compat.toml
+++ b/O/oneAPI_Support_jll/Compat.toml
@@ -1,7 +1,3 @@
 [0]
 JLLWrappers = "1.2.0-1"
 julia = "1"
-
-[2022]
-JLLWrappers = "1.2.0-1"
-julia = "1"

--- a/O/oneAPI_Support_jll/Deps.toml
+++ b/O/oneAPI_Support_jll/Deps.toml
@@ -3,9 +3,3 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[2022]
-Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/O/oneAPI_Support_jll/Versions.toml
+++ b/O/oneAPI_Support_jll/Versions.toml
@@ -1,8 +1,2 @@
 ["0.1.0+0"]
 git-tree-sha1 = "2d158bce0dd1a7a0e0efee1c10936c33762f9057"
-
-["2022.1.0+0"]
-git-tree-sha1 = "99c26371880e86fddd9c88ed18152f6ffc560437"
-
-["2022.1.0+1"]
-git-tree-sha1 = "d879007712830ffd6eec093b517f6cb203a53326"


### PR DESCRIPTION
To be able to semver the API of oneAPI_Support, we shouldn't be following the version of the contained Intel toolchain, but use a separate version.