### PR TITLE
Yank DiffEqCallbacks 3.9

### DIFF
--- a/D/DiffEqCallbacks/Versions.toml
+++ b/D/DiffEqCallbacks/Versions.toml
@@ -210,3 +210,4 @@ git-tree-sha1 = "befc86364d9b36abc6d874f91ab5d7b4d5e6bb62"
 
 ["3.9.0"]
 git-tree-sha1 = "9c802bf34741e2b4942912709321e87b7cbed023"
+yanked = true


### PR DESCRIPTION
This is missing a needed weak dependency, breaking package installs for some users. A 3.9.1 release will add it shortly.

cc: @ChrisRackauckas