### PR TITLE
Yank OrdinaryDiffEq v6.34.x releases

### DIFF
--- a/O/OrdinaryDiffEq/Versions.toml
+++ b/O/OrdinaryDiffEq/Versions.toml
@@ -843,9 +843,11 @@ git-tree-sha1 = "3e6e80272ae0525281e0531e766359891846a494"
 
 ["6.34.0"]
 git-tree-sha1 = "3ac675243369801ce79deaf11c3e63a87b7aa298"
+yanked = true
 
 ["6.34.1"]
 git-tree-sha1 = "c2a0484fbd99d7bb55ceb0677e57fb318bf7592c"
+yanked = true
 
 ["6.35.0"]
 git-tree-sha1 = "cfb874fa0336429cd6a057be0b1de1f125048c8c"


### PR DESCRIPTION
As planned in https://github.com/SciML/OrdinaryDiffEq.jl/pull/1806 to decouple it from DiffEqBase stuff, in order to prevent having to do this in the future. 🎉 paid that tech debt finally.