### PR TITLE
Cap old JET.jl versions to Julia < 1.11, and cap all JET.jl versions to LoweredCodeUtils < v2.4

### DIFF
--- a/J/JET/Compat.toml
+++ b/J/JET/Compat.toml
@@ -1,5 +1,5 @@
 ["0.0"]
-julia = "1"
+julia = "1-1.10"
 
 ["0.1"]
 LoweredCodeUtils = "1.2.4-1"
@@ -17,7 +17,7 @@ Revise = "3.1.14-3"
 julia = "1.6"
 
 ["0.2"]
-LoweredCodeUtils = "2"
+LoweredCodeUtils = "2-2.3"
 
 ["0.2.1-0.5.3"]
 Revise = "3.1.15-3"
@@ -27,23 +27,23 @@ JuliaInterpreter = "0.8.16-0.8"
 LoweredCodeUtils = "2.1"
 
 ["0.5-0.6.1"]
-julia = "1.7.0-1"
+julia = "1.7.0-1.10"
 
 ["0.5.4-0"]
 JuliaInterpreter = "0.9"
 Revise = "3.3.0-3"
 
 ["0.5.4-0.8.22"]
-LoweredCodeUtils = "2.2.0-2"
+LoweredCodeUtils = "2.2.0-2.3"
 
 ["0.6.16-0.6.20"]
 julia = "1.8.1-1.8.3"
 
 ["0.6.2-0.6.15"]
-julia = "1.8.0-1"
+julia = "1.8.0-1.10"
 
 ["0.6.21-0.7.14"]
-julia = "1.8.1-1"
+julia = "1.8.1-1.10"
 
 ["0.7.11-0.7.13"]
 Preferences = "1.3.0-1"
@@ -55,7 +55,7 @@ PrecompileTools = "1"
 Preferences = "1.4.0-1"
 
 ["0.7.15-0.8.21"]
-julia = "1.9.0-1"
+julia = "1.9.0-1.10"
 
 ["0.7.2-0.7.11"]
 SnoopPrecompile = "1"
@@ -69,7 +69,12 @@ Test = "1.9.0-1"
 InteractiveUtils = "1.10.0-1"
 Pkg = "1.10.0-1"
 Test = "1.10.0-1"
-julia = "1.10.0-1"
+
+["0.8.22-0.8.27"]
+julia = "1.10"
 
 ["0.8.23-0"]
 LoweredCodeUtils = "2.2-2.3"
+
+["0.8.28-0"]
+julia = "1.10.0-1"


### PR DESCRIPTION
Fixes #104585

This PR applies the following retroactive caps:
1. All versions of JET.jl prior to JET v0.8.28 are capped to Julia < 1.11.0.
2. All versions of JET.jl are capped to LoweredCodeUtils < 2.3.

## Script to generate this PR

<details>

<summary>
Here is the script I used to generate this PR: (click to expand)
</summary>

```julia
import Pkg
import RegistryTools

# Note: this script uses a lot of non-public internals, such as
# `Pkg.Versions.semver_spec`.

JET_package_path = "./J/JET"

JET_compat_filename = joinpath(abspath(JET_package_path), "Compat.toml")
JET_compat_dict = RegistryTools.Compress.load(JET_compat_filename)

JET_deps_dict = RegistryTools.Compress.load(joinpath(abspath(JET_package_path), "Deps.toml"))

deps_to_first_good_JET_version = Dict(
    "julia" => v"0.8.28",
    "LoweredCodeUtils" => v"∞",
)

deps_to_cap = Dict(
    "julia" => only(Pkg.Versions.semver_spec("< 1.11.0").ranges),
    "LoweredCodeUtils" => only(Pkg.Versions.semver_spec("< 2.4.0").ranges),
)

for (ver, info) in pairs(JET_compat_dict)
    for (dep, first_good_JET_version) in pairs(deps_to_first_good_JET_version)
        dep_is_julia = dep == "julia"
        this_ver_has_this_dep = haskey(get(JET_deps_dict, ver, Dict()), dep)
        if dep_is_julia || this_ver_has_this_dep
            if ver < first_good_JET_version
                old_compat_str = info[dep]
                old_compat_r = Pkg.Versions.VersionRange(old_compat_str)
                cap_to_add = deps_to_cap[dep]
                new_compat_r = intersect(old_compat_r, cap_to_add)
                new_compat_str = string(new_compat_r)

                # Now we mutate the `info` dict (and thus the `JET_compat_dict`
                # dict) with our new `[compat]` string.
                info[dep] = new_compat_str

                @info "" ver dep old=old_compat_str new=info[dep]
            end
        else
            @warn "JET.jl v$(ver) does not directly depend on $(dep)"
        end
    end
end

# Now we write our modified `JET_compat_dict` file back to the `Compat.toml`
# file.
RegistryTools.Compress.save(JET_compat_filename, JET_compat_dict)
```

</details>

<details>

<summary>
I ran the script with the following Julia version and RegistryTools version: (click to expand)
</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.2 (2024-03-01)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.10) pkg> st
Status `~/.julia/environments/v1.10/Project.toml`
  [d1eb7eb1] RegistryTools v2.2.3
```

</details>