### PR TITLE
Transfer ParameterSchedulers.jl to FluxML

### DIFF
--- a/P/ParameterSchedulers/Package.toml
+++ b/P/ParameterSchedulers/Package.toml
@@ -1,3 +1,3 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
-repo = "https://github.com/darsnack/ParameterSchedulers.jl.git"
+repo = "https://github.com/FluxML/ParameterSchedulers.jl.git"


### PR DESCRIPTION
Not sure if there is anything else to be done other than transferring the URL?