### PR TITLE
Move GeometryOps.jl to JuliaGeo

### DIFF
--- a/G/GeometryOps/Package.toml
+++ b/G/GeometryOps/Package.toml
@@ -1,3 +1,3 @@
 name = "GeometryOps"
 uuid = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"
-repo = "https://github.com/asinghvi17/GeometryOps.jl.git"
+repo = "https://github.com/JuliaGeo/GeometryOps.jl.git"


### PR DESCRIPTION
I just moved the GeometryOps.jl repo to JuliaGeo, this PR updates the URL in the registry.  No other changes were made.