### PR TITLE
Changing URL for HorizonsAPI

### DIFF
--- a/H/HorizonsAPI/Package.toml
+++ b/H/HorizonsAPI/Package.toml
@@ -1,3 +1,4 @@
 name = "HorizonsAPI"
 uuid = "c15253bb-5e94-4b8b-9a02-579bb6c8e3ce"
-repo = "https://github.com/cadojo/HorizonsAPI.jl.git"
+repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+subdir = "lib/HorizonsAPI"


### PR DESCRIPTION
I have moved this package to the `EphemerisSources.jl` repository.