### PR TITLE
Make CUDA_Runtime_jll compatible with CUDA_Driver_jll 0.2

### DIFF
--- a/C/CUDA_Runtime_jll/Compat.toml
+++ b/C/CUDA_Runtime_jll/Compat.toml
@@ -3,4 +3,4 @@ JLLWrappers = "1.4.0-1"
 julia = "1.6.0-1"
 
 ["0.2-0"]
-CUDA_Driver_jll = "0.1"
+CUDA_Driver_jll = "0.1, 0.2"

--- a/C/CUDA_Runtime_jll/Compat.toml
+++ b/C/CUDA_Runtime_jll/Compat.toml
@@ -3,4 +3,4 @@ JLLWrappers = "1.4.0-1"
 julia = "1.6.0-1"
 
 ["0.2-0"]
-CUDA_Driver_jll = "0.1, 0.2"
+CUDA_Driver_jll = ["0.1", "0.2"]


### PR DESCRIPTION
I changed this upstream, https://github.com/JuliaPackaging/Yggdrasil/commit/7654f598d512e754809717e9469a97c3a3a246a8#diff-3f8a2e1473c0045381f3690c8527fcb586312037dbc32e3e26b533efc7a4c556L31, but strangely that didn't do anything in https://github.com/JuliaRegistries/General/pull/70413... Maybe because I didn't bump the version number?