### PR TITLE
Fix MeshCat Compat.toml

### DIFF
--- a/M/MeshCat/Compat.toml
+++ b/M/MeshCat/Compat.toml
@@ -57,7 +57,7 @@ GeometryBasics = "0.3"
 
 ["0.14.2-0"]
 GeometryBasics = "0.3-0.4"
-Rotations = "1.1"
+Rotations = "1.1.0-1"
 
 ["0.2-0.3"]
 BinDeps = "0.8.7-0.8"


### PR DESCRIPTION
This will hopefully fix https://github.com/rdeits/MeshCat.jl/issues/214

This file was manually edited by @rdeits in https://github.com/JuliaRegistries/General/pull/51753

However, based on https://github.com/JuliaLang/Pkg.jl/issues/1190 I think the wrong version format was used.

