### PR TITLE
Moands.jl transfer

### DIFF
--- a/M/Monads/Package.toml
+++ b/M/Monads/Package.toml
@@ -1,3 +1,3 @@
 name = "Monads"
 uuid = "4a446bee-a8a1-53bd-a908-d1601923a297"
-repo = "https://github.com/pao/Monads.jl.git"
+repo = "https://github.com/ulysses4ever/Monads.jl.git"


### PR DESCRIPTION
Hello! I'm one of the maintainers of Monads.jl, which is currently hosted at https://github.com/pao/Monads.jl/. The owner of that repo has disappeared long time ago. I have write permissions to that repo (that's how the latest relesase, 0.2.3, has come to be a couple years ago) but since recent changes in registration procedures I can't make new releases anymore. The reason is: I have no admin rights on that repo, and so can't add the Registrator bot. I tried to use the web UI for the Registrator but got stuck as can be seen in #79613 and #80015. From what I understand, using a bot can solve this deadlock, and the bot is just handier than web UI.


I read #25367 about package disputes but wasn't able to discern the exact procedure. I proceed as follows: I posted a request for adding the bot on the current Monads.jl repository:
- https://github.com/pao/Monads.jl/issues/23

and waited for two weeks to no avail. I think it's pretty clear at this point that the owner of the repo, @pao, is not interested in the package (again, he hasn't been active on the repo for several years). So, I kindly ask the General registry admins to step in and allow me to transfer the package.