### PR TITLE
add my public registry

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -81,7 +81,10 @@ jobs:
             additional_statuses = String[],
             additional_check_runs = String[],
             check_license = true,
-            public_registries = String["https://github.com/HolyLab/HolyLabRegistry"],
+            public_registries = String[
+              "https://github.com/HolyLab/HolyLabRegistry",
+              "https://github.com/cossio/MyPublicJuliaRegistry"
+            ],
             point_to_slack = true,
           )
         shell: julia --color=yes --project=.ci/ {0}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -83,7 +83,7 @@ jobs:
             check_license = true,
             public_registries = String[
               "https://github.com/HolyLab/HolyLabRegistry",
-              "https://github.com/cossio/MyPublicJuliaRegistry"
+              "https://github.com/cossio/CossioJuliaRegistry"
             ],
             point_to_slack = true,
           )

--- a/.github/workflows/automerge_staging.yml
+++ b/.github/workflows/automerge_staging.yml
@@ -88,7 +88,7 @@ jobs:
             check_license = true,
             public_registries = String[
               "https://github.com/HolyLab/HolyLabRegistry",
-              "https://github.com/cossio/MyPublicJuliaRegistry"
+              "https://github.com/cossio/CossioJuliaRegistry"
             ],
           )
         shell: julia --color=yes --project=.ci/ {0}

--- a/.github/workflows/automerge_staging.yml
+++ b/.github/workflows/automerge_staging.yml
@@ -86,6 +86,9 @@ jobs:
             additional_statuses = String[],
             additional_check_runs = String[],
             check_license = true,
-            public_registries = String["https://github.com/HolyLab/HolyLabRegistry"],
+            public_registries = String[
+              "https://github.com/HolyLab/HolyLabRegistry",
+              "https://github.com/cossio/MyPublicJuliaRegistry"
+            ],
           )
         shell: julia --color=yes --project=.ci/ {0}


### PR DESCRIPTION
I would like to create a public registry where I will place some packages me and collaborators use in our research. In order to prevent [dependency confusion](https://github.com/JuliaLang/Pkg.jl/issues/2393), I would like to add this registry to the CI checks (as explained in https://juliaregistries.github.io/RegistryCI.jl/stable/public/#RegistryCI.AutoMerge.run).

If my understanding is correct, it suffices to list my registry under `public_registries`, as I'm doing in this PR.