### PR TITLE
[POLICY CHANGE] Allow folks to register packages useful only to a closed group

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,23 @@ documentation, tests, and continuous integration.
 Some types of packages should not be registered, or are not yet ready for registration:
 
 * The General registry is not a place for "personal packages" that consist of
-collections of "utility functions" nor for packages that are only useful for a closed group
-(like a research group or a company). For that, it is easy to set up your own registry using
+collections of "utility functions". For that, it is easy to set up your own registry using
 for example [LocalRegistry.jl](https://github.com/GunnarFarneback/LocalRegistry.jl). The
 [Pkg documentation about registries](https://pkgdocs.julialang.org/v1/registries/) might be useful
 if you decide to go this route.
 * "Empty" packages that do not yet have functionality are not ready to be registered.
+
+#### Should I register a package that is only useful to a small group of people
+
+For for packages that are only useful in a narrow domain, go ahead! Just make sure the
+pacakge name clearly indicates the domain which the package is useful for.
+
+For packages that are only useful to a closed group (like a research group, a company, 
+or a course at a specific college), please consider either making the package more 
+broadly useful or setting up your own registry, for example using
+[LocalRegistry.jl](https://github.com/GunnarFarneback/LocalRegistry.jl). However, even 
+packages only useful to a closed group may still be registered in the General registry 
+so long as their name clearly identifies the closed group the package is useful to.
 
 #### Can my package in this registry depend on unregistered packages?
 


### PR DESCRIPTION
The General registry is a source of information, not of trust. It tells Pkg where to find a package by a certain name, not whether or not a package is useful, secure, or well maintained. While some folks may use the General registry as a source of trust, I think this is mostly a lost cause as there are no code review requirements to adding a package to the registry. As such, I believe that opening registration to more folks is in line with the purpose of the General registry.

There are a few costs to registering a new package useful only to a closed group in the General registry
- Takes more time and bandwidth for folks to update their local copies if the registry
- Permanently makes a name unavailable for the whole rest of the community for all time
- Makes all visually or typographically similar names slightly less appealing due to a risk of confusion
- Makes PkgEval more noisy and costly

All these costs are minor, but also permanent, cumulative, and apply to the entire community.

There are a few benefits to registering such a package as well
- Easier to onboard new closed group members: they don't have to add a local registry. This is especially important for students less technical folks who may be following tutorials written for folks in the general community.
- Easier to maintain for the closed group: there is great tooling support for working with the general registry which is easier to utilize than setting up similar infrastructure locally
- Practically more public and open source: if an unregistered-in-General package is released publicity under an OSI approved license, but it's Project.toml depends on other public but unregistered packages, it can be difficult to install the correct dependencies without access the appropriate local registry to resolve those names. Even if a package author states that their package is only useful to a closed group, if they also grant permission for folks outside of that group to use their package, then I think it is good for us to enable folks outside that group to use their package (provided the general users outside the closed group know they are using a package designed for a closed group)
- Improves the coverage of PkgEval and therefore decreases the odds that users of unregistered packages (whether in that closed group or any other) see breaking changes in released Julia versions

Some of these costs are closed-group specific and some are community-wide.

I propose that the general registry permit the registration of packages that are only useful to a closed group, provided the package name clearly identifies the closed group the package is useful to.

This PR should not be merged without a wider community discussion.

c.f. https://github.com/JuliaRegistries/General/pull/49799, https://github.com/JuliaRegistries/General/pull/98372 which motivated this proposal.