### PR TITLE
Change `ITensorMakie` URL

### DIFF
--- a/I/ITensorMakie/Package.toml
+++ b/I/ITensorMakie/Package.toml
@@ -1,4 +1,3 @@
 name = "ITensorMakie"
 uuid = "72ca75eb-df6f-4d6b-80c5-d5eab17be3f9"
-repo = "https://github.com/ITensor/ITensors.jl.git"
-subdir = "ITensorMakie"
+repo = "https://github.com/ITensor/ITensorMakie.jl.git"


### PR DESCRIPTION
Following the [guide in the README for moving a subdirectory package into its own repository](https://github.com/JuliaRegistries/General?tab=readme-ov-file#how-do-i-move-a-subdirectory-package-to-its-own-repository):
```julia
julia> check_package_versions("ITensorMakie", "https://github.com/ITensor/ITensorMakie.jl")
Cloning into '/var/folders/qz/q22pzwm144z9fq57mpf1hfp40000gq/T/jl_lx8qRn'...
remote: Enumerating objects: 111, done.
remote: Counting objects: 100% (111/111), done.
remote: Compressing objects: 100% (61/61), done.
remote: Total 111 (delta 44), reused 111 (delta 44), pack-reused 0
Receiving objects: 100% (111/111), 345.19 KiB | 2.12 MiB/s, done.
Resolving deltas: 100% (44/44), done.
ITensorMakie: v0.1.0 found
ITensorMakie: v0.1.1 found
ITensorMakie: v0.1.2 found
ITensorMakie: v0.1.3 found
4-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "ITensorMakie", version = v"0.1.0", found = 1)
 (pkg_name = "ITensorMakie", version = v"0.1.1", found = 1)
 (pkg_name = "ITensorMakie", version = v"0.1.2", found = 1)
 (pkg_name = "ITensorMakie", version = v"0.1.3", found = 1)
```