### PR TITLE
Update URL for deprecated package GeoStatsViz.jl

### DIFF
--- a/G/GeoStatsViz/Package.toml
+++ b/G/GeoStatsViz/Package.toml
@@ -1,3 +1,3 @@
 name = "GeoStatsViz"
 uuid = "36492b79-4a51-4dff-89b6-31e03c9a81c2"
-repo = "https://github.com/JuliaEarth/GeoStatsViz.jl.git"
+repo = "https://github.com/juliohm/GeoStatsViz.jl.git"


### PR DESCRIPTION
Appreciate if you can review and merge. This package is no longer maintained.