### PR TITLE
Update Compat.toml for ControlSystemsMTK

### DIFF
--- a/C/ControlSystemsMTK/Compat.toml
+++ b/C/ControlSystemsMTK/Compat.toml
@@ -22,11 +22,8 @@ ModelingToolkit = "8.26.0-8"
 ["0.1.10-0"]
 MonteCarloMeasurements = "1.1.0-1"
 
-["0.1.11-0"]
+["0.1.7-0"]
 Symbolics = "5"
-
-["0.1.7-0.1.10"]
-Symbolics = "4.10.0-5"
 
 ["0.1.8-0"]
 DataInterpolations = "3.11.0-3"


### PR DESCRIPTION
Compat was declared for Symbolics v4 on a number of versions, but ControlSystemsMTK does not in fact compile with Symbolics v4 for those versions. This PR removes the compat for those versions of ControlSystemsMTK that fail to compile.