### PR TITLE
Transfer `CatBoost.jl` repo from `beacon-biosignals` to `JuliaAI`

### DIFF
--- a/C/CatBoost/Package.toml
+++ b/C/CatBoost/Package.toml
@@ -1,3 +1,3 @@
 name = "CatBoost"
 uuid = "e2e10f9a-a85d-4fa9-b6b2-639a32100a12"
-repo = "https://github.com/beacon-biosignals/CatBoost.jl.git"
+repo = "https://github.com/JuliaAI/CatBoost.jl.git"


### PR DESCRIPTION
`CatBoost.jl` was recently transfered from [`beacon-biosignals`](https://github.com/beacon-biosignals/CatBoost.jl) to [`JuliaAI`](https://github.com/JuliaAI/CatBoost.jl). The old URL will redirect to the new repo. The full git history is present. 