### PR TITLE
Fix repo URLs in non-canonical form (mostly OrdinaryDiffEq)

### DIFF
--- a/B/BlockDiagonals/Package.toml
+++ b/B/BlockDiagonals/Package.toml
@@ -1,3 +1,3 @@
 name = "BlockDiagonals"
 uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
-repo = "https://github.com/JuliaArrays/BlockDiagonals.jl"
+repo = "https://github.com/JuliaArrays/BlockDiagonals.jl.git"

--- a/O/OrdinaryDiffEqBDF/Package.toml
+++ b/O/OrdinaryDiffEqBDF/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqBDF"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqBDF"

--- a/O/OrdinaryDiffEqDefault/Package.toml
+++ b/O/OrdinaryDiffEqDefault/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqDefault"
 uuid = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqDefault"

--- a/O/OrdinaryDiffEqExponentialRK/Package.toml
+++ b/O/OrdinaryDiffEqExponentialRK/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqExponentialRK"
 uuid = "e0540318-69ee-4070-8777-9e2de6de23de"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqExponentialRK"

--- a/O/OrdinaryDiffEqLinear/Package.toml
+++ b/O/OrdinaryDiffEqLinear/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqLinear"
 uuid = "521117fe-8c41-49f8-b3b6-30780b3f0fb5"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqLinear"

--- a/O/OrdinaryDiffEqNordsieck/Package.toml
+++ b/O/OrdinaryDiffEqNordsieck/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqNordsieck"
 uuid = "c9986a66-5c92-4813-8696-a7ec84c806c8"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqNordsieck"

--- a/O/OrdinaryDiffEqPDIRK/Package.toml
+++ b/O/OrdinaryDiffEqPDIRK/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqPDIRK"
 uuid = "5dd0a6cf-3d4b-4314-aa06-06d4e299bc89"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqPDIRK"

--- a/O/OrdinaryDiffEqRosenbrock/Package.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqRosenbrock"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqRosenbrock"

--- a/O/OrdinaryDiffEqSDIRK/Package.toml
+++ b/O/OrdinaryDiffEqSDIRK/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqSDIRK"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqSDIRK"

--- a/O/OrdinaryDiffEqStabilizedIRK/Package.toml
+++ b/O/OrdinaryDiffEqStabilizedIRK/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqStabilizedIRK"
 uuid = "e3e12d00-db14-5390-b879-ac3dd2ef6296"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqStabilizedIRK"

--- a/O/OrdinaryDiffEqSymplecticRK/Package.toml
+++ b/O/OrdinaryDiffEqSymplecticRK/Package.toml
@@ -1,4 +1,4 @@
 name = "OrdinaryDiffEqSymplecticRK"
 uuid = "fa646aed-7ef9-47eb-84c4-9443fc8cbfa8"
-repo = "https://github.com/SciML/OrdinaryDiffEq.jl"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
 subdir = "lib/OrdinaryDiffEqSymplecticRK"


### PR DESCRIPTION
See the slack discussion. Some dropped the `.git` which makes JuliaRegistrator fail thinking the URL is not found. This seems to come from LocalRegistry.jl uses. This fixes it for all cases in the registry, which is mostly the OrdinaryDiffEq cases, plus one that was found by the regex which is BlockArrays.jl
