### PR TITLE
Yank Static v1.1.0

### DIFF
--- a/S/Static/Versions.toml
+++ b/S/Static/Versions.toml
@@ -153,6 +153,7 @@ git-tree-sha1 = "85fec8e64b6b8168d7a172d7f503c6770c7cfc08"
 
 ["1.1.0"]
 git-tree-sha1 = "0bbff21027dd8a107551847528127b62a35f7594"
+yanked = true
 
 ["1.1.1"]
 git-tree-sha1 = "87d51a3ee9a4b0d2fe054bdd3fc2436258db2603"


### PR DESCRIPTION
This is to prevent the resolver from being able to select Static 1.1.0 as a new version of static with an old precompile tools, so we don't get any test failures like https://github.com/sumiya11/Groebner.jl/actions/runs/9929029946/job/27426062429

@ChrisRackauckas