### PR TITLE
New URL for Sinograms.jl

### DIFF
--- a/S/Sinograms/Package.toml
+++ b/S/Sinograms/Package.toml
@@ -1,3 +1,3 @@
 name = "Sinograms"
 uuid = "02a14def-c6e6-4ab0-b2df-0ab64bc8cdd7"
-repo = "https://github.com/JeffFessler/Sinograms.jl.git"
+repo = "https://github.com/JuliaImageRecon/Sinograms.jl.git"


### PR DESCRIPTION
Figured this out after hitting errors:
https://github.com/JuliaImageRecon/Sinograms.jl/commit/daecffe4157959af43b7acafef7e481cb5878d39
and finally finding this:
https://github.com/JuliaRegistries/Registrator.jl/issues/181