### PR TITLE
New version: CImGuiPack_jll v0.3.0+0

### DIFF
--- a/jll/C/CImGuiPack_jll/Compat.toml
+++ b/jll/C/CImGuiPack_jll/Compat.toml
@@ -1,3 +1,8 @@
 [0]
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"
+
+["0.3-0"]
+Artifacts = "1"
+Libdl = "1"
+libcxxwrap_julia_jll = "0.13"

--- a/jll/C/CImGuiPack_jll/Deps.toml
+++ b/jll/C/CImGuiPack_jll/Deps.toml
@@ -5,3 +5,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 ["0-0.1.2"]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+["0.3-0"]
+GLFW_jll = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"

--- a/jll/C/CImGuiPack_jll/Versions.toml
+++ b/jll/C/CImGuiPack_jll/Versions.toml
@@ -10,3 +10,6 @@ yanked = true
 
 ["0.2.0+0"]
 git-tree-sha1 = "2952ca4340db090bb6ed44e93170dac28c58a733"
+
+["0.3.0+0"]
+git-tree-sha1 = "a812bb61c47f1582a76cd774317477f1d8947d5a"


### PR DESCRIPTION
UUID: 333409e9-af72-5310-9767-d6ad21a76a05
Repo: https://github.com/JuliaBinaryWrappers/CImGuiPack_jll.jl.git
Tree: a812bb61c47f1582a76cd774317477f1d8947d5a

Registrator tree SHA: 191228b6dd8b9d0e2965ae3e705fe54c51dcfee8