### PR TITLE
Change `ITensorGaussianMPS` URL

### DIFF
--- a/I/ITensorGaussianMPS/Package.toml
+++ b/I/ITensorGaussianMPS/Package.toml
@@ -1,4 +1,3 @@
 name = "ITensorGaussianMPS"
 uuid = "2be41995-7c9f-4653-b682-bfa4e7cebb93"
-repo = "https://github.com/ITensor/ITensors.jl.git"
-subdir = "ITensorGaussianMPS"
+repo = "https://github.com/ITensor/ITensorGaussianMPS.jl.git"


### PR DESCRIPTION
Similar to #105961, I followed the Github documentation guide to [splitting a subfolder out into a new repository](https://docs.github.com/en/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository), and then I [checked that the new repository contains all registered versions of the package](https://github.com/mtfishman/General/blob/master/CONTRIBUTING.md#appendix-checking-if-a-repository-contains-all-registered-versions-of-a-package):
```julia
julia> check_package_versions("ITensorGaussianMPS", "https://github.com/ITensor/ITensorGaussianMPS.jl.git")
Cloning into '/var/folders/qz/q22pzwm144z9fq57mpf1hfp40000gq/T/jl_Lzws5o'...
remote: Enumerating objects: 237, done.
remote: Counting objects: 100% (237/237), done.
remote: Compressing objects: 100% (106/106), done.
remote: Total 237 (delta 128), reused 236 (delta 127), pack-reused 0
Receiving objects: 100% (237/237), 80.22 KiB | 20.05 MiB/s, done.
Resolving deltas: 100% (128/128), done.
ITensorGaussianMPS: v0.0.1 found
ITensorGaussianMPS: v0.0.2 found
ITensorGaussianMPS: v0.0.3 found
ITensorGaussianMPS: v0.0.4 found
ITensorGaussianMPS: v0.0.5 found
ITensorGaussianMPS: v0.1.0 found
ITensorGaussianMPS: v0.1.1 found
ITensorGaussianMPS: v0.1.2 found
ITensorGaussianMPS: v0.1.3 found
ITensorGaussianMPS: v0.1.4 found
ITensorGaussianMPS: v0.1.5 found
ITensorGaussianMPS: v0.1.6 found
12-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "ITensorGaussianMPS", version = v"0.0.1", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.0.2", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.0.3", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.0.4", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.0.5", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.0", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.1", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.2", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.3", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.4", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.5", found = 1)
 (pkg_name = "ITensorGaussianMPS", version = v"0.1.6", found = 1)
```