### PR TITLE
Yank PETSc_jll 3.18.7+1

### DIFF
--- a/jll/P/PETSc_jll/Versions.toml
+++ b/jll/P/PETSc_jll/Versions.toml
@@ -42,6 +42,7 @@ git-tree-sha1 = "ff56ea8542aa4e931fa207d9cc7b3e1902be563e"
 
 ["3.18.7+1"]
 git-tree-sha1 = "ec25e03c463f2f0dac18ba357d2bd944f6d1a6ba"
+yanked = true
 
 ["3.18.8+0"]
 git-tree-sha1 = "d043d691c91e81ffc6a9d0405159a417f27f9764"


### PR DESCRIPTION
This build removed SuiteSparse support, which ended up breaking dependent packages because they had been built expecting SuiteSparse libraries available. This has been rebuilt as a new 3.18.8 version, so yank the broken one. See https://github.com/JuliaPackaging/Yggdrasil/pull/8004.

CC @boriskaus