### PR TITLE
Fix AutoMerge staging

### DIFF
--- a/.github/workflows/automerge_staging.yml
+++ b/.github/workflows/automerge_staging.yml
@@ -29,10 +29,12 @@ jobs:
       - uses: julia-actions/setup-julia@0b9b1d2cd24245f151902702d8e73b3f6b910014 # v1.6.0
         with:
           version: ${{ matrix.version }}
+      # No Project/Manifest for staging run
       - run: rm -rf .ci/JuliaManifest.*.toml
       - run: rm -rf .ci/JuliaManifest.toml
       - run: rm -rf .ci/Manifest.*.toml
       - run: rm -rf .ci/Manifest.toml
+      - run: rm -rf .ci/Project.toml
       - name: Cache artifacts
         uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8 # v2.1.5
         env:


### PR DESCRIPTION
Right now, the project compat bounds it to v7, [breaking staging](https://github.com/JuliaRegistries/General/actions/runs/3440372735/jobs/5738763935). But we manually add the master branch anyway. So let's rm the project, as we already rm the manifests.