### PR TITLE
Change URL for BlochSim

### DIFF
--- a/B/BlochSim/Package.toml
+++ b/B/BlochSim/Package.toml
@@ -1,3 +1,3 @@
 name = "BlochSim"
 uuid = "5c0f8cbe-99a4-11e9-108b-216da9629524"
-repo = "https://github.com/StevenWhitaker/BlochSim.jl.git"
+repo = "https://github.com/MagneticResonanceImaging/BlochSim.jl.git"


### PR DESCRIPTION
It moved about a month ago.

I ran the suggested code to verify that all the previous versions are there.

```
 (pkg_name = "BlochSim", version = v"0.1.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.2.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.2.1", found = 1)
 (pkg_name = "BlochSim", version = v"0.3.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.4.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.5.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.5.1", found = 1)
 (pkg_name = "BlochSim", version = v"0.6.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.7.0", found = 1)
 (pkg_name = "BlochSim", version = v"0.7.1", found = 1)
```