### PR TITLE
fix: move all Lux packages to a mono-repo

### DIFF
--- a/L/LuxCUDA/Package.toml
+++ b/L/LuxCUDA/Package.toml
@@ -1,3 +1,4 @@
 name = "LuxCUDA"
 uuid = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
-repo = "https://github.com/LuxDL/LuxCUDA.jl.git"
+repo = "https://github.com/LuxDL/Lux.jl.git"
+subdir = "lib/LuxCUDA"

--- a/L/LuxCore/Package.toml
+++ b/L/LuxCore/Package.toml
@@ -1,3 +1,4 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
-repo = "https://github.com/LuxDL/LuxCore.jl.git"
+repo = "https://github.com/LuxDL/Lux.jl.git"
+subdir = "lib/LuxCore"

--- a/L/LuxLib/Package.toml
+++ b/L/LuxLib/Package.toml
@@ -1,3 +1,4 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
-repo = "https://github.com/LuxDL/LuxLib.jl.git"
+repo = "https://github.com/LuxDL/Lux.jl.git"
+subdir = "lib/LuxLib"

--- a/L/LuxTestUtils/Package.toml
+++ b/L/LuxTestUtils/Package.toml
@@ -1,3 +1,4 @@
 name = "LuxTestUtils"
 uuid = "ac9de150-d08f-4546-94fb-7472b5760531"
-repo = "https://github.com/LuxDL/LuxTestUtils.jl.git"
+repo = "https://github.com/LuxDL/Lux.jl.git"
+subdir = "lib/LuxTestUtils"

--- a/M/MLDataDevices/Package.toml
+++ b/M/MLDataDevices/Package.toml
@@ -1,3 +1,4 @@
 name = "MLDataDevices"
 uuid = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
-repo = "https://github.com/LuxDL/MLDataDevices.jl.git"
+repo = "https://github.com/LuxDL/Lux.jl.git"
+subdir = "lib/MLDataDevices"

--- a/W/WeightInitializers/Package.toml
+++ b/W/WeightInitializers/Package.toml
@@ -1,3 +1,4 @@
 name = "WeightInitializers"
 uuid = "d49dbf32-c5c2-4618-8acc-27bb2598ef2d"
-repo = "https://github.com/LuxDL/WeightInitializers.jl.git"
+repo = "https://github.com/LuxDL/Lux.jl.git"
+subdir = "lib/WeightInitializers"


### PR DESCRIPTION
```julia
using RegistryInstances, UUIDs, Git

const GENERAL_UUID = UUID("23338594-aafe-5451-b93e-139f81909106")

pretty_print_row(row) = println(row.pkg_name, ": v", row.version, " ", row.found ? "found" : "is missing")
pretty_print_table(table) = foreach(pretty_print_row, table)

function check_all_found(table)
    idx = findfirst(row -> !row.found, table)
    idx === nothing && return nothing
    row = table[idx]
    error(string("Repository missing v", row.version, " of package $(row.pkg_name)"))
end

function check_packages_versions(pkg_names, repo_url; registry_uuid=GENERAL_UUID, verbose=true, throw=true)
    if repo_url === nothing
        dir = joinpath(@__DIR__, "..")
    else
        dir = mktempdir()
        run(`$(git()) clone $(repo_url) $dir`)
    end

    registry = only(filter!(r -> r.uuid == registry_uuid, reachable_registries()))

    table = @NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}[]

    for pkg_name in pkg_names
        pkg = registry.pkgs[only(uuids_from_name(registry, pkg_name))]
        versions = registry_info(pkg).version_info
        for version in sort(collect(keys(versions)))
            tree_sha = versions[version].git_tree_sha1
            found = success(`$(git()) -C $dir rev-parse -q --verify "$(tree_sha)^{tree}"`)

            push!(table, (; pkg_name, version, found))
        end
    end
    verbose && pretty_print_table(table)
    throw && check_all_found(table)
    return table
end

check_packages_versions(
    ["Lux", "LuxLib", "LuxCore", "MLDataDevices", "WeightInitializers", "LuxTestUtils", "LuxCUDA"],
    "https://github.com/LuxDL/Lux.jl.git"
)
```

Verified all registered versions are available from the updated links