### PR TITLE
[MakieTeX] Change URL to MakieOrg

### DIFF
--- a/M/MakieTeX/Package.toml
+++ b/M/MakieTeX/Package.toml
@@ -1,3 +1,3 @@
 name = "MakieTeX"
 uuid = "6d554a22-29e7-47bd-aee5-0c5f06619414"
-repo = "https://github.com/JuliaPlots/MakieTeX.jl.git"
+repo = "https://github.com/MakieOrg/MakieTeX.jl.git"


### PR DESCRIPTION
The package was transferred to MakieOrg, so this PR changes the URL accordingly.