### PR TITLE
Renamed GitHub organization for Coils, ElectricWires, and HeatTransferFluids

### DIFF
--- a/C/Coils/Package.toml
+++ b/C/Coils/Package.toml
@@ -1,3 +1,3 @@
 name = "Coils"
 uuid = "ab2e6513-8582-4355-97c5-84ec58029ba0"
-repo = "https://github.com/ryd-yb/Coils.jl.git"
+repo = "https://github.com/rydyb/Coils.jl.git"

--- a/E/ElectricWires/Package.toml
+++ b/E/ElectricWires/Package.toml
@@ -1,3 +1,3 @@
 name = "ElectricWires"
 uuid = "a6e744fb-b06e-4c79-977f-74d170207450"
-repo = "https://github.com/ryd-yb/ElectricWires.jl.git"
+repo = "https://github.com/rydyb/ElectricWires.jl.git"

--- a/H/HeatTransferFluids/Package.toml
+++ b/H/HeatTransferFluids/Package.toml
@@ -1,3 +1,3 @@
 name = "HeatTransferFluids"
 uuid = "44505bb3-94ea-493c-a20c-f0ca548ab76b"
-repo = "https://github.com/ryd-yb/HeatTransferFluids.jl.git"
+repo = "https://github.com/rydyb/HeatTransferFluids.jl.git"


### PR DESCRIPTION
We decided to rename our GitHub org from `ryd-yb` to `rydyb` and this PR updates the URL in our published packages.