### PR TITLE
Update Package.toml for RxInfer.jl

### DIFF
--- a/R/RxInfer/Package.toml
+++ b/R/RxInfer/Package.toml
@@ -1,3 +1,3 @@
 name = "RxInfer"
 uuid = "86711068-29c9-4ff7-b620-ae75d7495b3d"
-repo = "https://github.com/biaslab/RxInfer.jl.git"
+repo = "https://github.com/ReactiveBayes/RxInfer.jl.git"


### PR DESCRIPTION
RxInfer.jl has been moved to a different organization. The new URL is https://github.com/ReactiveBayes/RxInfer.jl