### PR TITLE
Change URL: QuanticsTCI.jl

### DIFF
--- a/Q/QuanticsTCI/Package.toml
+++ b/Q/QuanticsTCI/Package.toml
@@ -1,3 +1,3 @@
 name = "QuanticsTCI"
 uuid = "b11687fd-3a1c-4c41-97d0-998ab401d50e"
-repo = "https://gitlab.com/tensors4fields/QuanticsTCI.jl.git"
+repo = "https://github.com/tensor4all/QuanticsTCI.jl.git"


### PR DESCRIPTION
I have verified that the tree hashes of all the versions in the General registry are found at the new URL.
Note that older versions are not registered to the General registry.

```julia
using TOML
using HTTP

for pkg in ["QuanticsTCI"]
    # URL of the TOML file on GitHub
    url = "https://raw.githubusercontent.com/JuliaRegistries/General/master/"*pkg[1:1]*"/"*pkg*"/Versions.toml"

    # Download and parse the TOML file
    toml_data = HTTP.get(url)
    versions = TOML.parse(String(toml_data.body))

    for version in sort(collect(keys(versions)))
        tree_sha = versions[version]["git-tree-sha1"]
        print(version)
        try
            readchomp(`git rev-parse -q --verify "$(tree_sha)^{tree}"`)
            println(" found")
        catch
            println(" missing")
        end
    end
end
```

```
0.4.2 found
0.4.3 found
0.5.0 found
0.6.0 found
```