### PR TITLE
Change `IteratorSampling` url for renaming to `StreamSampling`

### DIFF
--- a/I/IteratorSampling/Package.toml
+++ b/I/IteratorSampling/Package.toml
@@ -1,3 +1,3 @@
 name = "IteratorSampling"
 uuid = "ef79a3d2-ae9f-5cd2-ab61-e13847810a6e"
-repo = "https://github.com/JuliaDynamics/IteratorSampling.jl.git"
+repo = "https://github.com/JuliaDynamics/StreamSampling.jl.git"


### PR DESCRIPTION
I'd like to change the name of the package from `IteratorSampling` to `StreamSampling` (repo: https://github.com/JuliaDynamics/StreamSampling.jl) because it better reflects its purpose. I have read at https://github.com/JuliaRegistries/General?tab=readme-ov-file#how-do-i-rename-an-existing-registered-package that this is the first step to do before registering it with the new name.  