### PR TITLE
SparseVariables.jl transferred to org

### DIFF
--- a/S/SparseVariables/Package.toml
+++ b/S/SparseVariables/Package.toml
@@ -1,3 +1,3 @@
 name = "SparseVariables"
 uuid = "2749762c-80ed-4b14-8f33-f0736679b02b"
-repo = "https://github.com/hellemo/SparseVariables.jl.git"
+repo = "https://github.com/sintefore/SparseVariables.jl.git"


### PR DESCRIPTION
SparseVariables.jl is transferred from private repo to the sintefore org.