### PR TITLE
Fix StaticArrays and FillArrays compat bounds for Statistics

### DIFF
--- a/F/FillArrays/Compat.toml
+++ b/F/FillArrays/Compat.toml
@@ -3,7 +3,7 @@ Compat = "0.35-2"
 julia = "0.6-1.10"
 
 ["0.12.1-0.12"]
-Statistics = "1-1.10"
+Statistics = "1-1.11"
 
 ["0.13-1"]
 Statistics = "1.6.0-1"

--- a/S/StaticArrays/Compat.toml
+++ b/S/StaticArrays/Compat.toml
@@ -1,9 +1,9 @@
 ["0-0.10"]
-Statistics = ["0.7", "1-1.10"]
+Statistics = ["0.7", "1-1.11"]
 julia = ["0.7", "1-1.10"]
 
 ["0.11"]
-Statistics = "1-1.10"
+Statistics = "1-1.11"
 julia = "1-1.10"
 
 ["0.12-0"]
@@ -11,11 +11,11 @@ Statistics = "1"
 julia = "1"
 
 ["1-1.3"]
-Statistics = "1-1.10"
+Statistics = "1-1.11"
 julia = "1-1.10"
 
 ["1.4"]
-Statistics = "1.6.0-1.10"
+Statistics = "1.6.0-1.11"
 julia = "1.6.0-1.10"
 
 ["1.5-1"]


### PR DESCRIPTION
On Julia 1.1 to 1.3, `Pkg.test` fails for these two packages as they have been marked to require Statistics 1.10 or below in accordance to their dependency on Julia 1.0 or below, but only Statistics 1.11 is registered. Registering an older Statistics version is apparently not enough to fix the problem, probably because of a resolver issue. Allow Statistics 1.11 as it works.

See https://github.com/JuliaRegistries/General/pull/89713#issuecomment-1693460400.