### PR TITLE
Change URLs for LightOSM.jl, RediSearch.jl and GraphQLClient.jl

### DIFF
--- a/G/GraphQLClient/Package.toml
+++ b/G/GraphQLClient/Package.toml
@@ -1,3 +1,3 @@
 name = "GraphQLClient"
 uuid = "09d831e3-9c21-47a9-bfd8-076871817219"
-repo = "https://github.com/DeloitteDigitalAPAC/GraphQLClient.jl.git"
+repo = "https://github.com/DeloitteOptimalReality/GraphQLClient.jl.git"

--- a/L/LightOSM/Package.toml
+++ b/L/LightOSM/Package.toml
@@ -1,3 +1,3 @@
 name = "LightOSM"
 uuid = "d1922b25-af4e-4ba3-84af-fe9bea896051"
-repo = "https://github.com/DeloitteDigitalAPAC/LightOSM.jl.git"
+repo = "https://github.com/DeloitteOptimalReality/LightOSM.jl.git"

--- a/R/RediSearch/Package.toml
+++ b/R/RediSearch/Package.toml
@@ -1,3 +1,3 @@
 name = "RediSearch"
 uuid = "353f7206-d691-4bbb-b12e-a9a2d4b8f055"
-repo = "https://github.com/jacksoncalvert/RediSearch.jl.git"
+repo = "https://github.com/DeloitteOptimalReality/RediSearch.jl.git"


### PR DESCRIPTION
We've transferred LightOSM.jl, RediSearch.jl and GraphQLClient.jl to a new company GitHub org. This PR just changes the URLs for the package repos.

Who needs to merge this PR? @giordano?

Cheers, 
Jarod