### PR TITLE
Change URL of TCIITensorConversion.jl

### DIFF
--- a/T/TCIITensorConversion/Package.toml
+++ b/T/TCIITensorConversion/Package.toml
@@ -1,3 +1,3 @@
 name = "TCIITensorConversion"
 uuid = "9f0aa9f4-9415-4e6a-8795-331ebf40aa04"
-repo = "https://gitlab.com/tensors4fields/TCIITensorConversion.jl.git"
+repo = "https://github.com/tensor4all/TCIITensorConversion.jl.git"


### PR DESCRIPTION
I have verified that the tree hashes of all the versions in the General registry are found at the new URL.
Note that older versions are not registered to the General registry.

```Julia
using TOML
using HTTP

for pkg in ["TCIITensorConversion"]
    # URL of the TOML file on GitHub
    url = "https://raw.githubusercontent.com/JuliaRegistries/General/master/"*pkg[1:1]*"/"*pkg*"/Versions.toml"

    # Download and parse the TOML file
    toml_data = HTTP.get(url)
    versions = TOML.parse(String(toml_data.body))

    for version in sort(collect(keys(versions)))
        tree_sha = versions[version]["git-tree-sha1"]
        print(version)
        try
            readchomp(`git rev-parse -q --verify "$(tree_sha)^{tree}"`)
            println(" found")
        catch
            println(" missing")
        end
    end
end
```

```
0.1.2 found
0.1.3 found
```