### PR TITLE
New version: Xpress_jll v8.13.4

### DIFF
--- a/jll/X/Xpress_jll/Compat.toml
+++ b/jll/X/Xpress_jll/Compat.toml
@@ -1,4 +1,4 @@
-[9]
+[8-9]
 Artifacts = "1"
 JLLWrappers = "1.2.0-1"
 Libdl = ["0.0.0", "1"]

--- a/jll/X/Xpress_jll/Deps.toml
+++ b/jll/X/Xpress_jll/Deps.toml
@@ -1,4 +1,4 @@
-[9]
+[8-9]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/jll/X/Xpress_jll/Versions.toml
+++ b/jll/X/Xpress_jll/Versions.toml
@@ -1,2 +1,5 @@
+["8.13.4"]
+git-tree-sha1 = "0353f5f1576bd97b4e6cf45e5620df52dd2c6cae"
+
 ["9.3.0"]
 git-tree-sha1 = "11bfe0157dde8ff717d6b55a9d63e6443c6a8677"


### PR DESCRIPTION
Registrator complained at me: https://github.com/jump-dev/Xpress_jll.jl/commit/61999cc27a96e2c7a0d23040a889a6b067e7bf03#commitcomment-140228985
so this is a manual attempt at registering an old version.

The relevant commit is:
```
commit 61999cc27a96e2c7a0d23040a889a6b067e7bf03
tree 0353f5f1576bd97b4e6cf45e5620df52dd2c6cae
parent cf612c4dc11d2383455e9b8a99669be896cd0ecf
author odow <o.dowson@gmail.com> 1711425253 +1300
committer odow <o.dowson@gmail.com> 1711425636 +1300

    Add v8.13.4
```