### PR TITLE
[UserNSSandbox_jll] Delete yanked version

### DIFF
--- a/U/UserNSSandbox_jll/Versions.toml
+++ b/U/UserNSSandbox_jll/Versions.toml
@@ -37,10 +37,6 @@ git-tree-sha1 = "c739fca3eca5647c833895362ea3cda5596a249f"
 ["2022.3.30+0"]
 git-tree-sha1 = "ebd94673ad737817c4f837250ea4c15d36a63e1d"
 
-["2022.3.30+1"]
-git-tree-sha1 = "5607eba78ccda080b0383985bff69fcce32f7a6c"
-yank = true
-
 ["2022.8.1+0"]
 git-tree-sha1 = "01af8fba7569264aacf3be73902b2ddf33a658df"
 


### PR DESCRIPTION
The yanking doesn't work well with build numbers, so let's just delete it.  I have verified that on Julia v1.8 at least, the deletion is handled very gracefully:

```
(sandboxed-buildkite-agent) pkg> instantiate
   Installed UserNSSandbox_jll ─ v2022.3.30+1
Precompiling project...
  2 dependencies successfully precompiled in 1 seconds. 8 already precompiled.

(sandboxed-buildkite-agent) pkg> resolve
   Installed UserNSSandbox_jll ─ v2022.3.30+0
    Updating `~/src/sandboxed-buildkite-agent/Project.toml`
⌅ [b88861f7] ↓ UserNSSandbox_jll v2022.3.30+1 ⇒ v2022.3.30+0
    Updating `~/src/sandboxed-buildkite-agent/Manifest.toml`
⌅ [b88861f7] ↓ UserNSSandbox_jll v2022.3.30+1 ⇒ v2022.3.30+0
        Info Packages marked with ⌅ have new versions available but cannot be upgraded. To see why use `status --outdated -m`
```

I deleted my copy of the package to make sure that instantiation can still occur, which it does.  And resolve gracefully moves us back to the other version (because I have a compat entry forcing that major.minor.patch version).