### PR TITLE
Update RemoteREPL url

### DIFF
--- a/R/RemoteREPL/Package.toml
+++ b/R/RemoteREPL/Package.toml
@@ -1,3 +1,3 @@
 name = "RemoteREPL"
 uuid = "1bd9f7bb-701c-4338-bec7-ac987af7c555"
-repo = "https://github.com/c42f/RemoteREPL.jl.git"
+repo = "https://github.com/JuliaWeb/RemoteREPL.jl.git"


### PR DESCRIPTION
I got the following error from JuliaRegistrator

> Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.

I think it was asking for this PR. When this is merged I will retrigger the registrator in https://github.com/JuliaWeb/RemoteREPL.jl/commit/101077bc344b050dabdccf9c918ab06e6a97340f