### PR TITLE
Update repo URL for VibrationalAnalysis.jl

### DIFF
--- a/V/VibrationalAnalysis/Package.toml
+++ b/V/VibrationalAnalysis/Package.toml
@@ -1,3 +1,3 @@
 name = "VibrationalAnalysis"
 uuid = "04082e5c-1d57-4577-9a0f-61e6cd56dade"
-repo = "https://github.com/galjos/VibrationalAnalysis.jl.git"
+repo = "https://github.com/MolarVerse/VibrationalAnalysis.jl.git"


### PR DESCRIPTION
The package was moved from galjos to MolarVerse.

@christopher-dG
