### PR TITLE
New version: SuiteSparse_GPU_jll v7.5.1+0

### DIFF
--- a/jll/S/SuiteSparse_GPU_jll/Compat.toml
+++ b/jll/S/SuiteSparse_GPU_jll/Compat.toml
@@ -10,7 +10,12 @@ Artifacts = "1"
 JLLWrappers = "1.4.0-1"
 LazyArtifacts = "1"
 Libdl = "1"
-SuiteSparse_jll = "7.5.0"
 TOML = "1"
 julia = "1.11.0-1"
 libblastrampoline_jll = "5.8.0-5"
+
+["7-7.5.0"]
+SuiteSparse_jll = "7.5.0"
+
+["7.5.1-7"]
+SuiteSparse_jll = "7.5.1"

--- a/jll/S/SuiteSparse_GPU_jll/Versions.toml
+++ b/jll/S/SuiteSparse_GPU_jll/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "4da1fe00d0803e45bfe374faab271fda6dc10df6"
 
 ["7.5.0+0"]
 git-tree-sha1 = "21e0a88d303f95d79f436543ab863cfeb46af77b"
+
+["7.5.1+0"]
+git-tree-sha1 = "2ab629edfb0f5e3b6f1513c3603cf4ec0081fa33"


### PR DESCRIPTION
UUID: d273dfef-62f2-5f88-806b-f32b81b662f1
Repo: https://github.com/JuliaBinaryWrappers/SuiteSparse_GPU_jll.jl.git
Tree: 2ab629edfb0f5e3b6f1513c3603cf4ec0081fa33

Registrator tree SHA: 17aec322677d9b81cdd6b9b9236b09a3f1374c6a