### PR TITLE
Ensure CURL_jll matches LibCURL_jll more precisely

### DIFF
--- a/jll/C/CURL_jll/Compat.toml
+++ b/jll/C/CURL_jll/Compat.toml
@@ -11,7 +11,7 @@ Artifacts = "1"
 Libdl = "1"
 
 ["8-8.5"]
-LibCURL_jll = "8.5.0-8.5"
+LibCURL_jll = "8.5.0-8.6"
 
 ["8.6-8"]
 LibCURL_jll = "8.6.0-8.6"

--- a/jll/C/CURL_jll/Compat.toml
+++ b/jll/C/CURL_jll/Compat.toml
@@ -1,5 +1,5 @@
 [7]
-LibCURL_jll = ["7.81.0-7", "8.0.1-8"]
+LibCURL_jll = ["7.81.0-7", "8.0.1-8.6"]
 
 [7-8]
 JLLWrappers = "1.2.0-1"
@@ -11,7 +11,7 @@ Artifacts = "1"
 Libdl = "1"
 
 ["8-8.5"]
-LibCURL_jll = "8.5.0-8"
+LibCURL_jll = "8.5.0-8.5"
 
 ["8.6-8"]
-LibCURL_jll = "8.6.0-8"
+LibCURL_jll = "8.6.0-8.6"


### PR DESCRIPTION
It is not allowable for CURL_jll to get a version of LibCURL_jll that varies too much from its own version.  Note that because LibCURL_jll is a stdlib this is not a problem for most users, but if you're using something like JLLPrefixes.jl to do your package instantiation, you can end up in a situation like this.