### PR TITLE
Update repo url for CausalityTools.jl after package renaming

### DIFF
--- a/C/CausalityTools/Package.toml
+++ b/C/CausalityTools/Package.toml
@@ -1,3 +1,3 @@
 name = "CausalityTools"
 uuid = "5520caf5-2dd7-5c5d-bfcb-a00e56ac49f7"
-repo = "https://github.com/JuliaDynamics/CausalityTools.jl.git"
+repo = "https://github.com/JuliaDynamics/Associations.jl.git"


### PR DESCRIPTION
CausalityTools.jl is now [Associations.jl](https://github.com/JuliaDynamics/Associations.jl). 