### PR TITLE
Adjust StyledStrings repo URL

### DIFF
--- a/S/StyledStrings/Package.toml
+++ b/S/StyledStrings/Package.toml
@@ -1,3 +1,3 @@
 name = "StyledStrings"
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
-repo = "https://github.com/julialang/StyledStrings.jl.git"
+repo = "https://github.com/JuliaLang/StyledStrings.jl.git"


### PR DESCRIPTION
I think the JuliaHub register bot could do with updating, since in #106027 the repo URL was canonicalised in the PR text but not the `Package.toml`.

This means that a minor release that improves precompilation warnings when used with another package results in:

> Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.

In the meantime, this PR fixes the situation with StyledStrings.