### PR TITLE
Update URL for ILog2.jl

### DIFF
--- a/I/ILog2/Package.toml
+++ b/I/ILog2/Package.toml
@@ -1,3 +1,3 @@
 name = "ILog2"
 uuid = "2cd5bd5f-40a1-5050-9e10-fc8cdb6109f5"
-repo = "https://github.com/jlapeyre/ILog2.jl.git"
+repo = "https://github.com/JuliaMath/ILog2.jl.git"


### PR DESCRIPTION
This commit changes the URL of ILog2.jl to point to the JuliaMath org.  This package was moved to JuliaMath over a year ago, but the URL was never updated in the General registry.