### PR TITLE
New version: WaveletsExt v0.2.2

### DIFF
--- a/W/WaveletsExt/Compat.toml
+++ b/W/WaveletsExt/Compat.toml
@@ -1,7 +1,3 @@
-[0]
-AverageShiftedHistograms = "0.8.6-0.8"
-Parameters = "0.12.2-0.12"
-
 ["0-0.1.1"]
 Reexport = "0.2"
 StatsBase = "0.33.4-0.33"
@@ -14,16 +10,19 @@ julia = "1.5.0-1"
 ["0-0.1.7"]
 Plots = "1.11.2-1"
 
-["0.1.11-0"]
+["0-0.2.1"]
+AverageShiftedHistograms = "0.8.6-0.8"
+Parameters = "0.12.2-0.12"
+
+["0.1.11-0.2.1"]
 ImageQualityIndexes = "0.2-0.3"
 
 ["0.1.13-0"]
 Combinatorics = "1"
-Statistics = "1.6.0-1"
 julia = "1.6.0-1"
 
-["0.1.2-0"]
-Wavelets = "0.9.3-0.9"
+["0.1.13-0.2.1"]
+Statistics = "1.6.0-1"
 
 ["0.1.2-0.1.10"]
 ImageQualityIndexes = "0.2"
@@ -32,13 +31,26 @@ ImageQualityIndexes = "0.2"
 Reexport = ["0.2", "1"]
 StatsBase = "0.33.5-0.33"
 
-["0.1.4-0"]
+["0.1.2-0.2.1"]
+Wavelets = "0.9.3-0.9"
+
+["0.1.4-0.2.1"]
 Distributions = "0.24-0.25"
 
 ["0.1.8-0"]
 Plots = "1.20.0-1"
 Reexport = "1.1.0-1"
+
+["0.1.8-0.2.1"]
 StatsBase = "0.33.9-0.33"
 
 ["0.1.9"]
 GR = "0.59"
+
+["0.2.2-0"]
+AverageShiftedHistograms = "0.8.9-0.8"
+Distributions = "0.25"
+ImageQualityIndexes = "0.3"
+Parameters = "0.12"
+StatsBase = "0.34"
+Wavelets = "0.10"

--- a/W/WaveletsExt/Versions.toml
+++ b/W/WaveletsExt/Versions.toml
@@ -60,3 +60,6 @@ git-tree-sha1 = "cd4afccb9d7987618199bf1d3b0022a9ec71bbf2"
 
 ["0.2.1"]
 git-tree-sha1 = "4cabb020c5d63e1185dda25043c267f5407fe154"
+
+["0.2.2"]
+git-tree-sha1 = "888ac8931079caba760865cf8b09d302222cbbf9"


### PR DESCRIPTION
UUID: 8f464e1e-25db-479f-b0a5-b7680379e03f
Repo:
Tree: 888ac8931079caba760865cf8b09d302222cbbf9

Original package (https://github.com/UCD4IDS/WaveletsExt.jl) is not maintained anymore, its developers are not responding to emails. This PR fixes a problem with the package compatibility on up-to-date systems.