### PR TITLE
[Binutils_jll] Manually register `v2.38.0+4`

### DIFF
--- a/B/Binutils_jll/Versions.toml
+++ b/B/Binutils_jll/Versions.toml
@@ -1,5 +1,8 @@
 ["2.38.0+3"]
 git-tree-sha1 = "c2f37fd56284eb23099b367d2421ec0e00a97952"
 
+["2.38.0+4"]
+git-tree-sha1 = "ffa0762c5e00e109c88f820b3e15fca842ffa808"
+
 ["2.39.0+0"]
 git-tree-sha1 = "0f8de7667146417b724ee64179e08d24a8642ab1"


### PR DESCRIPTION
This version is useful because it has cross-compilers included.  I'm using it as a part of my BB2 rebuild.