### PR TITLE
Restrict Sandbox compat a bit

### DIFF
--- a/S/Sandbox/Compat.toml
+++ b/S/Sandbox/Compat.toml
@@ -28,7 +28,7 @@ Preferences = "1.2.5-1"
 Tar_jll = "1.34.0-1"
 
 ["1.6-1"]
-UserNSSandbox_jll = "2023.3.27-2023"
+UserNSSandbox_jll = "2023.3.27-2023.7"
 
 [2]
 julia = "1.7.0-1"


### PR DESCRIPTION
UserNSSandbox_jll v2023.8.8 had backwards-incompatible changes, we need to not let older `Sandbox.jl` installations install those.