### PR TITLE
Update org name for Octonions

### DIFF
--- a/O/Octonions/Package.toml
+++ b/O/Octonions/Package.toml
@@ -1,3 +1,3 @@
 name = "Octonions"
 uuid = "d00ba074-1e29-4f5e-9fd4-d67071d6a14d"
-repo = "https://github.com/sethaxen/Octonions.jl.git"
+repo = "https://github.com/JuliaGeometry/Octonions.jl.git"


### PR DESCRIPTION
Octonions.jl has migrated to https://github.com/JuliaGeometry/Octonions.jl. This PR updates the URL.