### PR TITLE
change URL of RegularizedLeastSquares

### DIFF
--- a/R/RegularizedLeastSquares/Package.toml
+++ b/R/RegularizedLeastSquares/Package.toml
@@ -1,3 +1,3 @@
 name = "RegularizedLeastSquares"
 uuid = "1e9c538a-f78c-5de5-8ffb-0b6dbe892d23"
-repo = "https://github.com/tknopp/RegularizedLeastSquares.jl.git"
+repo = "https://github.com/JuliaImageRecon/RegularizedLeastSquares.jl.git"


### PR DESCRIPTION
The package RegularizedLeastSquares.jl has been moved from tknopp to JuliaImageRecon.