### PR TITLE
Relax Perl_jll - Readline_jll compat

### DIFF
--- a/jll/P/Perl_jll/Compat.toml
+++ b/jll/P/Perl_jll/Compat.toml
@@ -4,5 +4,5 @@ julia = "1"
 
 ["5.34-5"]
 JLLWrappers = "1.2.0-1"
-Readline_jll = "8.1.1-8.1"
+Readline_jll = "8.1.1-8"
 julia = "1.6.0-1"


### PR DESCRIPTION
Readline does seem to follow semver, soname is `libreadline.so.8`.
I checked locally that Perl_jll built with Readline 8.1.1 works with 8.2.1 as well.

I will adjust the compat entry in Yggdrasil afterwards.

cc: @thofma @fingolfin 