### PR TITLE
Update URL for deprecated package GeoStatsPlots.jl

### DIFF
--- a/G/GeoStatsPlots/Package.toml
+++ b/G/GeoStatsPlots/Package.toml
@@ -1,3 +1,3 @@
 name = "GeoStatsPlots"
 uuid = "cf22561b-6452-4701-9483-6c69015d00e1"
-repo = "https://github.com/JuliaEarth/GeoStatsPlots.jl.git"
+repo = "https://github.com/juliohm/GeoStatsPlots.jl.git"


### PR DESCRIPTION
Appreciate if someone can review and merge. This package is no longer maintained.