### PR TITLE
[NLopt] move from JuliaOpt to jump-dev

### DIFF
--- a/N/NLopt/Package.toml
+++ b/N/NLopt/Package.toml
@@ -1,3 +1,3 @@
 name = "NLopt"
 uuid = "76087f3c-5699-56af-9a33-bf431cd00edd"
-repo = "https://github.com/JuliaOpt/NLopt.jl.git"
+repo = "https://github.com/jump-dev/NLopt.jl.git"


### PR DESCRIPTION
We've moved https://github.com/jump-dev/NLopt.jl into the `jump-dev` organization.