### PR TITLE
CI: Use more permissive regex in `author_approval.yml`

### DIFF
--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -29,6 +29,10 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         shell: julia --compile=min --optimize=0 --color=yes {0}
         run: |
+          isempty(ENV["COMMENTER"]) && error("COMMENTER is empty")
+          if length(ENV["COMMENTER"]) != length(strip(ENV["COMMENTER"]))
+               error("COMMENTER has leading or lagging whitespace")
+          end
           m = match(r"Created by: @(\S+)", ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
           println("Matched user: ", m === nothing ? nothing : m[1])

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -29,7 +29,7 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         shell: julia --compile=min --optimize=0 --color=yes {0}
         run: |
-          m = match(r"Created by: @([^\s]+)", ENV["PR_BODY"])
+          m = match(r"Created by: @(\S+)", ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
           println("Matched user: ", m === nothing ? nothing : m[1])
           println("Commenter: ", ENV["COMMENTER"])

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -29,7 +29,7 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         shell: julia --compile=min --optimize=0 --color=yes {0}
         run: |
-          m = match(r"Created by: @([A-Za-z0-9]*+)(?:$|\n)", ENV["PR_BODY"])
+          m = match(r"Created by: @([^\s]+)", ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
           println("Matched user: ", m === nothing ? nothing : m[1])
           println("Commenter: ", ENV["COMMENTER"])


### PR DESCRIPTION
This is the one I tested in https://github.com/ericphanson/PkgA/pull/3 and works well. I don't think we need it to be super strict, because the workflow will not add the label unless the parsed name actually matches the commenter's name.

Note there are old github names like https://github.com/artur- which are valid but many regexes won't match (bc names like that aren't allowed in new accounts).

Created by: @ericphanson 