### PR TITLE
fix Ipopt_jll version on SCIP_PaPILO_jll

### DIFF
--- a/S/SCIP_PaPILO_jll/Compat.toml
+++ b/S/SCIP_PaPILO_jll/Compat.toml
@@ -9,7 +9,7 @@ oneTBB_jll = "2021.4.1-2021"
 [800]
 Bzip2_jll = "1.0.8-1"
 GMP_jll = "6.2.0-6"
-Ipopt_jll = "300.1400.403"
+Ipopt_jll = "300.1400.400"
 JLLWrappers = "1.2.0-1"
 OpenBLAS32_jll = "0.3.10-0.3"
 bliss_jll = "0.77.0"


### PR DESCRIPTION
The latest change from Yggdrasil hadn't been picked up by General
reference: https://github.com/JuliaPackaging/Yggdrasil/pull/5640#issuecomment-1277314187

cc @giordano 