### PR TITLE
MeshIntegrals.jl is now part of the JuliaGeometry organization

### DIFF
--- a/M/MeshIntegrals/Package.toml
+++ b/M/MeshIntegrals/Package.toml
@@ -1,3 +1,3 @@
 name = "MeshIntegrals"
 uuid = "dadec2fd-bbe0-4da4-9dbe-476c782c8e47"
-repo = "https://github.com/mikeingold/MeshIntegrals.jl.git"
+repo = "https://github.com/JuliaGeometry/MeshIntegrals.jl.git"


### PR DESCRIPTION
The MeshIntegrals.jl package has been moved from my personal account to the JuliaGeometry organization. This PR updates the `repo` link in General to reflect our new home.