### PR TITLE
Fix cuQuantum compat bounds for CUTENSOR_jll.

### DIFF
--- a/C/cuQuantum_jll/Compat.toml
+++ b/C/cuQuantum_jll/Compat.toml
@@ -1,7 +1,9 @@
 [0]
 JLLWrappers = "1.4.0-1"
 julia = "1.6.0-1"
+CUTENSOR_jll = "1.4"
 
 [22]
 JLLWrappers = "1.4.0-1"
 julia = "1.6.0-1"
+CUTENSOR_jll = "1.6"


### PR DESCRIPTION
I did add these bounds in Yggdrasil, so I'm not sure why they didn't apply: https://github.com/JuliaPackaging/Yggdrasil/blob/fccb4de6fdfdebf1a1e046415a11416b37f887f8/C/cuQuantum/build_tarballs.jl#L51-L54