### PR TITLE
Yank KernelAbstractions 0.9.16

### DIFF
--- a/K/KernelAbstractions/Versions.toml
+++ b/K/KernelAbstractions/Versions.toml
@@ -188,6 +188,7 @@ git-tree-sha1 = "653e0824fc9ab55b3beec67a6dbbe514a65fb954"
 
 ["0.9.16"]
 git-tree-sha1 = "4e0cb2f5aad44dcfdc91088e85dee4ecb22c791c"
+yanked = true
 
 ["0.9.17"]
 git-tree-sha1 = "c7753cc3febe006708ce6798482004241f7d890b"


### PR DESCRIPTION
Reverts https://github.com/JuliaGPU/KernelAbstractions.jl/pull/446 since that allowed for miscompilation on the CPU backend and yanks the corresponding release.