### PR TITLE
New package: InPartSMakie v0.1.12

### DIFF
--- a/I/InPartSMakie/Compat.toml
+++ b/I/InPartSMakie/Compat.toml
@@ -1,0 +1,9 @@
+[0]
+Colors = "0.12"
+CoordinateTransformations = "0.6"
+GeometryBasics = "0.4"
+InPartS = "0.4.0-0.6"
+InPartSObstacles = "0.1"
+Makie = "0.20.1-0.20"
+Requires = "1"
+Rotations = "1"

--- a/I/InPartSMakie/Deps.toml
+++ b/I/InPartSMakie/Deps.toml
@@ -1,0 +1,10 @@
+[0]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+InPartS = "f768f48f-0d8a-415b-80aa-7de5ff9b8474"
+InPartSObstacles = "4110d2ad-ee24-4968-96bf-19205974a08d"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"

--- a/I/InPartSMakie/Package.toml
+++ b/I/InPartSMakie/Package.toml
@@ -1,0 +1,3 @@
+name = "InPartSMakie"
+uuid = "6a17de3e-552d-46b5-89f5-35afbcb8c2d5"
+repo = "https://gitlab.gwdg.de/eDLS/inpartsmakie.jl"

--- a/I/InPartSMakie/Versions.toml
+++ b/I/InPartSMakie/Versions.toml
@@ -1,0 +1,2 @@
+["0.1.12"]
+git-tree-sha1 = "dfb25ec322f0b1237da730c6db4740f5507b43e4"

--- a/Registry.toml
+++ b/Registry.toml
@@ -4465,6 +4465,7 @@ some amount of consideration when choosing package names.
 69f646f0-5709-4f35-9e52-1656edff0883 = { name = "NbodyGradient", path = "N/NbodyGradient" }
 6a04ffb7-1155-443c-92eb-f1f26f00354c = { name = "SpatioTemporalTraits", path = "S/SpatioTemporalTraits" }
 6a1430e4-294a-53a5-a485-ec66ef6b843c = { name = "Leptonica_jll", path = "jll/L/Leptonica_jll" }
+6a17de3e-552d-46b5-89f5-35afbcb8c2d5 = { name = "InPartSMakie", path = "I/InPartSMakie" }
 6a1efff9-a015-4b29-891c-e02fc6e36f20 = { name = "TipiSDP", path = "T/TipiSDP" }
 6a2ea274-3061-11ea-0d63-ff850051a295 = { name = "Torch", path = "T/Torch" }
 6a31a4e8-6e70-5a2d-b005-bc2d500d80a5 = { name = "Expect", path = "E/Expect" }


### PR DESCRIPTION
- Registering package: InPartSMakie
- Repository: https://gitlab.gwdg.de/eDLS/inpartsmakie.jl
- Version: v0.1.12
- Commit: 70cf9eead0642e880cc17187fc5575309a60fab0
- Description: Makie visualsation for InPartS

*This PR was created using LocalRegistry.jl and a hacky GitLab CI script. If nothing went wrong, it should be similar to a Registrator-generated PR.
I am a machine user 🤖 and I’m currently controlled by @lhupe @philbit and @JonasIsensee.*
