### PR TITLE
[Hypatia] move repo URL to jump-dev

### DIFF
--- a/H/Hypatia/Package.toml
+++ b/H/Hypatia/Package.toml
@@ -1,3 +1,3 @@
 name = "Hypatia"
 uuid = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
-repo = "https://github.com/chriscoey/Hypatia.jl.git"
+repo = "https://github.com/jump-dev/Hypatia.jl.git"


### PR DESCRIPTION
The package was recently moved to a new location: https://github.com/jump-dev/Hypatia.jl