### PR TITLE
We moved GalerkinToolkit to a new github organization.

### DIFF
--- a/G/GalerkinToolkit/Package.toml
+++ b/G/GalerkinToolkit/Package.toml
@@ -1,3 +1,3 @@
 name = "GalerkinToolkit"
 uuid = "5e3ba9c4-dd81-444d-b69a-0e7bd7bf60a4"
-repo = "https://github.com/fverdugo/GalerkinToolkit.jl.git"
+repo = "https://github.com/GalerkinToolkit/GalerkinToolkit.jl.git"


### PR DESCRIPTION
We moved GalerkinToolkit to a new github organization.