### PR TITLE
Add FAQ entry about unregistered package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Packages like [PkgTemplates.jl](https://github.com/invenia/PkgTemplates.jl) or
 [PkgSkeleton.jl](https://github.com/tpapp/PkgSkeleton.jl) provide easy ways to setup
 documentation, tests, and continuous integration.
 
+#### Can my package in this registry depend on unregistered packages?
+
+No. In this registry, your package cannot depend on other packages that are
+unregistered. In addition, your package cannot depend on an unregistered
+version of an otherwise registered package. Both of these scenarios would cause
+this registry to be unreproducible.
+
 #### My pull request was not approved for automatic merging, what do I do?
 
 It is recommended that you fix the release to conform to the guidelines and


### PR DESCRIPTION
Per discussion in https://github.com/JuliaRegistries/General/pull/70373, I'm suggesting that an entry to the FAQ be added about how depending on unregistered packages or versions is not allowed in this registry.

As the Julia community gets more mature, some otherwise useful packages may not keep up with updates to work with new versions packages or Julia versions. One potential solution a dev may come up with when working on their own package is to just fork the outdated package, make the updates themselves, and then have a package depend on their new but unregistered repo/version/package, unaware that this is not allowed in this registry (for good reason). I am hoping that this FAQ entry will help prevent devs from doing this or getting frustrated when trying to perform registration actions.