### PR TITLE
Update URLs for Braket.jl and PyBraket.jl

### DIFF
--- a/B/Braket/Package.toml
+++ b/B/Braket/Package.toml
@@ -1,3 +1,3 @@
 name = "Braket"
 uuid = "19504a0f-b47d-4348-9127-acc6cc69ef67"
-repo = "https://github.com/awslabs/Braket.jl.git"
+repo = "https://github.com/amazon-braket/Braket.jl.git"

--- a/P/PyBraket/Package.toml
+++ b/P/PyBraket/Package.toml
@@ -1,4 +1,4 @@
 name = "PyBraket"
 uuid = "e85266a6-1825-490b-a80e-9b9469c53660"
-repo = "https://github.com/awslabs/Braket.jl.git"
+repo = "https://github.com/amazon-braket/Braket.jl.git"
 subdir = "PyBraket"


### PR DESCRIPTION
These repos have moved from `awslabs` to `amazon-braket` on GitHub. This PR fixes the URLs in General to reflect that.