### PR TITLE
Yank version 0.3.1 of MLJDecisionTreeInterface

### DIFF
--- a/M/MLJDecisionTreeInterface/Versions.toml
+++ b/M/MLJDecisionTreeInterface/Versions.toml
@@ -40,6 +40,7 @@ git-tree-sha1 = "74e8076ea6f64fcb490783f2033070b18fa3466f"
 
 ["0.3.1"]
 git-tree-sha1 = "884ca62299aa9e3f7c5c19488188a9385568fb37"
+yanked = true
 
 ["0.4.0"]
 git-tree-sha1 = "8059d088428cbe215ea0eb2199a58da2d806d446"


### PR DESCRIPTION
Was unexpectedly breaking for some packages. Supplanted by 0.4 already released.