### PR TITLE
github name change, update repo link

### DIFF
--- a/N/NMRInversions/Package.toml
+++ b/N/NMRInversions/Package.toml
@@ -1,3 +1,3 @@
 name = "NMRInversions"
 uuid = "55c20db2-0166-4687-95c3-62a9c7afb29b"
-repo = "https://github.com/arismavridis/NMRInversions.jl.git"
+repo = "https://github.com/aris-mav/NMRInversions.jl.git"


### PR DESCRIPTION
Registrator gives the message:
```
Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.
```
I change the link to address this.