### PR TITLE
Fix the Markdown rendering of some README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,15 +244,14 @@ registry, and code cannot be deleted.
 
 #### Can my package be registered without an [OSI approved license](https://opensource.org/licenses)?
 
+
 No, sorry. The registry is maintained by volunteers, and we don't have a legal team who can thoroughly review licenses.
 It is very easy to accidentally wander into legally murky territory when combining common OSI licenses[^1] like GPL
 with non-OSI licenses and we don't want to subject Julia users to that risk when installing packages registered in General.
-See these[^2] comments[^3] for more discussion. We are not lawyers and this is not legal advice.
+See [these](https://github.com/JuliaRegistries/General/pull/31549#issuecomment-796671872) [comments](https://github.com/JuliaRegistries/General/pull/31549#issuecomment-804196208) for more discussion. We are not lawyers and this is not legal advice.
 
 [^1]: Note that even within the world of OSI licenses, there are combinations of OSI licenses which are not
 legal to use together, such as GPL2 with Apache2.
-[^2]: https://github.com/JuliaRegistries/General/pull/31549#issuecomment-796671872
-[^3]: https://github.com/JuliaRegistries/General/pull/31549#issuecomment-804196208
 
 ## Registry maintenance
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,12 @@ registry, and code cannot be deleted.
 No, sorry. The registry is maintained by volunteers, and we don't have a legal team who can thoroughly review licenses.
 It is very easy to accidentally wander into legally murky territory when combining common OSI licenses[^1] like GPL
 with non-OSI licenses and we don't want to subject Julia users to that risk when installing packages registered in General.
-See [these](https://github.com/JuliaRegistries/General/pull/31549#issuecomment-796671872) [comments]
-(https://github.com/JuliaRegistries/General/pull/31549#issuecomment-804196208) for more discussion. We are not lawyers and this is not legal advice.
+See these[^2] comments[^3] for more discussion. We are not lawyers and this is not legal advice.
 
 [^1]: Note that even within the world of OSI licenses, there are combinations of OSI licenses which are not
 legal to use together, such as GPL2 with Apache2.
+[^2]: https://github.com/JuliaRegistries/General/pull/31549#issuecomment-796671872
+[^3]: https://github.com/JuliaRegistries/General/pull/31549#issuecomment-804196208
 
 ## Registry maintenance
 


### PR DESCRIPTION
~~For some reason, the normal (inline) syntax isn't rendering correctly here. So let's switch these two links to footnotes.~~