### PR TITLE
Increase operations-per-run in autoclose action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,3 +15,4 @@ jobs:
         days-before-stale: 30
         days-before-close: 7
         delete-branch: true
+        operations-per-run: 100


### PR DESCRIPTION
We run this once a day, it should be safe to increase it from 30 to 100.