### PR TITLE
Repo change for Petri.jl

### DIFF
--- a/P/Petri/Package.toml
+++ b/P/Petri/Package.toml
@@ -1,3 +1,3 @@
 name = "Petri"
 uuid = "4259d249-1051-49fa-8328-3f8ab9391c33"
-repo = "https://github.com/mehalter/Petri.jl.git"
+repo = "https://github.com/AlgebraicJulia/Petri.jl.git"


### PR DESCRIPTION
This repo has been transferred from @mehalter's personal GitHub to the AlgebraicJulia GitHub org.