### PR TITLE
[DynamicSumTypes] Change link for rename of package

### DIFF
--- a/D/DynamicSumTypes/Package.toml
+++ b/D/DynamicSumTypes/Package.toml
@@ -1,3 +1,3 @@
 name = "DynamicSumTypes"
 uuid = "5fcdbb90-de43-509e-b9a6-c4d43f29cf26"
-repo = "https://github.com/JuliaDynamics/DynamicSumTypes.jl.git"
+repo = "https://github.com/JuliaDynamics/LightSumTypes.jl.git"


### PR DESCRIPTION
Hi! I'm in the process to rename DynamicSumTypes.jl to LightSumTypes.jl because I was notified that it was a confusing name and I absolutely agree, so I update the link as required in the official procedure for renaming packages