### PR TITLE
Change SUNRepresentations url

### DIFF
--- a/S/SUNRepresentations/Package.toml
+++ b/S/SUNRepresentations/Package.toml
@@ -1,3 +1,3 @@
 name = "SUNRepresentations"
 uuid = "1a50b95c-7aac-476d-a9ce-2bfc675fc617"
-repo = "https://github.com/maartenvd/SUNRepresentations.jl.git"
+repo = "https://github.com/QuantumKitHub/SUNRepresentations.jl.git"


### PR DESCRIPTION
This PR updates the url of SUNRepresentations.jl.
This was previously hosted on: "https://github.com/maartenvd/SUNRepresentations.jl.git"
and is now transferred here: "https://github.com/QuantumKitHub/SUNRepresentations.jl.git"