### PR TITLE
Yank GR v0.70.1

### DIFF
--- a/G/GR/Versions.toml
+++ b/G/GR/Versions.toml
@@ -174,3 +174,4 @@ git-tree-sha1 = "d8dc25c9014438bbcb0f61849397d4454e9b988a"
 
 ["0.70.1"]
 git-tree-sha1 = "3a652dbb1ebbb4a364a3be3d5b8646715c9c4852"
+yanked = true


### PR DESCRIPTION
A changed I introduced in GR v0.70.1 prevents Julia from properly opening other shared libraries. For this reason, please yank GR v0.70.1.

For details see:
https://github.com/jheinen/GR.jl/pull/500#issuecomment-1312586737

cc: @jheinen