### PR TITLE
[Extrae_jll] Fix compat with PAPI_jll

### DIFF
--- a/jll/E/Extrae_jll/Compat.toml
+++ b/jll/E/Extrae_jll/Compat.toml
@@ -4,6 +4,7 @@ julia = "1.6.0-1"
 ["4.0"]
 Binutils_jll = "2.39"
 JLLWrappers = "1.2.0-1"
+PAPI_jll = "7.0"
 
 ["4.1-4"]
 Artifacts = "1"


### PR DESCRIPTION
I forgot to do this in #106397.