### PR TITLE
[ADIOS2_jll] Add explicit dependency on HDF5_jll for v2.9.0

### DIFF
--- a/jll/A/ADIOS2_jll/Compat.toml
+++ b/jll/A/ADIOS2_jll/Compat.toml
@@ -16,9 +16,11 @@ MPItrampoline_jll = "5"
 ["2.8.4-2.9.0"]
 MPItrampoline_jll = "5.0.1-5"
 
+["2.9.0"]
+HDF5_jll = "1.12"
+
 ["2-2.9.0"]
 zfp_jll = "0.5.5"
-HDF5_jll = "1.12"
 
 ["2.9.1-2"]
 HDF5_jll = "1.14"

--- a/jll/A/ADIOS2_jll/Deps.toml
+++ b/jll/A/ADIOS2_jll/Deps.toml
@@ -23,7 +23,5 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 ["2.9-2"]
 Blosc2_jll = "d43303dc-dd0e-56c6-b0a8-331f4c8c9bfb"
-SZ_jll = "409b0d58-1332-5589-be3b-4d778b0df058"
-
-["2.9.1-2"]
 HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
+SZ_jll = "409b0d58-1332-5589-be3b-4d778b0df058"


### PR DESCRIPTION
libadios2 dynamically links to HDF5 through a dependency, so we must explicitly add HDF5_jll as a dependency to make the compat bound effective.

Follow up to #91100.