### PR TITLE
New repo for `HMatrices.jl`

### DIFF
--- a/H/HMatrices/Package.toml
+++ b/H/HMatrices/Package.toml
@@ -1,3 +1,3 @@
 name = "HMatrices"
 uuid = "8646bddf-ab1c-4fa7-9c51-ba187d647618"
-repo = "https://github.com/WaveProp/HMatrices.jl.git"
+repo = "https://github.com/IntegralEquations/HMatrices.jl.git"


### PR DESCRIPTION
Transfer repo to a new organization:

[WaveProp/HMatrices.jl](https://github.com/IntegralEquations/HMatrices.jl) --> [IntegralEquations/HMatrices.jl](https://github.com/IntegralEquations/HMatrices.jl)