### PR TITLE
Fix compat in ClimaCoreTempestRemap

### DIFF
--- a/C/ClimaCoreTempestRemap/Compat.toml
+++ b/C/ClimaCoreTempestRemap/Compat.toml
@@ -25,7 +25,7 @@ NCDatasets = "0.11-0.13"
 PkgVersion = "0.1-0.3"
 
 ["0.3.11-0"]
-ClimaCore = "0.10.25-0.11"
+ClimaCore = "0.11"
 
 ["0.3.3-0.3.4"]
 ClimaCore = "0.8-0.10"


### PR DESCRIPTION
ClimaCore 0.11 introduced a braking change that broke ClimaCoreTempestRemap. The correct compat is `=0.11`.