### PR TITLE
Yank bad Singular_jll release

### DIFF
--- a/jll/S/Singular_jll/Versions.toml
+++ b/jll/S/Singular_jll/Versions.toml
@@ -106,3 +106,4 @@ git-tree-sha1 = "19e99fa01758a7377d9ddb9b21d897d1b8955fe4"
 
 ["403.201.202+0"]
 git-tree-sha1 = "fb9ce204c9ee218aaf2106c48a311cc34c6f75bc"
+yanked = true


### PR DESCRIPTION
Turns out this update was ABI breaking, and thus broke existing
releases of package using Singular_jll.

CC @hannes14 @thofma 