### PR TITLE
Yank DiskArrays 0.4.0

### DIFF
--- a/D/DiskArrays/Versions.toml
+++ b/D/DiskArrays/Versions.toml
@@ -120,6 +120,7 @@ git-tree-sha1 = "ef25c513cad08d7ebbed158c91768ae32f308336"
 
 ["0.4.0"]
 git-tree-sha1 = "941468c36c6aa48d2a6ddcc19030d70633c3941f"
+yanked = true
 
 ["0.4.1"]
 git-tree-sha1 = "2c8625436894796a38d1fa040d1ab087c869071d"


### PR DESCRIPTION
The compat entries about the minimum required Julia version for Diskarrays 0.4.0 were not correct.  