### PR TITLE
chore: update link to `LuxDeviceUtils.jl`

### DIFF
--- a/L/LuxDeviceUtils/Package.toml
+++ b/L/LuxDeviceUtils/Package.toml
@@ -1,3 +1,3 @@
 name = "LuxDeviceUtils"
 uuid = "34f89e08-e1d5-43b4-8944-0b49ac560553"
-repo = "https://github.com/LuxDL/LuxDeviceUtils.jl.git"
+repo = "https://github.com/LuxDL/DeviceUtils.jl.git"


### PR DESCRIPTION
Package rename without the "Lux" branding to facilitate wider adoption