### PR TITLE
Fix missing `.git` for `ThreadsX migration

### DIFF
--- a/T/ThreadsX/Package.toml
+++ b/T/ThreadsX/Package.toml
@@ -1,3 +1,3 @@
 name = "ThreadsX"
 uuid = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
-repo = "https://github.com/JuliaFolds2/ThreadsX.jl"
+repo = "https://github.com/JuliaFolds2/ThreadsX.jl.git"


### PR DESCRIPTION
Fixes error from https://github.com/JuliaRegistries/General/pull/100032