### PR TITLE
[OpenSSL_jll] Yank v1.1.18

### DIFF
--- a/O/OpenSSL_jll/Versions.toml
+++ b/O/OpenSSL_jll/Versions.toml
@@ -36,3 +36,4 @@ git-tree-sha1 = "e60321e3f2616584ff98f0a4f18d98ae6f89bbb3"
 
 ["1.1.18+0"]
 git-tree-sha1 = "a94dc0169bffbf7e5250fb7e1efb1a85b09105c7"
+yanked = true


### PR DESCRIPTION
Upstream version 1.1.1r has been withdrawn: <https://mta.openssl.org/pipermail/openssl-announce/2022-October/000237.html>.

Close https://github.com/JuliaPackaging/Yggdrasil/issues/5677.