### PR TITLE
Move `EasyJobsBase.jl` under main project `EasyJobs.jl`

### DIFF
--- a/E/EasyJobsBase/Package.toml
+++ b/E/EasyJobsBase/Package.toml
@@ -1,3 +1,4 @@
 name = "EasyJobsBase"
 uuid = "db8ca866-b61f-4bd1-a9b9-75c107d645d4"
-repo = "https://github.com/MineralsCloud/EasyJobsBase.jl.git"
+repo = "https://github.com/MineralsCloud/EasyJobs.jl.git"
+subdir = "EasyJobsBase"


### PR DESCRIPTION
I have referenced PR #35965 and fixed the Git tree in [`EasyJobs.jl`](https://github.com/MineralsCloud/EasyJobs.jl/commit/259a90781ab4e3435fc8b32a0a2ee2a17af08cb3).

I have checked the Git tree with the following code:

```julia
using TOML
for pkg in ["EasyJobsBase"]
    println(pkg)
    versions = TOML.parsefile(
        joinpath(first(DEPOT_PATH), "registries", "General", pkg[1:1], pkg, "Versions.toml")
    )
    for version in sort(collect(keys(versions)))
        tree_sha = versions[version]["git-tree-sha1"]
        print(version)
        try
            readchomp(`git rev-parse -q --verify "$(tree_sha)^{tree}"`)
            println(" found")
        catch
            println(" missing")
        end
    end
end
```

to make sure that every version of `EasyJobsBase.jl` can still be found even if the repository itself is archived.

<img width="560" alt="image" src="https://github.com/JuliaRegistries/General/assets/25192197/668b1786-2b20-442a-852b-ed24b8bb1326">
