### PR TITLE
Move URL to kestrelquantum for NamedTrajectories, QuantumCollocation, TrajectoryIndexingUtils, Piccolo

### DIFF
--- a/N/NamedTrajectories/Package.toml
+++ b/N/NamedTrajectories/Package.toml
@@ -1,3 +1,3 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
-repo = "https://github.com/aarontrowbridge/NamedTrajectories.jl.git"
+repo = "https://github.com/kestrelquantum/NamedTrajectories.jl.git"

--- a/P/Piccolo/Package.toml
+++ b/P/Piccolo/Package.toml
@@ -1,3 +1,3 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-repo = "https://github.com/aarontrowbridge/Piccolo.jl.git"
+repo = "https://github.com/kestrelquantum/Piccolo.jl.git"

--- a/Q/QuantumCollocation/Package.toml
+++ b/Q/QuantumCollocation/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumCollocation"
 uuid = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
-repo = "https://github.com/aarontrowbridge/QuantumCollocation.jl.git"
+repo = "https://github.com/kestrelquantum/QuantumCollocation.jl.git"

--- a/T/TrajectoryIndexingUtils/Package.toml
+++ b/T/TrajectoryIndexingUtils/Package.toml
@@ -1,3 +1,3 @@
 name = "TrajectoryIndexingUtils"
 uuid = "6dad8b7f-dd9a-4c28-9b70-85b9a079bfc8"
-repo = "https://github.com/aarontrowbridge/TrajectoryIndexingUtils.jl.git"
+repo = "https://github.com/kestrelquantum/TrajectoryIndexingUtils.jl.git"


### PR DESCRIPTION
These packages wer recently moved to a new location:
https://github.com/kestrelquantum/NamedTrajectories.jl
https://github.com/kestrelquantum/TrajectoryIndexingUtils.jl
https://github.com/kestrelquantum/QuantumCollocation.jl
https://github.com/kestrelquantum/Piccolo.jl