### PR TITLE
Yank ArrayInterfaceStaticArraysCore 0.1.2

### DIFF
--- a/A/ArrayInterfaceStaticArraysCore/Versions.toml
+++ b/A/ArrayInterfaceStaticArraysCore/Versions.toml
@@ -6,6 +6,7 @@ git-tree-sha1 = "438178aa53012a11a07bd3eceeeab378ed720727"
 
 ["0.1.2"]
 git-tree-sha1 = "9810254b8ac2ce2d673aac4b723e27e2d8f90b72"
+yank=true
 
 ["0.1.3"]
 git-tree-sha1 = "93c8ba53d8d26e124a5a8d4ec914c3a16e6a0970"

--- a/A/ArrayInterfaceStaticArraysCore/Versions.toml
+++ b/A/ArrayInterfaceStaticArraysCore/Versions.toml
@@ -6,7 +6,7 @@ git-tree-sha1 = "438178aa53012a11a07bd3eceeeab378ed720727"
 
 ["0.1.2"]
 git-tree-sha1 = "9810254b8ac2ce2d673aac4b723e27e2d8f90b72"
-yank=true
+yanked = true
 
 ["0.1.3"]
 git-tree-sha1 = "93c8ba53d8d26e124a5a8d4ec914c3a16e6a0970"


### PR DESCRIPTION
It requires a recent ArrayInterfaceCore, but did not update the compat.