### PR TITLE
[NEOSServer] move from odow to jump-dev

### DIFF
--- a/N/NEOSServer/Package.toml
+++ b/N/NEOSServer/Package.toml
@@ -1,3 +1,3 @@
 name = "NEOSServer"
 uuid = "f10290a3-90ea-431b-80e2-02d4e6b73321"
-repo = "https://github.com/odow/NEOSServer.jl.git"
+repo = "https://github.com/jump-dev/NEOSServer.jl.git"


### PR DESCRIPTION
I've moved https://github.com/jump-dev/NEOSServer.jl from my personal account into jump-dev.