### PR TITLE
Yank JLLWrappers v1.4.2

### DIFF
--- a/J/JLLWrappers/Versions.toml
+++ b/J/JLLWrappers/Versions.toml
@@ -36,3 +36,4 @@ git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
 
 ["1.4.2"]
 git-tree-sha1 = "a7e91ef94114d5bc8952bcaa8d6ff952cf709808"
+yanked = true


### PR DESCRIPTION
This needs to be v1.5.0 instead, as it introduces a deprecation warning.