### PR TITLE
Renamed repository

### DIFF
--- a/A/ApproximateVI/Package.toml
+++ b/A/ApproximateVI/Package.toml
@@ -1,3 +1,3 @@
 name = "ApproximateVI"
 uuid = "e67a2193-b68a-469d-be77-24baf3975c82"
-repo = "https://github.com/ngiann/GaussianVariationalInference.jl"
+repo = "https://github.com/ngiann/GaussianVariationalInference.jl.git"

--- a/A/ApproximateVI/Package.toml
+++ b/A/ApproximateVI/Package.toml
@@ -1,3 +1,3 @@
 name = "ApproximateVI"
 uuid = "e67a2193-b68a-469d-be77-24baf3975c82"
-repo = "https://github.com/ngiann/ApproximateVI.jl.git"
+repo = "https://github.com/ngiann/GaussianVariationalInference.jl"


### PR DESCRIPTION
New URL points to renamed repository with new URL

Old URL was https://github.com/ngiann/ApproximateVI.jl

New URL is https://github.com/ngiann/GaussianVariationalInference.jl

Renamed package to be registered in pull request #76328

Sidenote: The renaming followed after a short discussion at Julia discourse, [link](https://discourse.julialang.org/t/new-package-approximatevi-jl/93454/2).