### PR TITLE
new URL for NBInclude.jl

### DIFF
--- a/N/NBInclude/Package.toml
+++ b/N/NBInclude/Package.toml
@@ -1,3 +1,3 @@
 name = "NBInclude"
 uuid = "0db19996-df87-5ea3-a455-e3a50d440464"
-repo = "https://github.com/stevengj/NBInclude.jl.git"
+repo = "https://github.com/JuliaInterop/NBInclude.jl.git"


### PR DESCRIPTION
Is now at https://github.com/JuliaInterop/NBInclude.jl