### PR TITLE
New version: coreutils_jll v9.5.0+0

### DIFF
--- a/jll/C/coreutils_jll/Compat.toml
+++ b/jll/C/coreutils_jll/Compat.toml
@@ -4,3 +4,7 @@ julia = "1"
 [9]
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"
+
+["9.5-9"]
+Artifacts = "1"
+Libdl = "1"

--- a/jll/C/coreutils_jll/Deps.toml
+++ b/jll/C/coreutils_jll/Deps.toml
@@ -1,5 +1,7 @@
 [8-9]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+["8-9.1"]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [9]

--- a/jll/C/coreutils_jll/Versions.toml
+++ b/jll/C/coreutils_jll/Versions.toml
@@ -6,3 +6,6 @@ git-tree-sha1 = "ae56b3e014f5b279392a11425677436b71f93a42"
 
 ["9.1.0+0"]
 git-tree-sha1 = "018e29a17a59dbdf5bfc1625a24ee71bd9e23e8e"
+
+["9.5.0+0"]
+git-tree-sha1 = "995414cb1dabd65a710f93184faf0a916daf71b7"


### PR DESCRIPTION
UUID: 5818bda4-868b-5068-b238-e370ed6eefef
Repo: https://github.com/JuliaBinaryWrappers/coreutils_jll.jl.git
Tree: 995414cb1dabd65a710f93184faf0a916daf71b7

Registrator tree SHA: 191228b6dd8b9d0e2965ae3e705fe54c51dcfee8