### PR TITLE
Transfer LieGroups.jl from a personal space to JuliaManifolds

### DIFF
--- a/L/LieGroups/Package.toml
+++ b/L/LieGroups/Package.toml
@@ -1,3 +1,3 @@
 name = "LieGroups"
 uuid = "6774de46-80ba-43f8-ba42-e41071ccfc5f"
-repo = "https://github.com/yuehhua/LieGroups.jl.git"
+repo = "https://github.com/JuliaManifolds/LieGroups.jl.git"


### PR DESCRIPTION
Today we transferred the repository

https://github.com/JuliaManifolds/LieGroups.jl

to a GitHub Org and will start working on that again, so this PR updates the corresponding URL in the registry