### PR TITLE
yank pandoc_crossref_jll 0.3.17+1

### DIFF
--- a/jll/P/pandoc_crossref_jll/Compat.toml
+++ b/jll/P/pandoc_crossref_jll/Compat.toml
@@ -10,4 +10,3 @@ julia = "1.6.0-1"
 ["0.3.17-0"]
 Artifacts = "1"
 Libdl = "1"
-pandoc_jll = "3.2.0"

--- a/jll/P/pandoc_crossref_jll/Versions.toml
+++ b/jll/P/pandoc_crossref_jll/Versions.toml
@@ -21,3 +21,4 @@ git-tree-sha1 = "b03f15bd10a8e90b2cbf49a599d449fb74ec5f51"
 
 ["0.3.17+1"]
 git-tree-sha1 = "4c554a9ea8e5b121b1a54e8940f00609466532dc"
+yanked = true


### PR DESCRIPTION
The `+1` build added a new compat entry which applies to all builds and this breaks previously resolvable code. This PR yanks the problematic build version and removes the invalid compat.

cc @omus @giordano @kleinschmidt 