### PR TITLE
[OpenVAF_jll] Update LLVM compat to 16

### DIFF
--- a/jll/O/OpenVAF_jll/Compat.toml
+++ b/jll/O/OpenVAF_jll/Compat.toml
@@ -1,6 +1,6 @@
 [23]
 Artifacts = "1"
 JLLWrappers = "1.2.0-1"
-LLVM_full_jll = "15"
+LLVM_full_jll = "16"
 Libdl = "1"
 julia = "1.6.0-1"


### PR DESCRIPTION
This was changed in https://github.com/JuliaPackaging/Yggdrasil/pull/8106. The previous `+0` build was unfortunately broken.