### PR TITLE
New package: InPartSObstacles v0.1.6

### DIFF
--- a/I/InPartSObstacles/Compat.toml
+++ b/I/InPartSObstacles/Compat.toml
@@ -1,0 +1,3 @@
+[0]
+InPartS = "0.4-0.6"
+StaticArrays = "1"

--- a/I/InPartSObstacles/Deps.toml
+++ b/I/InPartSObstacles/Deps.toml
@@ -1,0 +1,4 @@
+[0]
+InPartS = "f768f48f-0d8a-415b-80aa-7de5ff9b8474"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/I/InPartSObstacles/Package.toml
+++ b/I/InPartSObstacles/Package.toml
@@ -1,0 +1,3 @@
+name = "InPartSObstacles"
+uuid = "4110d2ad-ee24-4968-96bf-19205974a08d"
+repo = "https://gitlab.gwdg.de/eDLS/InPartS-models/inpartsobstacles"

--- a/I/InPartSObstacles/Versions.toml
+++ b/I/InPartSObstacles/Versions.toml
@@ -1,0 +1,2 @@
+["0.1.6"]
+git-tree-sha1 = "68fba66ddc1a13a48ff904c951bb3cb7b7322faa"

--- a/Registry.toml
+++ b/Registry.toml
@@ -2764,6 +2764,7 @@ some amount of consideration when choosing package names.
 40e66cde-538c-5869-a4ad-c39174c6795b = { name = "LDLFactorizations", path = "L/LDLFactorizations" }
 40eb83ae-c93a-480c-8f39-f018b568f472 = { name = "AppBundler", path = "A/AppBundler" }
 410a4b4d-49e4-4fbc-ab6d-cb71b17b3775 = { name = "Tricks", path = "T/Tricks" }
+4110d2ad-ee24-4968-96bf-19205974a08d = { name = "InPartSObstacles", path = "I/InPartSObstacles" }
 411431e0-e8b7-467b-b5e0-f676ba4f2910 = { name = "Extents", path = "E/Extents" }
 41177cfe-c387-11e9-2806-edd030e4594e = { name = "MaxPlus", path = "M/MaxPlus" }
 411c8731-a39f-4a7d-8b26-fcc9fee4eb7b = { name = "Adjacently", path = "A/Adjacently" }


### PR DESCRIPTION
- Registering package: InPartSObstacles
- Repository: https://gitlab.gwdg.de/eDLS/InPartS-models/inpartsobstacles
- Version: v0.1.6
- Commit: 093eabf91a62307fc20d25d19bdc70eabd4262fc
- Description: 

*This PR was created using LocalRegistry.jl and a hacky GitLab CI script. If nothing went wrong, it should be similar to a Registrator-generated PR.
I am a machine user 🤖 and I’m currently controlled by @lhupe @philbit and @JonasIsensee.*
