### PR TITLE
ProbabilisticCircuits URL Update

### DIFF
--- a/P/ProbabilisticCircuits/Package.toml
+++ b/P/ProbabilisticCircuits/Package.toml
@@ -1,3 +1,3 @@
 name = "ProbabilisticCircuits"
 uuid = "2396afbe-23d7-11ea-1e05-f1aa98e17a44"
-repo = "https://github.com/Juice-jl/ProbabilisticCircuits.jl.git"
+repo = "https://github.com/Tractables/ProbabilisticCircuits.jl.git"


### PR DESCRIPTION
The URL currently points to a GitHub organization called Juice-jl which was renamed to Tractables (https://github.com/Tractables)