### PR TITLE
change `RecipesBase` and `RecipesPipeline` repos (subdir)

### DIFF
--- a/R/RecipesBase/Package.toml
+++ b/R/RecipesBase/Package.toml
@@ -1,3 +1,4 @@
 name = "RecipesBase"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-repo = "https://github.com/JuliaPlots/RecipesBase.jl.git"
+repo = "https://github.com/JuliaPlots/Plots.jl.git"
+subdir = "RecipesBase"

--- a/R/RecipesPipeline/Package.toml
+++ b/R/RecipesPipeline/Package.toml
@@ -1,3 +1,4 @@
 name = "RecipesPipeline"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-repo = "https://github.com/JuliaPlots/RecipesPipeline.jl.git"
+repo = "https://github.com/JuliaPlots/Plots.jl.git"
+subdir = "RecipesPipeline"


### PR DESCRIPTION
We are in the process of merging [`RecipesBase`](https://github.com/JuliaPlots/RecipesBase.jl) and [`RecipesPipeline`](https://github.com/JuliaPlots/RecipesPipeline.jl) into [`Plots`](https://github.com/JuliaPlots/Plots.jl/issues).

The merge procedure and sanity check used are found at https://github.com/JuliaPlots/Plots.jl/pull/4419#issuecomment-1266604686.

**If anyone could review the [PR](https://github.com/JuliaPlots/Plots.jl/pull/4419) for any potential issues regarding the registry**, it would be appreciated ...

Checked against this branch using:
```julia
julia> first(DEPOT_PATH)
# points to the branch of this PR
(@v1.8) pkg> activate --temp
(jl_zodEAE) pkg> add Plots@1.30.0  # test adding an old version
[...]
```

~~**Don't merge this until https://github.com/JuliaPlots/Plots.jl/pull/4419 is merged !**~~