### PR TITLE
Update URL for DirectedAcyclicGraphs

### DIFF
--- a/D/DirectedAcyclicGraphs/Package.toml
+++ b/D/DirectedAcyclicGraphs/Package.toml
@@ -1,3 +1,3 @@
 name = "DirectedAcyclicGraphs"
 uuid = "1e6dae5e-d6e2-422d-9af3-452e7a3785ee"
-repo = "https://github.com/Juice-jl/DirectedAcyclicGraphs.jl.git"
+repo = "https://github.com/Tractables/DirectedAcyclicGraphs.jl.git"


### PR DESCRIPTION
The URL currently points to a GitHub organization called Juice-jl which no longer exists. The package now resides in an organization called Tractables.

cc @khosravipasha, @guyvdbroeck