### PR TITLE
[GTK4_jll] cap compat to gdk_pixbuf_jll v2.42.8

### DIFF
--- a/jll/G/GTK4_jll/Compat.toml
+++ b/jll/G/GTK4_jll/Compat.toml
@@ -10,6 +10,9 @@ Wayland_protocols_jll = "1.23.0-1"
 ["4-4.8"]
 Glib_jll = "2.68.3-2"
 
+["4-4.12.4"]
+gdk_pixbuf_jll = "2.38.2-2.42.8"
+
 ["4.10"]
 Glib_jll = "2.74.0-2"
 


### PR DESCRIPTION
Add a cap on gdk_pixbuf_jll compatibility to older versions of GTK4_jll. An upgrade of Libtiff_jll required similar caps on other packages: https://github.com/JuliaRegistries/General/pull/86099, and then an upgrade of gdk_pixbuf_jll: https://github.com/JuliaPackaging/Yggdrasil/pull/7996 uncovered a compatibility problem with GTK4_jll.

GTK4_jll didn't have Libtiff listed as a dependency before, which is why it was not capped in https://github.com/JuliaRegistries/General/pull/86099. This has now been fixed: https://github.com/JuliaPackaging/Yggdrasil/pull/8033 but we need to add this cap to previous versions so they will continue to work.