### PR TITLE
Update repo url in Project.toml file for LatticeUtilities.jl package

### DIFF
--- a/L/LatticeUtilities/Package.toml
+++ b/L/LatticeUtilities/Package.toml
@@ -1,3 +1,3 @@
 name = "LatticeUtilities"
 uuid = "33fcf0eb-3ae3-43db-bfbc-1d92a3639bd1"
-repo = "https://github.com/cohensbw/LatticeUtilities.jl.git"
+repo = "https://github.com/SmoQySuite/LatticeUtilities.jl.git"


### PR DESCRIPTION
The ownership of the repo for the LatticeUtilities.jl package been transferred from my personal github account cohensbw to the github orgnaization SmoQySuite.