### PR TITLE
[MiniZinc_jll] fix HiGHS_jll compat

### DIFF
--- a/jll/M/MiniZinc_jll/Compat.toml
+++ b/jll/M/MiniZinc_jll/Compat.toml
@@ -3,7 +3,7 @@ JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"
 
 ["2.7-2.7.4"]
-HiGHS_jll = "1.5.1-1"
+HiGHS_jll = "1.5.3"
 
 ["2.7.6-2"]
 HiGHS_jll = "1.6.0"


### PR DESCRIPTION
x-ref https://github.com/jump-dev/MiniZinc.jl/issues/48

This should have been 1.5.3. It is fixed in the Project.toml: https://github.com/JuliaBinaryWrappers/MiniZinc_jll.jl/blob/7cc3dd33d76582bc5ffc33b5dbb7ea0c2c7bed6d/Project.toml#L15