### PR TITLE
New version: zed_jll v1.14.0+0

### DIFF
--- a/jll/Z/zed_jll/Compat.toml
+++ b/jll/Z/zed_jll/Compat.toml
@@ -1,3 +1,7 @@
 [1]
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"
+
+["1.14-1"]
+Artifacts = "1"
+Libdl = "1"

--- a/jll/Z/zed_jll/Deps.toml
+++ b/jll/Z/zed_jll/Deps.toml
@@ -2,4 +2,6 @@
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+["1-1.2"]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/jll/Z/zed_jll/Versions.toml
+++ b/jll/Z/zed_jll/Versions.toml
@@ -1,2 +1,5 @@
 ["1.2.0+0"]
 git-tree-sha1 = "72f73a27b4454a06c462e15ecf1231c9ec0820ca"
+
+["1.14.0+0"]
+git-tree-sha1 = "ab6abdeaaa48df5aa9e340830daad5744cca3c73"


### PR DESCRIPTION
UUID: a2fbc99b-683d-5036-9e5b-937a48409984
Repo: https://github.com/JuliaBinaryWrappers/zed_jll.jl.git
Tree: ab6abdeaaa48df5aa9e340830daad5744cca3c73

Registrator tree SHA: 191228b6dd8b9d0e2965ae3e705fe54c51dcfee8