### PR TITLE
[MPFR_jll] Manually register MPFR_jll 4.2.1

### DIFF
--- a/jll/M/MPFR_jll/Versions.toml
+++ b/jll/M/MPFR_jll/Versions.toml
@@ -40,3 +40,6 @@ git-tree-sha1 = "f1eb68aff002487ffb964838481e370355bdd270"
 
 ["4.2.0+1"]
 git-tree-sha1 = "b4b558295691eb90de3a84454cabc00a6888cfa9"
+
+["4.2.1+0"]
+git-tree-sha1 = "7372f4a7bfec7da9fc3f80b3da090b4589bde1a1"


### PR DESCRIPTION
This was already released in August 2023, and is being used by Julia itself, but due to a network issue (???) the corresponding PR to the General registry was never created, and so this version is still missing from the registry. Trying to fix this manually now.

For background and more information see https://github.com/JuliaPackaging/Yggdrasil/pull/9001 and https://github.com/JuliaPackaging/Yggdrasil/pull/8993

CC @benlorenz @giordano @hannes14