### PR TITLE
CI: fix the `author_approval` regex, and also check that `COMMENTER` is not empty

### DIFF
--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -29,7 +29,14 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         shell: julia --compile=min --optimize=0 --color=yes {0}
         run: |
-          m = match(r"Created by: @([A-Za-z0-9]*+)(?:$|\n)", ENV["PR_BODY"])
+          if isempty(ENV["COMMENTER"])
+              error("COMMENTER is empty")
+          end
+          if length(ENV["COMMENTER"]) != length(strip(ENV["COMMENTER"]))
+              error("COMMENTER has leading or lagging whitespace")
+          end
+          regex = r"Created by: @([A-Za-z0-9]*+)(?:$|\n|\r\n)"
+          m = match(regex, ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
           println("Matched user: ", m === nothing ? nothing : m[1])
           println("Commenter: ", ENV["COMMENTER"])

--- a/.github/workflows/author_approval.yml
+++ b/.github/workflows/author_approval.yml
@@ -35,7 +35,7 @@ jobs:
           if length(ENV["COMMENTER"]) != length(strip(ENV["COMMENTER"]))
               error("COMMENTER has leading or lagging whitespace")
           end
-          regex = r"Created by: @([A-Za-z0-9]*+)(?:$|\n|\r\n)"
+          regex = r"Created by: @([A-Za-z0-9\-]*+)(?:$|\n|\r\n)"
           m = match(regex, ENV["PR_BODY"])
           verified = !isnothing(m) && m[1] == ENV["COMMENTER"]
           println("Matched user: ", m === nothing ? nothing : m[1])


### PR DESCRIPTION
The situation here is that GitHub will give `\r\n` where there are newlines (instead of just `\n`).

---

```julia
import GitHub

auth = GitHub.authenticate(ENV["MY_GITHUB_PAT"])

repo = GitHub.repo("JuliaRegistries/General"; auth)

pr = GitHub.pull_request(repo, "99707"; auth)

pr_body = pr.body

old_regex = r"Created by: @([A-Za-z0-9]*+)(?:$|\n)"
new_regex = r"Created by: @([A-Za-z0-9\-]*+)(?:$|\n|\r\n)"

match(old_regex, pr_body) # nothing
match(new_regex, pr_body) # RegexMatch("Created by: @ericphanson\r\n", 1="ericphanson")
```