### PR TITLE
Change the url of MittagLeffler.jl to point to JuliaMath

### DIFF
--- a/M/MittagLeffler/Package.toml
+++ b/M/MittagLeffler/Package.toml
@@ -1,3 +1,3 @@
 name = "MittagLeffler"
 uuid = "9c257583-4f8f-53fd-abd9-c69d5080dd54"
-repo = "https://github.com/jlapeyre/MittagLeffler.jl.git"
+repo = "https://github.com/JuliaMath/MittagLeffler.jl.git"


### PR DESCRIPTION
This repo was transferred to JuliaMath. But the package url was never updated.