### PR TITLE
[FastAlmostBandedMatrices] Repository Transferred to Org

### DIFF
--- a/F/FastAlmostBandedMatrices/Package.toml
+++ b/F/FastAlmostBandedMatrices/Package.toml
@@ -1,3 +1,3 @@
 name = "FastAlmostBandedMatrices"
 uuid = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
-repo = "https://github.com/avik-pal/FastAlmostBandedMatrices.jl.git"
+repo = "https://github.com/SciML/FastAlmostBandedMatrices.jl.git"


### PR DESCRIPTION
New location https://github.com/SciML/FastAlmostBandedMatrices.jl