### PR TITLE
[GeoMakie] Retroactively cap GeometryBasics versions to avoid method …

### DIFF
--- a/G/GeoMakie/Compat.toml
+++ b/G/GeoMakie/Compat.toml
@@ -153,7 +153,7 @@ GeoInterface = ["0.5", "1"]
 Proj = "1"
 
 ["0.4.3-0.5"]
-GeometryBasics = "0.4.4-0.4"
+GeometryBasics = "0.4.4-0.4.10"
 
 ["0.4.3-0.5.0"]
 GeoJSON = "0.6"
@@ -179,7 +179,7 @@ Statistics = "1"
 Makie = "0.20"
 
 ["0.6-0.6.2"]
-GeometryBasics = "0.4.6-0.4"
+GeometryBasics = "0.4.6-0.4.10"
 
 ["0.6.1-0"]
 GeoJSON = "0.6-0.8"


### PR DESCRIPTION
…overwriting

A hack from GeoMakie was upstreamed into GeometryBasics in v0.4.11 of GeometryBasics, this PR caps all versions before the upstreaming.