### PR TITLE
URL change: DataToolkit, http → https

### DIFF
--- a/D/DataToolkit/Package.toml
+++ b/D/DataToolkit/Package.toml
@@ -1,3 +1,3 @@
 name = "DataToolkit"
 uuid = "dc83c90b-d41d-4e55-bdb7-0fc919659999"
-repo = "http://github.com/tecosaur/DataToolkit.jl.git"
+repo = "https://github.com/tecosaur/DataToolkit.jl.git"


### PR DESCRIPTION
I tried to `@JuliaRegistrator register`, and it complained about a URL change which is probably resolved by this.