### PR TITLE
Move ResumableFunctions and SimJulia to JuliaDynamics

### DIFF
--- a/R/ResumableFunctions/Package.toml
+++ b/R/ResumableFunctions/Package.toml
@@ -1,3 +1,3 @@
 name = "ResumableFunctions"
 uuid = "c5292f4c-5179-55e1-98c5-05642aab7184"
-repo = "https://github.com/BenLauwens/ResumableFunctions.jl.git"
+repo = "https://github.com/JuliaDynamics/ResumableFunctions.jl.git"

--- a/S/SimJulia/Package.toml
+++ b/S/SimJulia/Package.toml
@@ -1,3 +1,3 @@
 name = "SimJulia"
 uuid = "428bdadb-6287-5aa5-874b-9969638295fd"
-repo = "https://github.com/BenLauwens/SimJulia.jl.git"
+repo = "https://github.com/JuliaDynamics/ConcurrentSim.jl.git"


### PR DESCRIPTION
These repositories are already transferred to JuliaDynamics. This just updates the Registry links.

Note that the SimJulia repository was also renamed. That is because the package itself is renamed and the newly named package is soon to be registered (with a different name and UUID but from the same repo).