### PR TITLE
Fix Commits For DiagrammaticEquations Repository Refactor

### DIFF
--- a/D/DiagrammaticEquations/Versions.toml
+++ b/D/DiagrammaticEquations/Versions.toml
@@ -1,5 +1,5 @@
 ["0.0.1"]
-git-tree-sha1 = "642908a89ac58d6ce347f52a1286196433be8262"
+git-tree-sha1 = "768c15000d0eeb0a9096e0965a163055cf7c39df"
 
 ["0.1.0"]
-git-tree-sha1 = "2febd1ec47375ce1f38688535a2ca49cfd0426f3"
+git-tree-sha1 = "6a4ca76f96f9014d8bf22ca13e84d95472203bf7"


### PR DESCRIPTION
[DiagrammaticEquations.jl](https://github.com/AlgebraicJulia/DiagrammaticEquations.jl) is actually a fork of, Decapodes.jl, to extract some core functionality into a separate package. Originally the repository was created as a new repository and files copied over rather than a fork. We have completed a rebase as to maintain the original history and capture the forked nature of the project.

These git commit hashes are the updated hashes for the same commits previously released. The hashes that are currently listed no longer belong to any repository. I'm not sure how long GitHub maintains links to commits that no longer belong to a repo (my guess is 90 days).

Thank you in advance for helping me get this resolved!