### PR TITLE
transfer MicroMamba, CondaPkg and PythonCall to JuliaPy org

### DIFF
--- a/C/CondaPkg/Package.toml
+++ b/C/CondaPkg/Package.toml
@@ -1,3 +1,3 @@
 name = "CondaPkg"
 uuid = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
-repo = "https://github.com/cjdoris/CondaPkg.jl.git"
+repo = "https://github.com/JuliaPy/CondaPkg.jl.git"

--- a/M/MicroMamba/Package.toml
+++ b/M/MicroMamba/Package.toml
@@ -1,3 +1,3 @@
 name = "MicroMamba"
 uuid = "0b3b1443-0f03-428d-bdfb-f27f9c1191ea"
-repo = "https://github.com/cjdoris/MicroMamba.jl.git"
+repo = "https://github.com/JuliaPy/MicroMamba.jl.git"

--- a/P/PythonCall/Package.toml
+++ b/P/PythonCall/Package.toml
@@ -1,3 +1,3 @@
 name = "PythonCall"
 uuid = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
-repo = "https://github.com/cjdoris/PythonCall.jl.git"
+repo = "https://github.com/JuliaPy/PythonCall.jl.git"


### PR DESCRIPTION
The PythonCall stack of packages is now hosted under the JuliaPy org on github.