### PR TITLE
Update Tapir.jl URL for renaming

### DIFF
--- a/T/Tapir/Package.toml
+++ b/T/Tapir/Package.toml
@@ -1,3 +1,3 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
-repo = "https://github.com/compintell/Tapir.jl.git"
+repo = "https://github.com/compintell/Mooncake.jl.git"


### PR DESCRIPTION
Tapir.jl -> Mooncake.jl.

A PR to do the full renaming will appear later today, if everything goes according to plan.