### PR TITLE
Fix poor repo naming convention for Quantikz.jl

### DIFF
--- a/Q/Quantikz/Package.toml
+++ b/Q/Quantikz/Package.toml
@@ -1,3 +1,3 @@
 name = "Quantikz"
 uuid = "b0d11df0-eea3-4d79-b4a5-421488cbf74b"
-repo = "https://github.com/QuantumSavory/Quantikz.git"
+repo = "https://github.com/QuantumSavory/Quantikz.jl.git"


### PR DESCRIPTION
Apologies for the extra manual work, this fixes a stupid old typo.