### PR TITLE
Change QSymbolics URL

### DIFF
--- a/Q/QSymbolicsBase/Package.toml
+++ b/Q/QSymbolicsBase/Package.toml
@@ -1,4 +1,4 @@
 name = "QSymbolicsBase"
 uuid = "a8697a1a-c835-4068-9491-e8abc49d0056"
-repo = "https://github.com/Krastanov/QSymbolics.jl.git"
+repo = "https://github.com/Krastanov/QuantumSymbolics.jl.git"
 subdir = "QSymbolicsBase"

--- a/Q/QSymbolicsClifford/Package.toml
+++ b/Q/QSymbolicsClifford/Package.toml
@@ -1,4 +1,4 @@
 name = "QSymbolicsClifford"
 uuid = "3bf15ae1-300d-4269-a8e5-03a020b0328d"
-repo = "https://github.com/Krastanov/QSymbolics.jl.git"
+repo = "https://github.com/Krastanov/QuantumSymbolics.jl.git"
 subdir = "QSymbolicsClifford"

--- a/Q/QSymbolicsOptics/Package.toml
+++ b/Q/QSymbolicsOptics/Package.toml
@@ -1,4 +1,4 @@
 name = "QSymbolicsOptics"
 uuid = "3c38c10f-068b-409d-8b1c-aa4375858705"
-repo = "https://github.com/Krastanov/QSymbolics.jl.git"
+repo = "https://github.com/Krastanov/QuantumSymbolics.jl.git"
 subdir = "QSymbolicsOptics"


### PR DESCRIPTION
The QSymbolicsBase, QSymbolicsClifford, and QSymbolicsOptics packages are in the same tree as QuantumSymbolics (they are dependencies of the latter).

These three packages were registered without issues but then the registration of QuantumSymbolics originally failed and required a change of name. That change of name now requires also a change of URL so that we can continue registering these packages.