### PR TITLE
changing repo name github.com/gher-ulg -> github.com/gher-uliege

### DIFF
--- a/D/DINCAE/Package.toml
+++ b/D/DINCAE/Package.toml
@@ -1,3 +1,3 @@
 name = "DINCAE"
 uuid = "0d879ee6-e5ed-4b6f-b65c-f78122b59944"
-repo = "https://github.com/gher-ulg/DINCAE.jl.git"
+repo = "https://github.com/gher-uliege/DINCAE.jl.git"

--- a/D/DIVAnd/Package.toml
+++ b/D/DIVAnd/Package.toml
@@ -1,3 +1,3 @@
 name = "DIVAnd"
 uuid = "efc8151c-67de-5a8f-9a35-d8f54746ae9d"
-repo = "https://github.com/gher-ulg/DIVAnd.jl.git"
+repo = "https://github.com/gher-uliege/DIVAnd.jl.git"

--- a/D/DIVAnd_HFRadar/Package.toml
+++ b/D/DIVAnd_HFRadar/Package.toml
@@ -1,3 +1,3 @@
 name = "DIVAnd_HFRadar"
 uuid = "7f46824f-871f-4a07-b57f-28974f6a6036"
-repo = "https://github.com/gher-ulg/DIVAnd_HFRadar.jl.git"
+repo = "https://github.com/gher-uliege/DIVAnd_HFRadar.jl.git"

--- a/P/PhysOcean/Package.toml
+++ b/P/PhysOcean/Package.toml
@@ -1,3 +1,3 @@
 name = "PhysOcean"
 uuid = "3725be50-bbbd-5592-92c3-2f0e82159c3e"
-repo = "https://github.com/gher-ulg/PhysOcean.jl.git"
+repo = "https://github.com/gher-uliege/PhysOcean.jl.git"


### PR DESCRIPTION
Our university changed its name from ULg to ULiege. We changed the name of our repo accordingly. This PR updates our repo URLs.

I am currently getting this error when registering a new release.

```
Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.
```

CC @ctroupin