### PR TITLE
Yank Arpack `v0.5.0` and un-yank Arpack_jll `v3.8.0+0`

### DIFF
--- a/A/Arpack/Versions.toml
+++ b/A/Arpack/Versions.toml
@@ -39,6 +39,7 @@ git-tree-sha1 = "2ff92b71ba1747c5fdd541f8fc87736d82f40ec9"
 
 ["0.5.0"]
 git-tree-sha1 = "288d58589d4249a63095f3f41ece91bf34c32c19"
+yanked = true
 
 ["0.5.1"]
 git-tree-sha1 = "9bdebb9148912e3c800dff80528b11064ddca424"

--- a/A/Arpack_jll/Versions.toml
+++ b/A/Arpack_jll/Versions.toml
@@ -19,7 +19,6 @@ git-tree-sha1 = "5ba6c757e8feccf03a1554dfaf3e26b3cfc7fd5e"
 
 ["3.7.0+0"]
 git-tree-sha1 = "cc34a702b843b26db6f8a5e7579762448829548d"
-yanked = true
 
 ["3.8.0+0"]
 git-tree-sha1 = "4c31b0101997beb213a9e6c39116b052e73ca38c"

--- a/A/Arpack_jll/Versions.toml
+++ b/A/Arpack_jll/Versions.toml
@@ -23,4 +23,3 @@ yanked = true
 
 ["3.8.0+0"]
 git-tree-sha1 = "4c31b0101997beb213a9e6c39116b052e73ca38c"
-yanked = true


### PR DESCRIPTION
Follow up to #59395.  In practice this doesn't change much because Arpack `v0.5.0` is not installable anyway, but it allows installing Arpack_jll `v3.8.0+0` if necessary.

CC: @ViralBShah @IanButterworth 