### PR TITLE
chore: retroactively upperbound LuxCore in Lux

### DIFF
--- a/L/Lux/Compat.toml
+++ b/L/Lux/Compat.toml
@@ -58,7 +58,7 @@ SnoopPrecompile = "1"
 LuxLib = "0.1.7-0.1"
 
 ["0.4.35-0.4.44"]
-LuxCore = "0.1"
+LuxCore = "0.1-0.1.23"
 
 ["0.4.36-0.5.16"]
 Functors = "0.2-0.4"
@@ -89,7 +89,7 @@ TruncatedStacktraces = "1.1.0-1"
 ReverseDiff = "1"
 
 ["0.4.45-0.4.53"]
-LuxCore = "0.1.3-0.1"
+LuxCore = "0.1.3-0.1.23"
 
 ["0.4.49-0.4"]
 LuxCUDA = "0.1"
@@ -104,7 +104,7 @@ Statistics = "1.6.0-1"
 LuxLib = "0.2"
 
 ["0.4.54-0.5.4"]
-LuxCore = "0.1.4-0.1"
+LuxCore = "0.1.4-0.1.23"
 
 ["0.4.56-0.5.15"]
 WeightInitializers = "0.1"
@@ -163,7 +163,7 @@ GPUArraysCore = "0.1"
 WeightInitializers = "0.1.5-0.1"
 
 ["0.5.17"]
-LuxCore = "0.1.7-0.1"
+LuxCore = "0.1.7-0.1.23"
 
 ["0.5.17-0"]
 Adapt = "4"
@@ -199,13 +199,13 @@ PrecompileTools = "1.2.0-1"
 Setfield = "1"
 
 ["0.5.18"]
-LuxCore = "0.1.8-0.1"
+LuxCore = "0.1.8-0.1.23"
 
 ["0.5.19-0.5.22"]
-LuxCore = "0.1.11-0.1"
+LuxCore = "0.1.11-0.1.23"
 
 ["0.5.23-0.5.37"]
-LuxCore = "0.1.12-0.1"
+LuxCore = "0.1.12-0.1.23"
 
 ["0.5.27-0"]
 LinearAlgebra = "1.10.0-1"
@@ -251,7 +251,7 @@ Reexport = "1.2.2-1"
 ArrayInterface = "7.9.0-7"
 
 ["0.5.38-0.5.57"]
-LuxCore = "0.1.14-0.1"
+LuxCore = "0.1.14-0.1.23"
 
 ["0.5.38-0.5.61"]
 ADTypes = ["0.2", "1"]
@@ -273,7 +273,7 @@ LuxLib = "0.3.22-0.3"
 LuxLib = "0.3.23-0.3"
 
 ["0.5.5-0.5.16"]
-LuxCore = "0.1.6-0.1"
+LuxCore = "0.1.6-0.1.23"
 MacroTools = "0.5"
 
 ["0.5.51-0"]
@@ -294,7 +294,7 @@ Statistics = "1.10.0-1"
 EnzymeCore = "0.7.5-0.7"
 
 ["0.5.58-0"]
-LuxCore = "0.1.16-0.1"
+LuxCore = "0.1.16-0.1.23"
 UnrolledUtilities = "0.1.2-0.1"
 
 ["0.5.61-0"]


### PR DESCRIPTION
let me know if this is not the right course of action. A type piracy is being fixed in LuxCore 0.1.24 which will break Lux installation if not bounded.