### PR TITLE
Transfer ExplainableAI.jl to Julia-XAI org

### DIFF
--- a/E/ExplainableAI/Package.toml
+++ b/E/ExplainableAI/Package.toml
@@ -1,3 +1,3 @@
 name = "ExplainableAI"
 uuid = "4f1bc3e1-d60d-4ed0-9367-9bdff9846d3b"
-repo = "https://github.com/adrhill/ExplainableAI.jl.git"
+repo = "https://github.com/Julia-XAI/ExplainableAI.jl.git"


### PR DESCRIPTION
New URL: https://github.com/Julia-XAI/ExplainableAI.jl