### PR TITLE
Move OpticSim.jl to a new repo

### DIFF
--- a/O/OpticSim/Package.toml
+++ b/O/OpticSim/Package.toml
@@ -1,3 +1,3 @@
 name = "OpticSim"
 uuid = "24114763-4efb-45e7-af0e-cde916beb153"
-repo = "https://github.com/microsoft/OpticSim.jl.git"
+repo = "https://github.com/brianguenter/OpticSim.jl.git"


### PR DESCRIPTION
The old repo for OpticSim.jl, https://github.com/microsoft/OpticSim.jl, will no longer be updated. We have updated the README on this repo to point to the new repo. Please move to https://github.com/brianguenter/OpticSim.jl.