### PR TITLE
Yank StatsBase version 0.33.22

### DIFF
--- a/S/StatsBase/Versions.toml
+++ b/S/StatsBase/Versions.toml
@@ -102,3 +102,4 @@ git-tree-sha1 = "d1bf48bfcc554a3761a133fe3a9bb01488e06916"
 
 ["0.33.22"]
 git-tree-sha1 = "9e07a3a1e7373f389c87f8fdb932667cebbfbe23"
+yanked = true


### PR DESCRIPTION
It's breaking. See e.g. https://github.com/JuliaStats/KernelDensity.jl/pull/114 and https://github.com/VaclavMacha/EvalMetrics.jl/blob/master/src/EvalMetrics.jl#L7. We should tag a 0.34.0 instead.