### PR TITLE
Update URL for DocumenterCitations.jl

### DIFF
--- a/D/DocumenterCitations/Package.toml
+++ b/D/DocumenterCitations/Package.toml
@@ -1,3 +1,3 @@
 name = "DocumenterCitations"
 uuid = "daee34ce-89f3-4625-b898-19384cb65244"
-repo = "https://github.com/ali-ramadhan/DocumenterCitations.jl.git"
+repo = "https://github.com/JuliaDocs/DocumenterCitations.jl.git"


### PR DESCRIPTION
Unfortunately we did not manage to transfer the repository since the original maintainer is MIA, so this right now points to a fork, see discussion in https://github.com/ali-ramadhan/DocumenterCitations.jl/pull/64.

cc @goerz @simonbyrne 