### PR TITLE
Change url for FunctionZeros to JuliaMath org

### DIFF
--- a/F/FunctionZeros/Package.toml
+++ b/F/FunctionZeros/Package.toml
@@ -1,3 +1,3 @@
 name = "FunctionZeros"
 uuid = "b21f74c0-b399-568f-9643-d20f4fa2c814"
-repo = "https://github.com/jlapeyre/FunctionZeros.jl.git"
+repo = "https://github.com/JuliaMath/FunctionZeros.jl.git"


### PR DESCRIPTION
I moved this repo from my GH account to JuliaMath
