### PR TITLE
Change URL for TensorCrossInterpolation.jl

### DIFF
--- a/T/TensorCrossInterpolation/Package.toml
+++ b/T/TensorCrossInterpolation/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorCrossInterpolation"
 uuid = "b261b2ec-6378-4871-b32e-9173bb050604"
-repo = "https://gitlab.com/tensors4fields/TensorCrossInterpolation.jl.git"
+repo = "https://github.com/tensor4all/TensorCrossInterpolation.jl.git"


### PR DESCRIPTION
I have verified that the tree hashes of all the versions in the General registry are found at the new URL.
Note that older versions are not registered to the General registry.

```julia
using TOML
using HTTP

for pkg in ["TensorCrossInterpolation"]
    # URL of the TOML file on GitHub
    url = "https://raw.githubusercontent.com/JuliaRegistries/General/master/"*pkg[1:1]*"/"*pkg*"/Versions.toml"

    # Download and parse the TOML file
    toml_data = HTTP.get(url)
    versions = TOML.parse(String(toml_data.body))

    for version in sort(collect(keys(versions)))
        tree_sha = versions[version]["git-tree-sha1"]
        print(version)
        try
            readchomp(`git rev-parse -q --verify "$(tree_sha)^{tree}"`)
            println(" found")
        catch
            println(" missing")
        end
    end
end
```

```
0.8.1 found
0.8.2 found
0.8.3 found
0.9.0 found
0.9.1 found
0.9.2 found
0.9.3 found
0.9.4 found
0.9.5 found
```