### PR TITLE
Migrate StableTasks.jl to JuliaFolds2

### DIFF
--- a/S/StableTasks/Package.toml
+++ b/S/StableTasks/Package.toml
@@ -1,3 +1,3 @@
 name = "StableTasks"
 uuid = "91464d47-22a1-43fe-8b7f-2d57ee82463f"
-repo = "https://github.com/MasonProtter/StableTasks.jl.git"
+repo = "https://github.com/JuliaFolds2/StableTasks.jl.git"


### PR DESCRIPTION
This was my package and I moved the repo to JuliaFolds2 where it better belongs.