### PR TITLE
New version: OndaBatches v0.3.3

### DIFF
--- a/O/OndaBatches/Compat.toml
+++ b/O/OndaBatches/Compat.toml
@@ -1,15 +1,23 @@
 [0]
 AWS = "1.75.1-1"
-AlignedSpans = "0.2"
 DataFrames = "1.3.4-1"
-Legolas = "0.5"
-Onda = "0.15"
 StatsBase = "0.33"
 Tables = "1.7.0-1"
-TimeSpans = "0.3"
 julia = "1.7.0-1"
 
-["0-0.4.3"]
+["0-0.3"]
+AWSS3 = "0.9.8-0.10"
+Legolas = "0.3.3-0.4"
+Onda = "0.14.6-0.14"
+TimeSpans = "0.2.9-0.2"
+
+["0.4-0"]
+AlignedSpans = "0.2"
+Legolas = "0.5"
+Onda = "0.15"
+TimeSpans = "0.3"
+
+["0.4-0.4.3"]
 AWSS3 = "0.9.8-0.9"
 
 ["0.4.4-0"]

--- a/O/OndaBatches/Deps.toml
+++ b/O/OndaBatches/Deps.toml
@@ -1,7 +1,6 @@
 [0]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
-AlignedSpans = "72438786-fd5d-49ef-8843-650acbdfe662"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -11,3 +10,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TimeSpans = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+["0.4-0"]
+AlignedSpans = "72438786-fd5d-49ef-8843-650acbdfe662"

--- a/O/OndaBatches/Versions.toml
+++ b/O/OndaBatches/Versions.toml
@@ -1,3 +1,6 @@
+["0.3.3"]
+git-tree-sha1 = "114f44f2a9d417ebc91d8a04bf8f1f1db644b1d2"
+
 ["0.4.3"]
 git-tree-sha1 = "462d361d3f38060dabfe1e32949e21300c77c5f1"
 


### PR DESCRIPTION
UUID: 181bd894-5b11-491a-bec3-9b1779d96000
Repo: https://github.com/beacon-biosignals/OndaBatches.jl
Tree: 114f44f2a9d417ebc91d8a04bf8f1f1db644b1d2
Version: 0.3.3

[Registrator failed to create PR](https://github.com/beacon-biosignals/OndaBatches.jl/commit/cb0b7465becadee29046ff936a3097d28434c2af#commitcomment-100159696) (registering a backport branch from a formerly-private package, so 0.3.x does not exist in General but [0.4.x does](https://github.com/JuliaRegistries/General/pull/76789)).  I created this commit using LocalRegistry