### PR TITLE
Update `PkgGraph` URL (renamed repo/package)

### DIFF
--- a/P/PkgGraph/Package.toml
+++ b/P/PkgGraph/Package.toml
@@ -1,3 +1,3 @@
 name = "PkgGraph"
 uuid = "f9c1b9e4-72e8-4a14-ade5-14f45fc35f11"
-repo = "https://github.com/tfiers/PkgGraph.jl.git"
+repo = "https://github.com/tfiers/PkgGraphs.jl.git"


### PR DESCRIPTION
As per https://github.com/JuliaRegistries/General#how-do-i-rename-an-existing-registered-package

In preparation of submitting a PR to register `PkgGraphs.jl`.