### PR TITLE
Change `ITensorUnicodePlots` URL

### DIFF
--- a/I/ITensorUnicodePlots/Package.toml
+++ b/I/ITensorUnicodePlots/Package.toml
@@ -1,4 +1,3 @@
 name = "ITensorUnicodePlots"
 uuid = "73163f41-4a9e-479f-8353-73bf94dbd758"
-repo = "https://github.com/ITensor/ITensors.jl.git"
-subdir = "ITensorUnicodePlots"
+repo = "https://github.com/ITensor/ITensorUnicodePlots.jl.git"


### PR DESCRIPTION
Following the [guide in the README for moving a subdirectory package into its own repository](https://github.com/JuliaRegistries/General?tab=readme-ov-file#how-do-i-move-a-subdirectory-package-to-its-own-repository):
```julia
julia> check_package_versions("ITensorUnicodePlots", "https://github.com/ITensor/ITensorUnicodePlots.jl")
Cloning into '/var/folders/qz/q22pzwm144z9fq57mpf1hfp40000gq/T/jl_E2bdNx'...
remote: Enumerating objects: 165, done.
remote: Counting objects: 100% (165/165), done.
remote: Compressing objects: 100% (77/77), done.
remote: Total 165 (delta 87), reused 165 (delta 87), pack-reused 0
Receiving objects: 100% (165/165), 352.59 KiB | 1.82 MiB/s, done.
Resolving deltas: 100% (87/87), done.
ITensorUnicodePlots: v0.1.0 found
ITensorUnicodePlots: v0.1.1 found
ITensorUnicodePlots: v0.1.2 found
ITensorUnicodePlots: v0.1.3 found
4-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "ITensorUnicodePlots", version = v"0.1.0", found = 1)
 (pkg_name = "ITensorUnicodePlots", version = v"0.1.1", found = 1)
 (pkg_name = "ITensorUnicodePlots", version = v"0.1.2", found = 1)
 (pkg_name = "ITensorUnicodePlots", version = v"0.1.3", found = 1)
```