### PR TITLE
Update URL for KomaMRI package

### DIFF
--- a/K/KomaMRI/Package.toml
+++ b/K/KomaMRI/Package.toml
@@ -1,3 +1,3 @@
 name = "KomaMRI"
 uuid = "6a340f8b-2cdf-4c04-99be-4953d9b66d0a"
-repo = "https://github.com/cncastillo/KomaMRI.jl.git"
+repo = "https://github.com/JuliaHealth/KomaMRI.jl.git"

--- a/K/KomaMRIBase/Package.toml
+++ b/K/KomaMRIBase/Package.toml
@@ -1,4 +1,4 @@
 name = "KomaMRIBase"
 uuid = "d0bc0b20-b151-4d03-b2a4-6ca51751cb9c"
-repo = "https://github.com/cncastillo/KomaMRI.jl.git"
+repo = "https://github.com/JuliaHealth/KomaMRI.jl.git"
 subdir = "KomaMRIBase"

--- a/K/KomaMRICore/Package.toml
+++ b/K/KomaMRICore/Package.toml
@@ -1,4 +1,4 @@
 name = "KomaMRICore"
 uuid = "4baa4f4d-2ae9-40db-8331-a7d1080e3f4e"
-repo = "https://github.com/cncastillo/KomaMRI.jl.git"
+repo = "https://github.com/JuliaHealth/KomaMRI.jl.git"
 subdir = "KomaMRICore"

--- a/K/KomaMRIFiles/Package.toml
+++ b/K/KomaMRIFiles/Package.toml
@@ -1,4 +1,4 @@
 name = "KomaMRIFiles"
 uuid = "fcf631a6-1c7e-4e88-9e64-b8888386d9dc"
-repo = "https://github.com/cncastillo/KomaMRI.jl.git"
+repo = "https://github.com/JuliaHealth/KomaMRI.jl.git"
 subdir = "KomaMRIFiles"

--- a/K/KomaMRIPlots/Package.toml
+++ b/K/KomaMRIPlots/Package.toml
@@ -1,4 +1,4 @@
 name = "KomaMRIPlots"
 uuid = "76db0263-63f3-4d26-bb9a-5dba378db904"
-repo = "https://github.com/cncastillo/KomaMRI.jl.git"
+repo = "https://github.com/JuliaHealth/KomaMRI.jl.git"
 subdir = "KomaMRIPlots"


### PR DESCRIPTION
We transfer the KomaMRI package to an organization so we made the repo URL path changes.