### PR TITLE
Force old FastTransforms to use FFTW <v1.6

### DIFF
--- a/F/FastTransforms/Compat.toml
+++ b/F/FastTransforms/Compat.toml
@@ -136,7 +136,7 @@ LowRankApprox = "0.2.3-0.2"
 
 ["0.6.1-0.6"]
 AbstractFFTs = "0.4-0.5"
-FFTW = ["0.3", "1"]
+FFTW = ["0.3", "1 - 1.5"]
 LowRankApprox = "0.2.3-0.4"
 
 ["0.7"]
@@ -146,7 +146,7 @@ AbstractFFTs = "0.4"
 Reexport = "0.2"
 
 ["0.7-0.14.9"]
-FFTW = "1"
+FFTW = "1 - 1.5"
 
 ["0.7-0.9.0"]
 BinaryProvider = "0.5.8-0.5"


### PR DESCRIPTION
Older versions of `FastTransforms` are incompatible with `FFTW` v1.6, so the only way to prevent these from being fetched seems to be to impose a hard compatibility bound on these and limit these to FFTW v1.5 and below.

cc @MikaelSlevinsky