### PR TITLE
Cap `RecursiveArrayToolsVersion` for existing versions of `Symbolics`

### DIFF
--- a/S/Symbolics/Compat.toml
+++ b/S/Symbolics/Compat.toml
@@ -35,6 +35,9 @@ RuntimeGeneratedFunctions = "0.4.3-0.5"
 ["0-5.5"]
 SciMLBase = "1.8.0-1"
 
+["0-5.9"]
+RecursiveArrayTools = "0.0.1-2.38"
+
 ["0.1.11-0.1.20"]
 AbstractAlgebra = "0.13-0.15"
 


### PR DESCRIPTION
This is the last piece to get  https://github.com/SciML/RecursiveArrayTools.jl/pull/287 and  https://github.com/JuliaSymbolics/Symbolics.jl/pull/997 working.