### PR TITLE
Update Pathfinder.jl repo url

### DIFF
--- a/P/Pathfinder/Package.toml
+++ b/P/Pathfinder/Package.toml
@@ -1,3 +1,3 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
-repo = "https://github.com/sethaxen/Pathfinder.jl.git"
+repo = "https://github.com/mlcolab/Pathfinder.jl.git"


### PR DESCRIPTION
Pathfinder has moved to the mlcolab org. This PR updates the URL accordingly.