### PR TITLE
Update Package.toml for ReactiveMP.jl

### DIFF
--- a/R/ReactiveMP/Package.toml
+++ b/R/ReactiveMP/Package.toml
@@ -1,3 +1,3 @@
 name = "ReactiveMP"
 uuid = "a194aa59-28ba-4574-a09c-4a745416d6e3"
-repo = "https://github.com/biaslab/ReactiveMP.jl.git"
+repo = "https://github.com/ReactiveBayes/ReactiveMP.jl.git"


### PR DESCRIPTION
ReactiveMP.jl package has been moved to a different organization. The new URL is https://github.com/ReactiveBayes/ReactiveMP.jl