### PR TITLE
Org rename JuliaPsychometricsBazzar => JuliaPsychometricsBazaar

### DIFF
--- a/F/FittedItemBanks/Package.toml
+++ b/F/FittedItemBanks/Package.toml
@@ -1,3 +1,3 @@
 name = "FittedItemBanks"
 uuid = "3f797b09-34e4-41d7-acf6-3302ae3248a5"
-repo = "https://github.com/JuliaPsychometricsBazzar/FittedItemBanks.jl.git"
+repo = "https://github.com/JuliaPsychometricsBazaar/FittedItemBanks.jl.git"

--- a/I/ItemResponseDatasets/Package.toml
+++ b/I/ItemResponseDatasets/Package.toml
@@ -1,3 +1,3 @@
 name = "ItemResponseDatasets"
 uuid = "e47bb625-2913-44fb-8b24-b88572ac4ea9"
-repo = "https://github.com/JuliaPsychometricsBazzar/ItemResponseDatasets.jl.git"
+repo = "https://github.com/JuliaPsychometricsBazaar/ItemResponseDatasets.jl.git"


### PR DESCRIPTION
This fixes a spelling mistake in the GitHub org name. You can confirm the rename has already been done on GitHub, e.g. https://github.com/JuliaPsychometricsBazzar/FittedItemBanks.jl.git redirects to https://github.com/JuliaPsychometricsBazaar/FittedItemBanks.jl.git