### PR TITLE
Change MixedStructTypes url for renaming to DynamicSumTypes

### DIFF
--- a/M/MixedStructTypes/Package.toml
+++ b/M/MixedStructTypes/Package.toml
@@ -1,3 +1,3 @@
 name = "MixedStructTypes"
 uuid = "3d69f371-6fa5-5add-b11c-3293622cad62"
-repo = "https://github.com/JuliaDynamics/MixedStructTypes.jl.git"
+repo = "https://github.com/JuliaDynamics/DynamicSumTypes.jl.git"


### PR DESCRIPTION
I'd like to change the name of the package because its evolution made me realize that this is a better name, repo: https://github.com/JuliaDynamics/DynamicSumTypes.jl, I plan a 1.0 release of the package soon so I thought that this could be a good moment to change its name