### PR TITLE
[Extrae_jll] Fix compat bound with Binutils_jll

### DIFF
--- a/jll/E/Extrae_jll/Compat.toml
+++ b/jll/E/Extrae_jll/Compat.toml
@@ -1,3 +1,4 @@
 [4]
+Binutils_jll = "2.39"
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"


### PR DESCRIPTION
`libbfd` in binutils embeds version number.  CC: @mofeing.