### PR TITLE
Change `ITensorVisualizationBase` URL

### DIFF
--- a/I/ITensorVisualizationBase/Package.toml
+++ b/I/ITensorVisualizationBase/Package.toml
@@ -1,4 +1,3 @@
 name = "ITensorVisualizationBase"
 uuid = "cd2553d2-8bef-4d93-8a38-c62f17d5ad23"
-repo = "https://github.com/ITensor/ITensors.jl.git"
-subdir = "ITensorVisualizationBase"
+repo = "https://github.com/ITensor/ITensorVisualizationBase.jl.git"


### PR DESCRIPTION
Following the [guide in the README for moving a subdirectory package into its own repository](https://github.com/JuliaRegistries/General?tab=readme-ov-file#how-do-i-move-a-subdirectory-package-to-its-own-repository) (introduced recently in #106408):
```julia
julia> check_package_versions("ITensorVisualizationBase", "https://github.com/ITensor/ITensorVisualizationBase.jl.git")
Cloning into '/var/folders/qz/q22pzwm144z9fq57mpf1hfp40000gq/T/jl_xXVQQr'...
remote: Enumerating objects: 125, done.
remote: Counting objects: 100% (125/125), done.
remote: Compressing objects: 100% (74/74), done.
remote: Total 125 (delta 49), reused 125 (delta 49), pack-reused 0
Receiving objects: 100% (125/125), 940.43 KiB | 1.72 MiB/s, done.
Resolving deltas: 100% (49/49), done.
ITensorVisualizationBase: v0.1.0 found
ITensorVisualizationBase: v0.1.1 found
ITensorVisualizationBase: v0.1.2 found
ITensorVisualizationBase: v0.1.3 found
ITensorVisualizationBase: v0.1.4 found
ITensorVisualizationBase: v0.1.5 found
ITensorVisualizationBase: v0.1.6 found
ITensorVisualizationBase: v0.1.7 found
8-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.0", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.1", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.2", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.3", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.4", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.5", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.6", found = 1)
 (pkg_name = "ITensorVisualizationBase", version = v"0.1.7", found = 1)
```