### PR TITLE
yank `1.0.2`

### DIFF
--- a/S/SnoopPrecompile/Versions.toml
+++ b/S/SnoopPrecompile/Versions.toml
@@ -6,3 +6,4 @@ git-tree-sha1 = "f604441450a3c0569830946e5b33b78c928e1a85"
 
 ["1.0.2"]
 git-tree-sha1 = "2a3e0f5f25a88dffc47fe12bcccb0ea7c34a827e"
+yanked = true


### PR DESCRIPTION
https://github.com/JuliaPlots/Plots.jl/issues/4597
https://discourse.julialang.org/t/error-precompiling-plots-recipesbase-jl-607-needs-to-be-placed-at-the-top-level-or-use-eval/91694
https://github.com/timholy/SnoopCompile.jl/issues/317
