### PR TITLE
yank RecursiveArrayTools v2.39.0

### DIFF
--- a/R/RecursiveArrayTools/Versions.toml
+++ b/R/RecursiveArrayTools/Versions.toml
@@ -399,3 +399,4 @@ git-tree-sha1 = "d7087c013e8a496ff396bae843b1e16d9a30ede8"
 
 ["2.39.0"]
 git-tree-sha1 = "fa453b42ba1623bd2e70260bf44dac850a3430a7"
+yanked = true


### PR DESCRIPTION
This was an accidentally breaking change so it will be yanked and replaced by a version 3 (see also https://github.com/JuliaRegistries/General/pull/93498 which tried to fix this)