### PR TITLE
Migrate FLoops.jl to JuliaFolds2

### DIFF
--- a/F/FLoops/Package.toml
+++ b/F/FLoops/Package.toml
@@ -1,3 +1,3 @@
 name = "FLoops"
 uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
-repo = "https://github.com/JuliaFolds/FLoops.jl.git"
+repo = "https://github.com/JuliaFolds2/FLoops.jl.git"


### PR DESCRIPTION
FLoops.jl is being migrated to https://github.com/JuliaFolds2/FLoops.jl