### PR TITLE
Update Package.toml for Rocket.jl

### DIFF
--- a/R/Rocket/Package.toml
+++ b/R/Rocket/Package.toml
@@ -1,3 +1,3 @@
 name = "Rocket"
 uuid = "df971d30-c9d6-4b37-b8ff-e965b2cb3a40"
-repo = "https://github.com/biaslab/Rocket.jl.git"
+repo = "https://github.com/ReactiveBayes/Rocket.jl.git"


### PR DESCRIPTION
Rocket.jl has been moved to a different organization. The new URL is https://github.com/ReactiveBayes/Rocket.jl