### PR TITLE
Yank ADTypes v1.6.0 and v1.6.1 (maybe unnecessary?)

### DIFF
--- a/A/ADTypes/Versions.toml
+++ b/A/ADTypes/Versions.toml
@@ -78,9 +78,11 @@ git-tree-sha1 = "1f3835083f5b40fc01a3c87e64bc3275cf447481"
 
 ["1.6.0"]
 git-tree-sha1 = "878aee357e230c375cc531952933889cbf9e9314"
+yanked = true
 
 ["1.6.1"]
 git-tree-sha1 = "aa4d425271a914d8c4af6ad9fccb6eb3aec662c7"
+yanked = true
 
 ["1.6.2"]
 git-tree-sha1 = "6778bcc27496dae5723ff37ee30af451db8b35fe"


### PR DESCRIPTION
ADTypes [v1.6.0](https://github.com/SciML/ADTypes.jl/releases/tag/v1.6.0) introduced a keyword argument `AutoEnzyme(constant_function=false)`, which we later realized was a bad idea. The keyword was removed in ADTypes v1.6.2, and this PR yanks v1.6.0 and v1.6.1 to prevent people from installing faulty versions. On the other hand, since there is a patch release v1.6.2, maybe yanking is not necessary?
Ping @wsmoses @ChrisRackauckas 