### PR TITLE
CI: Add workflow for author approved label

### DIFF
--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -6,11 +6,14 @@ on:
 jobs:
   label:
     permissions:
+        # We need `write` permissions on `pull-requests` in order to be able to
+        # add/remove labels from PRs. As far as we can tell, there is no narrower
+        # permission that we can use.
         pull-requests: write
     runs-on: ubuntu-latest
-    # Run on comments that are:
+    # Run on comments that are satisfy all of the following:
     # 1) on PRs, not issues,
-    # 2) not from bot users and,
+    # 2) not from bot users
     # 3) include the string "merge approved"
     # If so, we will do the work to check that the commenter is the package author,
     # and conditionally apply the author-approved label.
@@ -26,7 +29,7 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         shell: julia --compile=min --optimize=0 --color=yes {0}
         run: |
-          m = match(r"Created by: @([^\s]+)", ENV["PR_BODY"])
+          m = match(r"Created by: @([A-Za-z0-9]*+)(?:$|\n)", ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
           println("Matched user: ", m === nothing ? nothing : m[1])
           println("Commenter: ", ENV["COMMENTER"])
@@ -38,6 +41,9 @@ jobs:
         if: ${{ steps.verify-author.outputs.verified == 'true' }}
         env:
           PR_NUM: ${{ github.event.issue.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # We cannot use `${{ secrets.GITHUB_TOKEN }}` here, because
+          # if we use `GITHUB_TOKEN` here, then the "label created" event
+          # will not trigger any further GitHub Actions.
+          GH_TOKEN: ${{ secrets.TAGBOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh pr edit "$PR_NUM" --add-label "package-author-approved"

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -11,11 +11,11 @@ jobs:
     # Run on comments that are:
     # 1) on PRs, not issues,
     # 2) not from bot users and,
-    # 3) include the string "approved"
+    # 3) include the string "merge approved"
     # If so, we will do the work to check that the commenter is the package author,
     # and conditionally apply the author-approved label.
-    # note: `approved` here is case-sensitive 
-    if: ${{ github.event.issue.pull_request && github.event.issue.user.type != 'Bot' && contains(github.event.comment.body, 'approved') }}
+    # note: `merge approved` here is NOT case-sensitive, see https://docs.github.com/en/actions/learn-github-actions/expressions#contains
+    if: ${{ github.event.issue.pull_request && github.event.issue.user.type != 'Bot' && contains(github.event.comment.body, 'merge approved') }}
     steps:
       - name: Verify package author
         id: verify-author

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -46,4 +46,4 @@ jobs:
           # will not trigger any further GitHub Actions.
           GH_TOKEN: ${{ secrets.TAGBOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh pr edit "$PR_NUM" --add-label "Override AutoMerge: package author approved"
+        run: gh pr edit "${PR_NUM:?}" --add-label "Override AutoMerge: package author approved"

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -14,11 +14,12 @@ jobs:
     # Run on comments that are satisfy all of the following:
     # 1) on PRs, not issues,
     # 2) not from bot users
-    # 3) include the string "merge approved"
+    # 3) include the string "[merge approved]"
+    # 4) include the string "[noblock]"
     # If so, we will do the work to check that the commenter is the package author,
     # and conditionally apply the author-approved label.
-    # note: `merge approved` here is NOT case-sensitive, see https://docs.github.com/en/actions/learn-github-actions/expressions#contains
-    if: ${{ github.event.issue.pull_request && github.event.issue.user.type != 'Bot' && contains(github.event.comment.body, 'merge approved') }}
+    # note: `[merge approved]` here is NOT case-sensitive, see https://docs.github.com/en/actions/learn-github-actions/expressions#contains
+    if: ${{ github.event.issue.pull_request && github.event.issue.user.type != 'Bot' && contains(github.event.comment.body, '[merge approved]') }}
     steps:
       - name: Verify package author
         id: verify-author
@@ -46,4 +47,4 @@ jobs:
           # will not trigger any further GitHub Actions.
           GH_TOKEN: ${{ secrets.TAGBOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh pr edit "$PR_NUM" --add-label "package-author-approved"
+        run: gh pr edit "$PR_NUM" --add-label "Override AutoMerge: package author approved"

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -15,7 +15,6 @@ jobs:
     # 1) on PRs, not issues,
     # 2) not from bot users
     # 3) include the string "[merge approved]"
-    # 4) include the string "[noblock]"
     # If so, we will do the work to check that the commenter is the package author,
     # and conditionally apply the author-approved label.
     # note: `[merge approved]` here is NOT case-sensitive, see https://docs.github.com/en/actions/learn-github-actions/expressions#contains

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -1,0 +1,33 @@
+name: Author Approval Label
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # Run on comments that are:
+    # 1) on PRs, not issues,
+    # 2) not from bot users and,
+    # 3) include the string "approved"
+    # If so, we will do the work to check that the commenter is the package author,
+    # and conditionally apply the author-approved label.
+    if: ${{ github.event.issue.pull_request && github.event.issue.user.type != 'Bot' && contains(github.event.comment.body, 'approved') }}
+    steps:
+      - name: Verify package author
+        id: verify-author
+        env:
+          PR_BODY: ${{ github.event.issue.body }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        shell: julia --color=yes {0}
+        run: |
+          m = match(r"Created by: @([^\s]+)", ENV["PR_BODY"])
+          verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
+          open(ENV["GITHUB_OUTPUT"], "a") do io
+            println(io, "verified=$verified")
+          end
+      - name: Add label
+        if: ${{ steps.verify-author.outputs.verified == 'true' }}
+        env:
+          PR_NUM: ${{ github.event.issue.number }}
+        run: gh pr edit "$PR_NUM" --add-label "author-approved"

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -30,4 +30,6 @@ jobs:
         if: ${{ steps.verify-author.outputs.verified == 'true' }}
         env:
           PR_NUM: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh pr edit "$PR_NUM" --add-label "author-approved"

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Verify package author
         id: verify-author
         env:
+          # We use an env variable, not direct interpolation into the script, for security:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           PR_BODY: ${{ github.event.issue.body }}
           COMMENTER: ${{ github.event.comment.user.login }}
         shell: julia --color=yes {0}

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -39,4 +39,4 @@ jobs:
           PR_NUM: ${{ github.event.issue.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh pr edit "$PR_NUM" --add-label "author-approved"
+        run: gh pr edit "$PR_NUM" --add-label "package-author-approved"

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -14,6 +14,7 @@ jobs:
     # 3) include the string "approved"
     # If so, we will do the work to check that the commenter is the package author,
     # and conditionally apply the author-approved label.
+    # note: `approved` here is case-sensitive 
     if: ${{ github.event.issue.pull_request && github.event.issue.user.type != 'Bot' && contains(github.event.comment.body, 'approved') }}
     steps:
       - name: Verify package author

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   label:
+    permissions:
+        pull-requests: write
     runs-on: ubuntu-latest
     # Run on comments that are:
     # 1) on PRs, not issues,
@@ -21,10 +23,13 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           PR_BODY: ${{ github.event.issue.body }}
           COMMENTER: ${{ github.event.comment.user.login }}
-        shell: julia --color=yes {0}
+        shell: julia --compile=min --optimize=0 --color=yes {0}
         run: |
           m = match(r"Created by: @([^\s]+)", ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
+          println("Matched user: ", m === nothing ? nothing : m[1])
+          println("Commenter: ", ENV["COMMENTER"])
+          println("Verified: ", verified)
           open(ENV["GITHUB_OUTPUT"], "a") do io
             println(io, "verified=$verified")
           end


### PR DESCRIPTION
This intends to facilitate AutoMerge reading this label and bypassing some checks if the author approves. The intended use is:
1. AutoMerge would have guidelines that can be bypassed if the author approves. Without approval, these fail and the automerge comment instructs the author (well: whoever registered the version/package) to comment with "approved".
2. If the author does so, that triggers this workflow, which adds the "author-approved" label to the PR
3. The AutoMerge workflow would be updated to retrigger when this label is applied. It would run through the same logic, but this time notice the label, and use it to bypass those checks.

Currently this workflow is useless as AutoMerge does not have such conditional checks, but I wanted to put a PR to try it out.

Note that https://github.com/JuliaRegistries/RegistryCI.jl/pull/536 shows how easy it is to use label information within automerge itself, which I think makes this a viable route.

For the sake of testing, I will add text to trigger the regex:

- Created by: @ericphanson 