### PR TITLE
Transfer DifferentiationInterface to the JuliaDiff org

### DIFF
--- a/D/DifferentiationInterface/Package.toml
+++ b/D/DifferentiationInterface/Package.toml
@@ -1,4 +1,4 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-repo = "https://github.com/gdalle/DifferentiationInterface.jl.git"
+repo = "https://github.com/JuliaDiff/DifferentiationInterface.jl.git"
 subdir = "DifferentiationInterface"

--- a/D/DifferentiationInterfaceTest/Package.toml
+++ b/D/DifferentiationInterfaceTest/Package.toml
@@ -1,4 +1,4 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
-repo = "https://github.com/gdalle/DifferentiationInterface.jl.git"
+repo = "https://github.com/JuliaDiff/DifferentiationInterface.jl.git"
 subdir = "DifferentiationInterfaceTest"


### PR DESCRIPTION
Move two packages from my own profile to the JuliaDiff organization:

- DifferentiationInterface
- DifferentiationInterfaceTest

Both are part of the same monorepo at <https://github.com/JuliaDiff/DifferentiationInterface.jl>