### PR TITLE
yank broken endian i SegyIO.jl v0.8.4

### DIFF
--- a/S/SegyIO/Versions.toml
+++ b/S/SegyIO/Versions.toml
@@ -24,3 +24,4 @@ git-tree-sha1 = "ecfa216e23fe8812fd4a599df8a789964e260ff6"
 
 ["0.8.4"]
 git-tree-sha1 = "b1aa1ade7c1247576c98bffc3d693f48053d85ff"
+yanked = true


### PR DESCRIPTION
This version should have not been released as it breaks the endianness of a lot of existing segy files. THis was a mistake on my side to release it too quickly.