### PR TITLE
Revert "New package: GMTAccess v0.1.0"

### DIFF
--- a/G/GMTAccess/Compat.toml
+++ b/G/GMTAccess/Compat.toml
@@ -1,4 +1,0 @@
-[0]
-BenchmarkTools = "1.2.0-1"
-Revise = "3.1.20-3"
-julia = "1.6.0-1"

--- a/G/GMTAccess/Deps.toml
+++ b/G/GMTAccess/Deps.toml
@@ -1,3 +1,0 @@
-[0]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/G/GMTAccess/Package.toml
+++ b/G/GMTAccess/Package.toml
@@ -1,3 +1,0 @@
-name = "GMTAccess"
-uuid = "4908299a-382f-4474-b696-db03060d32c1"
-repo = "https://github.com/KwatMDPhD/GMTAccess.jl.git"

--- a/G/GMTAccess/Versions.toml
+++ b/G/GMTAccess/Versions.toml
@@ -1,2 +1,0 @@
-["0.1.0"]
-git-tree-sha1 = "1ab2acd70274b7e40cae58bf3da55c1454864b0b"

--- a/Registry.toml
+++ b/Registry.toml
@@ -2482,7 +2482,6 @@ some amount of consideration when choosing package names.
 48c1b23d-d9bb-4f6d-9629-79933a599311 = { name = "SpiderMonkey", path = "S/SpiderMonkey" }
 48e2ed6f-953e-42f9-a56e-74c660f20e0a = { name = "SparseGaussianProcesses", path = "S/SparseGaussianProcesses" }
 48ea66d6-70bf-4733-809e-20017acf6e3b = { name = "NewsLookout", path = "N/NewsLookout" }
-4908299a-382f-4474-b696-db03060d32c1 = { name = "GMTAccess", path = "G/GMTAccess" }
 490da00b-a60c-4ded-a4cf-df7cded56bfa = { name = "Thunks", path = "T/Thunks" }
 491db154-c145-5abe-9c32-446728d60cce = { name = "Check_jll", path = "C/Check_jll" }
 492392ba-fc20-5d72-afbd-f61f3c69e3d5 = { name = "LinearFold_jll", path = "L/LinearFold_jll" }


### PR DESCRIPTION
Reverts JuliaRegistries/General#48280

Similar to https://github.com/JuliaRegistries/General/pull/48517
xref: https://github.com/JuliaRegistries/General/pull/72711

https://github.com/KwatMDPhD/GMTAccess.jl no longer exists.

The content consists of 

```julia
function read(pa::String)::Dict{String, Vector{String}}

    se_ge_ = Dict{String, Vector{String}}()

    for li in readlines(pa)

        sp_ = split(li, '\t')

        se = sp_[1]

        ge_ = [ge for ge in sp_[3:end] if ge != ""]

        if length(ge_) == 0

            println(se, " is empty")

        else

            se_ge_[se] = ge_

        end


    end

    return se_ge_

end

function read(pa_::Vector{String})::Dict{String, Vector{String}}

    se_ge_ = Dict{String, Vector{String}}()

    for pa in pa_

        merge!(se_ge_, read(pa))

    end

    return se_ge_

end
```

```julia
function write_txt(pa::String, se_ge_::Dict{String, Vector{String}})::Nothing

    if !endswith(pa, ".txt")

        error(pa, " is not .txt.")

    end

    open(pa, "w") do io

        for (se, ge_) in se_ge_

            write(io, string("-"^80, "\n"))

            write(io, string(se, " (", length(ge_), "):\n"))

            for ge in ge_

                write(io, string("  ", ge, "\n"))

            end

        end

    end

    return

end
```

cc: @KristofferC @StefanKarpinski @DilumAluthge