### PR TITLE
Allow RegistryCI v9

### DIFF
--- a/.ci/Project.toml
+++ b/.ci/Project.toml
@@ -8,6 +8,6 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 [compat]
 GitHub = "5"
 HTTP = "0.9, 1"
-RegistryCI = "7, 8"
+RegistryCI = "7, 8, 9"
 TimeZones = "1"
 julia = "1.3"


### PR DESCRIPTION
I want to deploy https://github.com/JuliaRegistries/General/pull/94135 (which includes https://github.com/JuliaRegistries/RegistryCI.jl/pull/516). Since v9 is a breaking change, I need to first update the compat entry.

This PR does not actually deploy RegistryCI v9. That will happen in a follow-up PR to update the manifests.