### PR TITLE
Update link for IteratorSampling repo

### DIFF
--- a/I/IteratorSampling/Package.toml
+++ b/I/IteratorSampling/Package.toml
@@ -1,3 +1,3 @@
 name = "IteratorSampling"
 uuid = "ef79a3d2-ae9f-5cd2-ab61-e13847810a6e"
-repo = "https://github.com/Tortar/IteratorSampling.jl.git"
+repo = "https://github.com/JuliaDynamics/IteratorSampling.jl.git"


### PR DESCRIPTION
The package changed link (now is at https://github.com/JuliaDynamics/IteratorSampling.jl), and it doesn't allow to register a new version automatically because of that, could someone merge this please?