### PR TITLE
Rename consistency CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Registry Consistency
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Just having it called `CI` has the potential to be confusing for people not familiar with the CI on General. It can easily happen that people confuse the passing `CI` checks with the requirements for automerging.

I hope nothing breaks because of this though, that'd be a bit ironic.