### PR TITLE
Fix PBWDeformations URL

### DIFF
--- a/P/PBWDeformations/Package.toml
+++ b/P/PBWDeformations/Package.toml
@@ -1,3 +1,3 @@
 name = "PBWDeformations"
 uuid = "5e7992ee-18b2-4301-9ba0-4f17696dc75a"
-repo = "https://github.com/lgoettgens/PBWDeformations.jl"
+repo = "https://github.com/lgoettgens/PBWDeformations.jl.git"


### PR DESCRIPTION
In https://github.com/JuliaRegistries/General/pull/89539 the `.git` ending of the URL got lost, so I am now unable to register a new version. It would be great if this got merged, thanks!