### PR TITLE
Moves `EphemerisSources.jl` packages to JuliaAstro

### DIFF
--- a/E/EphemerisSources/Package.toml
+++ b/E/EphemerisSources/Package.toml
@@ -1,3 +1,3 @@
 name = "EphemerisSources"
 uuid = "858900df-f7ae-402a-aa8c-3e4ef85aa271"
-repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+repo = "https://github.com/JuliaAstro/EphemerisSources.jl.git"

--- a/E/EphemerisSourcesBase/Package.toml
+++ b/E/EphemerisSourcesBase/Package.toml
@@ -1,4 +1,4 @@
 name = "EphemerisSourcesBase"
 uuid = "b8f1d712-e88d-4f2a-8498-e66ce688ee29"
-repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+repo = "https://github.com/JuliaAstro/EphemerisSources.jl.git"
 subdir = "lib/EphemerisSourcesBase"

--- a/H/HorizonsAPI/Package.toml
+++ b/H/HorizonsAPI/Package.toml
@@ -1,4 +1,4 @@
 name = "HorizonsAPI"
 uuid = "c15253bb-5e94-4b8b-9a02-579bb6c8e3ce"
-repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+repo = "https://github.com/JuliaAstro/EphemerisSources.jl.git"
 subdir = "lib/HorizonsAPI"

--- a/H/HorizonsEphemeris/Package.toml
+++ b/H/HorizonsEphemeris/Package.toml
@@ -1,4 +1,4 @@
 name = "HorizonsEphemeris"
 uuid = "05ee1981-f730-42d8-b713-4f42d99733dc"
-repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+repo = "https://github.com/JuliaAstro/EphemerisSources.jl.git"
 subdir = "lib/HorizonsEphemeris"

--- a/S/SPICEBodies/Package.toml
+++ b/S/SPICEBodies/Package.toml
@@ -1,4 +1,4 @@
 name = "SPICEBodies"
 uuid = "19f1efb6-7162-484a-b3a1-b52c391689d7"
-repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+repo = "https://github.com/JuliaAstro/EphemerisSources.jl.git"
 subdir = "lib/SPICEBodies"

--- a/S/SPICEKernels/Package.toml
+++ b/S/SPICEKernels/Package.toml
@@ -1,4 +1,4 @@
 name = "SPICEKernels"
 uuid = "8e9d28ce-e483-4ef7-bfd9-45b8fef6369c"
-repo = "https://github.com/cadojo/EphemerisSources.jl.git"
+repo = "https://github.com/JuliaAstro/EphemerisSources.jl.git"
 subdir = "lib/SPICEKernels"


### PR DESCRIPTION
The `EphemerisSources.jl` project has moved into @JuliaAstro. All tags and releases are still available in the project [repository](https://github.com/JuliaAstro/EphemerisSources.jl).