### PR TITLE
Cap DataFitting.jl compat

### DIFF
--- a/D/DataFitting/Compat.toml
+++ b/D/DataFitting/Compat.toml
@@ -1,4 +1,4 @@
 [0]
 LsqFit = "0.0.0-0.11"
 Statistics = "0.6-1"
-julia = "0.6-1"
+julia = "0.6-1 - 1.5"


### PR DESCRIPTION
I and several other people now have been stuck trying to help people who ended up with seriously out of date package versions because they installed this ancient, unmaintained package. The github link for it even 404s now: https://github.com/gcalderone/DataFitting.jl. For reproducibility reasons it should stay in the registry, but it shouldn't be installable on modern versions of julia. 

I put the limit at julia v1.5 but that was pretty arbitrary and maybe overly agressive, Open to any suggestions for where to set the compat bound. It'd be really unfortunate if we had to set it at 1.9 though.

Relevant to discussion in https://github.com/JuliaLang/Pkg.jl/issues/2194 