### PR TITLE
Revert "New version: libLLVM_jll v15.0.7+1"

### DIFF
--- a/L/libLLVM_jll/Versions.toml
+++ b/L/libLLVM_jll/Versions.toml
@@ -140,6 +140,3 @@ git-tree-sha1 = "6bb49cc1e427e8a02ce5db8aaf227f29e6ff5089"
 
 ["15.0.7+0"]
 git-tree-sha1 = "77b1e65db39eb8eb6583b4d279224afdc033f629"
-
-["15.0.7+1"]
-git-tree-sha1 = "8654b35b609cca4d1d8cdad6b2b4ee4756daca50"


### PR DESCRIPTION
Reverts JuliaRegistries/General#78823.  This build is wrong and useless (it's just identical as the previous one), no one should have used it.  CC @vchuravy @gbaraldi