### PR TITLE
CI: Stop running consistency tests on 1.4 and 1.5 (but keep running them on 1.3)

### DIFF
--- a/.github/workflows/registry-consistency-ci-cron.yml
+++ b/.github/workflows/registry-consistency-ci-cron.yml
@@ -1,6 +1,6 @@
 name: Registry Consistency (Cron)
 on:
-    schedule:
+  schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
 env:

--- a/.github/workflows/registry-consistency-ci-cron.yml
+++ b/.github/workflows/registry-consistency-ci-cron.yml
@@ -1,11 +1,7 @@
-name: Registry Consistency
+name: Registry Consistency (Cron)
 on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+    schedule:
+    - cron:  '0 0 * * *'
   workflow_dispatch:
 env:
     JULIA_PKG_USE_CLI_GIT: true
@@ -19,12 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          # Keep this list in sync with `update_manifests.yml`.
           # - '1.0' # RegistryCI currently doesn't support Julia 1.0
           # - '1.1' # RegistryCI currently doesn't support Julia 1.1
           # - '1.2' # RegistryCI currently doesn't support Julia 1.2
           - '1.3'
-          # We intentionally skip the following: 1.4, 1.5
-          # But we include those when we run the once-daily cron job.
+          - '1.4'
+          - '1.5'
           - '1.6'
           - '1.7'
           - '1.8'

--- a/.github/workflows/registry-consistency-ci.yml
+++ b/.github/workflows/registry-consistency-ci.yml
@@ -24,8 +24,6 @@ jobs:
           # - '1.1' # RegistryCI currently doesn't support Julia 1.1
           # - '1.2' # RegistryCI currently doesn't support Julia 1.2
           - '1.3'
-          - '1.4'
-          - '1.5'
           - '1.6'
           - '1.7'
           - '1.8'

--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # Keep this list in sync with `ci.yml`.
+          # Keep this list in sync with `registry-consistency-ci-cron.yml`.
           - '1.3'
           - '1.4'
           - '1.5'


### PR DESCRIPTION
The idea here is to try to conserve CI resources.

We intentionally keep the 1.3 job; hopefully, that'll help us continue to catch problems that might affect older Julia versions.