### PR TITLE
yank broken `GR_jll` (windows - vscode)

### DIFF
--- a/G/GR_jll/Versions.toml
+++ b/G/GR_jll/Versions.toml
@@ -84,3 +84,4 @@ git-tree-sha1 = "bc9f7725571ddb4ab2c4bc74fa397c1c5ad08943"
 
 ["0.69.1+1"]
 git-tree-sha1 = "080c3bfabd8242f52d84425fd2ee84ae75ad789d"
+yanked = true


### PR DESCRIPTION
Per https://discourse.julialang.org/t/plots-jl-gr-jl-broken-due-to-gr-jll-v0-69-1-1/89708.