### PR TITLE
Update `Package.toml` for RxEnvironments.jl

### DIFF
--- a/R/RxEnvironments/Package.toml
+++ b/R/RxEnvironments/Package.toml
@@ -1,3 +1,3 @@
 name = "RxEnvironments"
 uuid = "5ea003d0-0c30-4e5c-84d5-cc22d8d83890"
-repo = "https://github.com/biaslab/RxEnvironments.jl.git"
+repo = "https://github.com/ReactiveBayes/RxEnvironments.jl.git"


### PR DESCRIPTION
RxEnvironments.jl has been moved to a new organisation. The new link is https://github.com/ReactiveBayes/RxEnvironments.jl