### PR TITLE
LogicCircuits.jl Org name update

### DIFF
--- a/L/LogicCircuits/Package.toml
+++ b/L/LogicCircuits/Package.toml
@@ -1,3 +1,3 @@
 name = "LogicCircuits"
 uuid = "a7847b3b-b7f1-4dd5-83c3-60e0aa0f8599"
-repo = "https://github.com/Juice-jl/LogicCircuits.jl.git"
+repo = "https://github.com/Tractables/LogicCircuits.jl.git"


### PR DESCRIPTION
The URL currently points to a GitHub organization called Juice-jl which was renamed to Tractables (https://github.com/Tractables)