### PR TITLE
MicroMamba: remove unworking patch version

### DIFF
--- a/M/MicroMamba/Versions.toml
+++ b/M/MicroMamba/Versions.toml
@@ -27,6 +27,3 @@ git-tree-sha1 = "18ae2d81035c717f9b0d92c809575266dfe73cc9"
 
 ["0.1.9"]
 git-tree-sha1 = "b49f11c4f9272fcbd66816ab8c3128d39982966c"
-
-["0.1.10"]
-git-tree-sha1 = "539c0d9ab5cc3bca6c2bfdfbf2b050d99390bf52"


### PR DESCRIPTION
This is not the ideal solution but I tried to email the maintainer to request a faster merge, but the email address on the maintainer's personal page is not deliverable. I think this should at least make things work before we hear from @cjdoris about the PR and issues. Then we can re-register v0.1.10 after @kshyatt's PR is merged.

cc @giordano if we can have a quick merge and update the registry.