### PR TITLE
[MultiHashParsing.jl] update repo URL

### DIFF
--- a/M/MultiHashParsing/Package.toml
+++ b/M/MultiHashParsing/Package.toml
@@ -1,4 +1,4 @@
 name = "MultiHashParsing"
 uuid = "73786568-6863-756d-6873-6168796e616d"
-repo = "https://github.com/JuliaPackaging/BB2.jl.git"
+repo = "https://github.com/JuliaPackaging/BinaryBuilder2.jl.git"
 subdir = "MultiHashParsing.jl"


### PR DESCRIPTION
The `BB2.jl` repository was renamed to `BinaryBuilder2.jl` for clarity.