### PR TITLE
CUDNN_jll: remove CUDA_loader dep.

### DIFF
--- a/C/CUDNN_jll/Deps.toml
+++ b/C/CUDNN_jll/Deps.toml
@@ -1,6 +1,5 @@
 [8]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-CUDA_loader_jll = "46276fb2-733a-55e8-a436-109f48337aca"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
I removed this upstream (on Yggdrasil), but since I didn't bump the version there (as we're following the library version) that didn't apply, so remove the dep manually.