### PR TITLE
Update MicroMagnetic.jl repository URL

### DIFF
--- a/M/MicroMagnetic/Package.toml
+++ b/M/MicroMagnetic/Package.toml
@@ -1,3 +1,3 @@
 name = "MicroMagnetic"
 uuid = "cef16ca0-16a8-11ef-389e-9fbcf1974e83"
-repo = "https://github.com/ww1g11/MicroMagnetic.jl.git"
+repo = "https://github.com/MagneticSimulation/MicroMagnetic.jl.git"


### PR DESCRIPTION
We have transferred MicroMagnetic.jl to an organization https://github.com/MagneticSimulation, so updating the repository URL is better.