### PR TITLE
CI: change `Registry Consistency / CI` to `Registry Consistency / check`

### DIFF
--- a/.github/workflows/registry-consistency-ci.yml
+++ b/.github/workflows/registry-consistency-ci.yml
@@ -12,7 +12,7 @@ env:
 permissions:
   contents: read
 jobs:
-  CI:
+  check:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
Follow-up to #99844, based on Mosè's idea [here](https://github.com/JuliaRegistries/General/pull/99844#issuecomment-1917457626).

It's a little annoying to do (because we have to click the "Update branch" on all currently open PRs), but we only have to do that task once, and it might be worth it to get rid of the `CI` word anywhere in this job name.