### PR TITLE
[MKL_jll] Set compat bounds for `IntelOpenMP_jll`

### DIFF
--- a/jll/M/MKL_jll/Compat.toml
+++ b/jll/M/MKL_jll/Compat.toml
@@ -1,4 +1,5 @@
 [2019-2023]
+IntelOpenMP_jll = "2018-2023"
 julia = "1"
 
 [2021-2024]
@@ -7,5 +8,6 @@ LazyArtifacts = "1"
 
 [2024]
 Artifacts = "1"
+IntelOpenMP_jll = "2024"
 Libdl = "1"
 julia = "1.6.0-1"


### PR DESCRIPTION
MKL should be used together with the corresponding version IntelOpenMP.

Fix https://github.com/JuliaMath/FFTW.jl/issues/280, fix https://github.com/JuliaMath/FFTW.jl/issues/281.