### PR TITLE
Update URL for Hyperscripts.jl

### DIFF
--- a/H/Hyperscript/Package.toml
+++ b/H/Hyperscript/Package.toml
@@ -1,3 +1,3 @@
 name = "Hyperscript"
 uuid = "47d2ed2b-36de-50cf-bf87-49c2cf4b8b91"
-repo = "https://github.com/yurivish/Hyperscript.jl.git"
+repo = "https://github.com/JuliaWeb/Hyperscript.jl.git"


### PR DESCRIPTION
Hyperscript has been moved to JuliaWeb: https://github.com/JuliaWeb/Hyperscript.jl
https://github.com/JuliaWeb/Hyperscript.jl/pull/39#issuecomment-937319593