### PR TITLE
Update the URL of IDFDataCanada.jl

### DIFF
--- a/I/IDFDataCanada/Package.toml
+++ b/I/IDFDataCanada/Package.toml
@@ -1,3 +1,3 @@
 name = "IDFDataCanada"
 uuid = "b4a361a7-a77f-4d9e-8c40-a407543557fa"
-repo = "https://github.com/houton199/IDFDataCanada.jl.git"
+repo = "https://github.com/JuliaExtremes/IDFDataCanada.jl.git"


### PR DESCRIPTION
The package was transferred to an organization. The repo URL in the package's Package.toml file was modified accordingly. 