### PR TITLE
Change `ITensorGLMakie` URL

### DIFF
--- a/I/ITensorGLMakie/Package.toml
+++ b/I/ITensorGLMakie/Package.toml
@@ -1,4 +1,3 @@
 name = "ITensorGLMakie"
 uuid = "3f718f31-6db8-4f43-a433-67cb5c73363e"
-repo = "https://github.com/ITensor/ITensors.jl.git"
-subdir = "ITensorGLMakie"
+repo = "https://github.com/ITensor/ITensorGLMakie.jl.git"


### PR DESCRIPTION
Following the [guide in the README for moving a subdirectory package into its own repository](https://github.com/JuliaRegistries/General?tab=readme-ov-file#how-do-i-move-a-subdirectory-package-to-its-own-repository):
```julia
julia> check_package_versions("ITensorGLMakie", "https://github.com/ITensor/ITensorGLMakie.jl")
Cloning into '/var/folders/qz/q22pzwm144z9fq57mpf1hfp40000gq/T/jl_Tt9TgC'...
remote: Enumerating objects: 126, done.
remote: Counting objects: 100% (126/126), done.
remote: Compressing objects: 100% (74/74), done.
remote: Total 126 (delta 50), reused 126 (delta 50), pack-reused 0
Receiving objects: 100% (126/126), 682.50 KiB | 1.94 MiB/s, done.
Resolving deltas: 100% (50/50), done.
ITensorGLMakie: v0.1.0 found
ITensorGLMakie: v0.1.1 found
ITensorGLMakie: v0.1.2 found
3-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "ITensorGLMakie", version = v"0.1.0", found = 1)
 (pkg_name = "ITensorGLMakie", version = v"0.1.1", found = 1)
 (pkg_name = "ITensorGLMakie", version = v"0.1.2", found = 1)
```