### PR TITLE
Yank AbstractMCMC 4.5.0

### DIFF
--- a/A/AbstractMCMC/Versions.toml
+++ b/A/AbstractMCMC/Versions.toml
@@ -117,3 +117,4 @@ git-tree-sha1 = "87e63dcb990029346b091b170252f3c416568afc"
 
 ["4.5.0"]
 git-tree-sha1 = "e7fba5aed576f624d7bdcfe47f81e4f96c0f4bda"
+yanked = true


### PR DESCRIPTION
This version contains breaking changes which were accidentally released in a non-breaking release: https://github.com/TuringLang/AbstractMCMC.jl/pull/132#issue-1959740311