### PR TITLE
[HierarchicalEOM] Update URL

### DIFF
--- a/H/HierarchicalEOM/Package.toml
+++ b/H/HierarchicalEOM/Package.toml
@@ -1,3 +1,3 @@
 name = "HierarchicalEOM"
 uuid = "a62dbcb7-80f5-4d31-9a88-8b19fd92b128"
-repo = "https://github.com/NCKU-QFort/HierarchicalEOM.jl.git"
+repo = "https://github.com/qutip/HierarchicalEOM.jl.git"


### PR DESCRIPTION
Changing the repository link for [`HierarchicalEOM.jl`](https://github.com/qutip/HierarchicalEOM.jl) (transferring to a new organization)