### PR TITLE
Update MakieThemes.jl URLs

### DIFF
--- a/M/MakieThemes/Package.toml
+++ b/M/MakieThemes/Package.toml
@@ -1,3 +1,3 @@
 name = "MakieThemes"
 uuid = "e296ed71-da82-5faf-88ab-0034a9761098"
-repo = "https://github.com/JuliaPlots/MakieThemes.jl.git"
+repo = "https://github.com/MakieOrg/MakieThemes.jl.git"


### PR DESCRIPTION
MakieThemes was just moved to MakieOrg.