### PR TITLE
MozillaCACerts_jll: allow stdlibs with version 0.0.0

### DIFF
--- a/jll/M/MozillaCACerts_jll/Compat.toml
+++ b/jll/M/MozillaCACerts_jll/Compat.toml
@@ -8,6 +8,6 @@ JLLWrappers = "1.1.0-1"
 JLLWrappers = "1.2.0-1"
 
 ["2023.12-2024"]
-Artifacts = "1"
-Libdl = "1"
-Pkg = "1"
+Artifacts = ["0.0.0", "1"]
+Libdl = ["0.0.0", "1"]
+Pkg = ["0.0.0", "1"]


### PR DESCRIPTION
See https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/1324 for more discussion.

See https://github.com/JuliaRegistries/RegistryCI.jl/pull/557 (for example, [this CI log](https://github.com/JuliaRegistries/RegistryCI.jl/actions/runs/8869626132/job/24350502653?pr=557)) for an example breakage.

---

<details>

<summary>
I used the following Julia code to generate this PR: (click to expand)
</summary>

```julia
import Pkg
import RegistryTools
import TOML

const Compress = RegistryTools.Compress

function _read_registry_toml(; registry_root::AbstractString)
    registry_toml_filename = joinpath(registry_root, "Registry.toml")
    registry_toml_dict = TOML.parsefile(registry_toml_filename)
    return registry_toml_dict
end

function _pkgname_to_pkguuidstr(; pkgnamestr::AbstractString, registry_root::AbstractString)
    registry_toml_dict = _read_registry_toml(; registry_root)
    a = filter(pair -> pair[2]["name"] == pkgnamestr, registry_toml_dict["packages"])
    b = only(a)
    found_name_str = b[2]["name"]
    if found_name_str != pkgnamestr
        error("Expected name $(pkgnamestr), found name $(found_name_str)")
    end
    pkguuidstr = b[1]
    return pkguuidstr
end

function _get_pkgpath(; pkgnamestr::AbstractString, registry_root::AbstractString)
    pkguuidstr = _pkgname_to_pkguuidstr(; pkgnamestr, registry_root)
    registry_toml_dict = _read_registry_toml(; registry_root)
    _pkgrelpath = registry_toml_dict["packages"][pkguuidstr]["path"]
    pkgpath = joinpath(registry_root, _pkgrelpath)
    return pkgpath
end

function _is_stdlib_name(namestr::AbstractString)
    list = sort(unique([x[1] for x in values(Pkg.Types.stdlibs())]))
    return namestr in list
end

function _parse_versionranges_from_registry(range_str::AbstractString)
    ranges_r = [Pkg.Types.VersionRange(range_str)]
    ranges_r::Vector{Pkg.Types.VersionRange}
    return ranges_r
end

function _parse_versionranges_from_registry(ranges_str::AbstractVector{<:AbstractString})
    ranges_r = Pkg.Types.VersionRange.(ranges_str)
    ranges_r::Vector{Pkg.Types.VersionRange}
    return ranges_r
end

function _print_versionranges_to_registry(ranges_r::AbstractVector{Pkg.Types.VersionRange})
    if length(ranges_r) == 0
        error("Did not expect ranges_r to have length 0")
    end
    if length(ranges_r) == 1
        return string(Pkg.Types.VersionSpec(ranges_r))
    end
    return string.(ranges_r)
end

function _patchup_compat_dict!(compat_dict::AbstractDict)
    for (_, info) in pairs(compat_dict)
        # for (namestr, old_ranges_str) in pairs(info)
        for namestr in keys(info)
            old_ranges_str = info[namestr]
            old_ranges_r = _parse_versionranges_from_registry(old_ranges_str)
            if _is_stdlib_name(namestr)
                ranges_to_add_r = [only(Pkg.Types.semver_spec("< 0.0.1").ranges)]
                new_ranges_r = vcat(ranges_to_add_r, old_ranges_r)
                new_ranges_r::Vector{Pkg.Types.VersionRange}
                new_ranges_str = _print_versionranges_to_registry(new_ranges_r)

                # Mutate `info` (and thus mutate `compat_dict`)
                info[namestr] = new_ranges_str

                @info "Patched stdlib compat entry: $(namestr)" old_ranges_str new_ranges_str
            else 
                @debug "Skipping because it's not a stdlib: $(namestr)"
            end
        end
    end
    return nothing
end

function main(pkgname_str; registry_root::AbstractString = ".")
    pkgnamestr = "MozillaCACerts_jll"
    
    pkgpath = abspath(_get_pkgpath(; pkgnamestr, registry_root))
    compat_filename = joinpath(pkgpath, "Compat.toml")
    compat_dict = Compress.load(compat_filename)
    _patchup_compat_dict!(compat_dict)
    Compress.save(compat_filename, compat_dict)
    return nothing
end
```

</details>

I invoked this code as follows:

```julia
main("MozillaCACerts_jll")
```