### PR TITLE
Extend LocalRegistry's Julia compat to 1.10.

### DIFF
--- a/L/LocalRegistry/Compat.toml
+++ b/L/LocalRegistry/Compat.toml
@@ -18,4 +18,4 @@ julia = "1.1-1.8"
 
 ["0.5.3-0"]
 RegistryTools = "2"
-julia = "1.6-1.9"
+julia = "1.6-1.10"


### PR DESCRIPTION
LocalRegistry ties into Pkg internals and therefore sets Julia upper bounds to minor versions. This extends compat for the latest version to Julia 1.10, on the assumption that nothing dramatic will happen to Pkg between the 1.10 alpha release and the final release.