### PR TITLE
Yank AbbreviatedStackTraces v0.1.8

### DIFF
--- a/A/AbbreviatedStackTraces/Versions.toml
+++ b/A/AbbreviatedStackTraces/Versions.toml
@@ -18,3 +18,4 @@ git-tree-sha1 = "15bb7cfdeef551343a1e0b7d42636f53b6a42b5a"
 
 ["0.1.8"]
 git-tree-sha1 = "81184bfc45ad8150b955f367ccdd347247a54d0e"
+yanked = true


### PR DESCRIPTION
Completely broken due to missing import. v0.1.9 already pending merge into Registry #78832.

(Am I doing this right?)