### PR TITLE
[SwarmMakie.jl] Transfer repo to MakieOrg

### DIFF
--- a/S/SwarmMakie/Package.toml
+++ b/S/SwarmMakie/Package.toml
@@ -1,3 +1,3 @@
 name = "SwarmMakie"
 uuid = "0b1c068e-6a84-4e66-8136-5c95cafa83ed"
-repo = "https://github.com/asinghvi17/SwarmMakie.jl.git"
+repo = "https://github.com/MakieOrg/SwarmMakie.jl.git"


### PR DESCRIPTION
Changes the URL for S/SwarmMakie accordingly.