### PR TITLE
[CI] Explicitly refer to '1.9' instead of '1'

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1'
+          - '1.9'
         os:
           - ubuntu-latest
         arch:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.3.0
       - uses: julia-actions/setup-julia@58ad1cdde70774ab0693de31c3cd4e751b46aea2 # v1.9.4
         with:
-          version: '1'
+          version: '1.9'
       - run: write(ENV["GITHUB_OUTPUT"], "manifest_version=$(VERSION.major).$(VERSION.minor)")
         shell: julia --color=yes --project=.ci/ {0}
         id: manifest_version

--- a/.github/workflows/automerge_staging.yml
+++ b/.github/workflows/automerge_staging.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1'
+          - '1.9'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          # Keep this list in sync with `update_manifests.yml`.
           - '1.3'
           - '1.4'
           - '1.5'
           - '1.6'
           - '1.7'
           - '1.8'
-          # - '1.9' # TODO: uncomment this line once Julia 1.10.0 is released
-          # - '~1.10.0-0' # TODO: uncomment this line once the first Julia 1.10.0 release candidate comes out. TODO: delete this line once Julia 1.10.0 is released
-          - '1'
+          - '1.9'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -27,9 +27,7 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
-          # - '1.9' # TODO: uncomment this line once Julia 1.10.0 is released
-          # - '~1.10.0-0' # TODO: uncomment this line once the first Julia 1.10.0 release candidate comes out. TODO: delete this line once Julia 1.10.0 is released
-          - '1'
+          - '1.9'
           - 'nightly'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.3.0


### PR DESCRIPTION
CI is currently broken because Julia v1.10.0 has been released, so '1' means v1.10, but the manifest of Julia v1.10 is out-of-date, and we currently can't update manifests.

Ref: https://github.com/JuliaRegistries/General/pull/95226#issuecomment-1869790342.