### PR TITLE
url change to SpeedyWeather/SpeedyWeather.jl

### DIFF
--- a/S/SpeedyWeather/Package.toml
+++ b/S/SpeedyWeather/Package.toml
@@ -1,3 +1,3 @@
 name = "SpeedyWeather"
 uuid = "9e226e20-d153-4fed-8a5b-493def4f21a9"
-repo = "https://github.com/milankl/SpeedyWeather.jl.git"
+repo = "https://github.com/SpeedyWeather/SpeedyWeather.jl.git"


### PR DESCRIPTION
this package was moved from github.com/milankl/SpeedyWeather.jl to [github.com/SpeedyWeather/SpeedyWeather.jl](https://github.com/SpeedyWeather/SpeedyWeather.jl)