### PR TITLE
New version: QML v0.8.0

### DIFF
--- a/Q/QML/Compat.toml
+++ b/Q/QML/Compat.toml
@@ -17,14 +17,21 @@ CxxWrap = "0.11"
 FileIO = "1.3"
 jlqml_jll = "0.1.3-0.1"
 
+["0.7"]
+Observables = "0.4"
+
 ["0.7-0"]
 ColorTypes = "0.11"
-Observables = "0.4"
 julia = "1.6.0-1"
 
 ["0.7.0"]
 jlqml_jll = "0.2"
 
-["0.7.1-0"]
+["0.7.1-0.7"]
 CxxWrap = "0.12"
 jlqml_jll = "0.3"
+
+["0.8-0"]
+CxxWrap = "0.14"
+Observables = "0.5"
+jlqml_jll = "0.5.3-0.5"

--- a/Q/QML/Deps.toml
+++ b/Q/QML/Deps.toml
@@ -10,5 +10,8 @@ jlqml_jll = "6b5019fb-a83d-5b4e-a9f7-678a36c28df7"
 ["0-0.6"]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 
-["0.6.1-0"]
+["0.6.1-0.7"]
 Mesa_jll = "78dcde23-ec64-5e07-a917-6fe22bbc0f45"
+
+["0.8-0"]
+Qt6Wayland_jll = "e99dba38-086e-5de3-a5b1-6e4c66e897c3"

--- a/Q/QML/Package.toml
+++ b/Q/QML/Package.toml
@@ -1,3 +1,3 @@
 name = "QML"
 uuid = "2db162a6-7e43-52c3-8d84-290c1c42d82a"
-repo = "https://github.com/barche/QML.jl.git"
+repo = "https://github.com/JuliaGraphics/QML.jl.git"

--- a/Q/QML/Versions.toml
+++ b/Q/QML/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "fb1858a2f058d4a3d8c765edae0e909722d19dbf"
 
 ["0.7.1"]
 git-tree-sha1 = "9a1b2598d20817f9d6a87b00d14316a9831480f8"
+
+["0.8.0"]
+git-tree-sha1 = "8b4065aab80821daae07602de0293fa8f9a59222"


### PR DESCRIPTION
Manual PR because of the change to JuliaGraphics, created by using `LocalRegistry.jl` and manually updating the URL.