### PR TITLE
URL change request

### DIFF
--- a/G/GIFImages/Package.toml
+++ b/G/GIFImages/Package.toml
@@ -1,3 +1,3 @@
 name = "GIFImages"
 uuid = "7064036c-d33e-4a25-b247-cf6150d8ad81"
-repo = "https://github.com/ashwani-rathee/GIFImages.jl.git"
+repo = "https://github.com/JuliaIO/GIFImages.jl.git"


### PR DESCRIPTION
GIFImages was shifted from my account to JuliaIO, hence the update in URL
- Changed to: https://github.com/JuliaIO/GIFImages.jl.git