### PR TITLE
StructIO.jl now lives in JuliaIO

### DIFF
--- a/S/StructIO/Package.toml
+++ b/S/StructIO/Package.toml
@@ -1,3 +1,3 @@
 name = "StructIO"
 uuid = "53d494c1-5632-5724-8f4c-31dff12d585f"
-repo = "https://github.com/Keno/StructIO.jl.git"
+repo = "https://github.com/JuliaIO/StructIO.jl.git"


### PR DESCRIPTION
It was moved to https://github.com/JuliaIO/StructIO.jl from https://github.com/Keno/StructIO.jl in 2023 by @ararslan (https://github.com/JuliaIO/StructIO.jl/pull/19).