### PR TITLE
[XZ_jll] Yank compromised versions

### DIFF
--- a/jll/X/XZ_jll/Versions.toml
+++ b/jll/X/XZ_jll/Versions.toml
@@ -42,6 +42,8 @@ git-tree-sha1 = "ac88fb95ae6447c8dda6a5503f3bafd496ae8632"
 
 ["5.6.0+0"]
 git-tree-sha1 = "37195dcb94a5970397ad425b95a9a26d0befce3a"
+yanked = true
 
 ["5.6.1+0"]
 git-tree-sha1 = "31c421e5516a6248dfb22c194519e37effbf1f30"
+yanked = true


### PR DESCRIPTION
It was reported builds of XZ v5.6.0 and v5.6.1 from release tarballs were compromised due to a backdoor: https://www.openwall.com/lists/oss-security/2024/03/29/4.