### PR TITLE
Update MicroMagnetic.jl URL

### DIFF
--- a/M/MicroMagnetic/Package.toml
+++ b/M/MicroMagnetic/Package.toml
@@ -1,3 +1,3 @@
 name = "MicroMagnetic"
 uuid = "cef16ca0-16a8-11ef-389e-9fbcf1974e83"
-repo = "https://github.com/ww1g11/MicroMagnetic.jl.git"
+repo = "https://github.com/MagneticSimulation/MicroMagnetic.jl.git"


### PR DESCRIPTION
MicroMagnetic.jl is transferred to an organization https://github.com/MagneticSimulation. I closed the pull request https://github.com/JuliaRegistries/General/pull/115185 because it was modified on the master branch. 