### PR TITLE
[JLL] Yank broken GDAL and breaking PROJ

### DIFF
--- a/jll/G/GDAL_jll/Versions.toml
+++ b/jll/G/GDAL_jll/Versions.toml
@@ -109,3 +109,4 @@ git-tree-sha1 = "1740251f4f1ce850d4eaad052d5e419229d4b2af"
 
 ["301.901.0+0"]
 git-tree-sha1 = "420559d37b7f2c3e30f3127d16d2fbd521e4126e"
+yanked = true

--- a/jll/P/PROJ_jll/Versions.toml
+++ b/jll/P/PROJ_jll/Versions.toml
@@ -57,3 +57,4 @@ git-tree-sha1 = "84aa844bd56f62282116b413fbefb45e370e54d6"
 
 ["901.400.0+0"]
 git-tree-sha1 = "0d04367a7ab67636da8bbdb6338c94d1a577d8e2"
+yanked = true


### PR DESCRIPTION
The latest GDAL_jll release is broken on Windows, and since we don't know the cause I don't think we can fix the ecosystem that builds on GDAL and PROJ anytime soon without yanking.

The latest PROJ_jll is breaking on Windows and was mistakenly not released as breaking. This causes GDAL_jll to fail as well since the DLL name changed.

cc @eschnett @rafaqz @joa-quim @evetion 

Ref
https://github.com/JuliaPackaging/Yggdrasil/pull/8746#issuecomment-2130321111
https://github.com/JuliaGeo/GDAL.jl/issues/173
