### PR TITLE
Fix ChebyshevTransforms link

### DIFF
--- a/C/ChebyshevTransforms/Package.toml
+++ b/C/ChebyshevTransforms/Package.toml
@@ -1,3 +1,3 @@
 name = "ChebyshevTransforms"
 uuid = "2752694e-a3a0-42bd-9f17-5f3242da1ce6"
-repo = "https://github.com/Luapulu/ChebyshevTransforms.jl.git"
+repo = "https://github.com/JuliaApproximation/ChebyshevTransforms.jl"


### PR DESCRIPTION
I moved the repo to JuliaApproximation, so the link needs to be updated.