### PR TITLE
Update RCall Julia compat

### DIFF
--- a/R/RCall/Compat.toml
+++ b/R/RCall/Compat.toml
@@ -16,7 +16,7 @@ CategoricalArrays = "0.3.0-0.7"
 DataStructures = "0.5.0-0.18"
 WinReg = "0.2.0-0.3"
 
-["0.13-0"]
+["0.13-0.13.18"]
 julia = "1"
 
 ["0.13.10"]
@@ -65,6 +65,9 @@ WinReg = "0.2-0.3"
 ["0.13.7-0.13.9"]
 CategoricalArrays = "0.8"
 DataFrames = "0.21"
+
+["0.14.0-0"]
+julia = "1.6"
 
 ["0.14.1-0"]
 Preferences = "1"


### PR DESCRIPTION
RCall itself is compatible with Julia 1.0, but there are some issues with resolving dependencies on earlier Julia versions. Starting with RCall 0.14, the effective Julia compatibility is 1.6. See https://github.com/JuliaInterop/RCall.jl/issues/531

cc @ViralBShah 