### PR TITLE
Update URL for Mango.jl in Package.toml

### DIFF
--- a/M/Mango/Package.toml
+++ b/M/Mango/Package.toml
@@ -1,3 +1,3 @@
 name = "Mango"
 uuid = "5e49fdec-d473-4d14-b295-7bff2fcf1925"
-repo = "https://gitlab.com/mango-agents/Mango.jl.git"
+repo = "https://github.com/OFFIS-DAI/Mango.jl.git"


### PR DESCRIPTION
We moved our Julia Package Mango.jl to GitHub, so we would like to change the URL now to be able to keep creating releases.

If you want to verify it, you may look at the old URL https://gitlab.com/mango-agents/Mango.jl, where we inserted a reference to the new location on github (right, below Project information).

Many thanks for considering my request. :)