### PR TITLE
README: Past package exceptions do not provide a precedent for current and future registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ In this case, the release should be completely deleted from the registry and a n
 issued. This is a drastic measure that breaks reproducibility guarantees and has never been performed as of 
 April, 2024.
 
+### My new package registration PR fails one or more AutoMerge checks because of reason [X]. However, the General registry already contains a package PastPackage that does thing [X]. Will registry maintainers consider this PastPackage when they evaluate my new package registration PR?
+
+As a general rule, no. If your package registration does not meet AutoMerge guidelines, then the presence of previous exceptions to those guidelines does not justify an exception for your package, and registry maintainers will not consider past packages to be any kind of precedent that applies to current and future registrations.
+
 ## Registry maintenance
 
 The General registry is a shared resource that belongs to the entire Julia community. Therefore, we welcome comments and suggestions from everyone in the Julia community. However, all decisions regarding the General registry are ultimately up to the discretion of the registry maintainers.


### PR DESCRIPTION
From time to time, people will attempt to justify a new package registration by saying "we already have packages that do X".

For example, from time to time, someone wants to register a package that begins with a lowercase letter. This does not meet the AutoMerge requirement that all packages should start with an uppercase letter. In such situations, sometimes people will point out some examples of packages (currently registered in General) that begin with a lowercase letter.

Another example would be package name length. From time to time, someone tries to register a three-letter package name, and when AutoMerge reports that the name-length-guideline fails, the package author (or someone else) points out that there are currently packages in General that have three-letter name.

In my opinion, we need to clamp down on this. As I see it, just because a certain decision was made in the past, that doesn't mean that registry maintainers should be bound by it in the future. Some of those past decisions might (in retrospect) have been mistakes, and it doesn't make sense to force us to repeat those same mistakes.

With this PR, we write something explicitly in the README of General explaining that if your package registration does not meet AutoMerge guidelines, then the presence of previous exceptions to those guidelines does not justify an exception for your package, and registry maintainers will not consider past packages to be any kind of precedent that applies to current and future registrations.