### PR TITLE
New version: InPartSMakie v0.1.13

### DIFF
--- a/I/InPartSMakie/Compat.toml
+++ b/I/InPartSMakie/Compat.toml
@@ -2,8 +2,14 @@
 Colors = "0.12"
 CoordinateTransformations = "0.6"
 GeometryBasics = "0.4"
-InPartS = "0.4.0-0.6"
 InPartSObstacles = "0.1"
-Makie = "0.20.1-0.20"
 Requires = "1"
 Rotations = "1"
+
+["0-0.1.12"]
+InPartS = "0.4.0-0.6"
+Makie = "0.20.1-0.20"
+
+["0.1.13-0"]
+InPartS = "0.4.0-0.7"
+Makie = "0.21"

--- a/I/InPartSMakie/Versions.toml
+++ b/I/InPartSMakie/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.12"]
 git-tree-sha1 = "dfb25ec322f0b1237da730c6db4740f5507b43e4"
+
+["0.1.13"]
+git-tree-sha1 = "be18f1f4b88267af1775d9fa22af9ac5e7eb59ac"


### PR DESCRIPTION
- Registering package: InPartSMakie
- Repository: https://gitlab.gwdg.de/eDLS/inpartsmakie.jl
- Version: v0.1.13
- Commit: 1cc312950e2b24b5608fd8a95b3b181fc7b69806
- Description: Makie visualsation for InPartS

*This PR was created using LocalRegistry.jl and a hacky GitLab CI script. If nothing went wrong, it should be similar to a Registrator-generated PR.
I am a machine user 🤖 and I’m currently controlled by @lhupe @philbit and @JonasIsensee.*
