### PR TITLE
yank DataFrames.jl 1.6.0

### DIFF
--- a/D/DataFrames/Versions.toml
+++ b/D/DataFrames/Versions.toml
@@ -189,6 +189,7 @@ git-tree-sha1 = "aa51303df86f8626a962fccb878430cdb0a97eee"
 
 ["1.6.0"]
 git-tree-sha1 = "089d29c0fc00a190661517e4f3cba5dcb3fd0c08"
+yanked = true
 
 ["1.6.1"]
 git-tree-sha1 = "04c738083f29f86e62c8afc341f0967d8717bdb8"


### PR DESCRIPTION
DataFrames.jl 1.6.0 contained incomplete Project.toml specification. Now that we have DataFrames.jl 1.6.1 released we want to signal Julia package manager that DataFrames.jl 1.6.0 should not be considered when performing package version resolution.

@KristofferC, @DilumAluthge - is this the proper way to achieve this effect? Thank you!

CC @nalimilan @davidanthoff @palday