### PR TITLE
change repository path: COBREXA

### DIFF
--- a/C/COBREXA/Package.toml
+++ b/C/COBREXA/Package.toml
@@ -1,3 +1,3 @@
 name = "COBREXA"
 uuid = "babc4406-5200-4a30-9033-bf5ae714c842"
-repo = "https://github.com/LCSB-BioCore/COBREXA.jl.git"
+repo = "https://github.com/COBREXA/COBREXA.jl.git"


### PR DESCRIPTION
Hello,

we have moved COBREXA.jl development to a new place ( https://github.com/COBREXA/COBREXA.jl ); the original one is now marked as legacy ( https://github.com/LCSB-BioCore/COBREXA.jl ) but will stay there because of compatibility reasons. This PR simply changes the path in `Package.toml`.

Once this is merged I hope to immediately release a new major version.

Please let me know in case any other actions/changes/explanations are needed to get this merged. As one possible problem, the official how-to for moving the repositories recommends using the github's "move repository" functionality, but that was unfortunately not a possibility for us. The existing tags and SHAs in the repository should be intact.

Thanks!
-mk

cc @stelmo