### PR TITLE
Update repo URLs for OpenFHE and SecureArithmetic

### DIFF
--- a/O/OpenFHE/Package.toml
+++ b/O/OpenFHE/Package.toml
@@ -1,3 +1,3 @@
 name = "OpenFHE"
 uuid = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
-repo = "https://github.com/sloede/OpenFHE.jl.git"
+repo = "https://github.com/hpsc-lab/OpenFHE.jl.git"

--- a/S/SecureArithmetic/Package.toml
+++ b/S/SecureArithmetic/Package.toml
@@ -1,3 +1,3 @@
 name = "SecureArithmetic"
 uuid = "38cee09b-6d7e-4d21-866e-807a7f642fe9"
-repo = "https://github.com/sloede/SecureArithmetic.jl.git"
+repo = "https://github.com/hpsc-lab/SecureArithmetic.jl.git"


### PR DESCRIPTION
They have been moved to their new home in the HPSC Lab org (https://github.com/hpsc-lab):
* https://github.com/hpsc-lab/OpenFHE.jl
* https://github.com/hpsc-lab/SecureArithmetic.jl