### PR TITLE
New package: StateSelection

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -4591,6 +4591,7 @@ some amount of consideration when choosing package names.
 647c4018-d7ef-4d03-a0cc-8889a722319e = { name = "MixedModelsPermutations", path = "M/MixedModelsPermutations" }
 6484683b-de53-5689-b9d2-2f18b83297fe = { name = "DrakeLCMTypes", path = "D/DrakeLCMTypes" }
 6486599b-a3cd-4e92-a99a-2cea90cc8c3c = { name = "ReinforcementLearningTrajectories", path = "R/ReinforcementLearningTrajectories" }
+64909d44-ed92-46a8-bbd9-f047dfbdc84b = { name = "StateSelection", path = "S/StateSelection" }
 6490f8d2-1475-45bb-865d-edb65413071d = { name = "CheckedCalls", path = "C/CheckedCalls" }
 64931d76-8770-46b0-8423-0a5d3a7d2d72 = { name = "ParameterSpacePartitions", path = "P/ParameterSpacePartitions" }
 649716ba-0eb1-4560-ace2-251185f55281 = { name = "OverflowContexts", path = "O/OverflowContexts" }

--- a/S/StateSelection/Compat.toml
+++ b/S/StateSelection/Compat.toml
@@ -1,0 +1,9 @@
+[0]
+DocStringExtensions = "0.9.3 - 0.9"
+FindFirstFunctions = "1.2.0 - 1"
+Graphs = "1.10.0 - 1"
+LinearAlgebra = "1.11.0 - 1"
+Setfield = "1.1.1 - 1"
+SparseArrays = "1.11.0 - 1"
+UnPack = "1.0.2 - 1"
+julia = "1.9.0 - 1"

--- a/S/StateSelection/Deps.toml
+++ b/S/StateSelection/Deps.toml
@@ -1,0 +1,8 @@
+[0]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+FindFirstFunctions = "64ca27bc-2ba2-4a57-88aa-44e436879224"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"

--- a/S/StateSelection/Package.toml
+++ b/S/StateSelection/Package.toml
@@ -1,0 +1,3 @@
+name = "StateSelection"
+uuid = "64909d44-ed92-46a8-bbd9-f047dfbdc84b"
+repo = "git@github.com:JuliaComputing/StateSelection.jl.git"

--- a/S/StateSelection/Versions.toml
+++ b/S/StateSelection/Versions.toml
@@ -1,0 +1,5 @@
+["0.2.0"]
+git-tree-sha1 = "3a3a11a8c070d261e2c61a27d227fc19e67216f0"
+
+["0.2.1"]
+git-tree-sha1 = "8f678b62e77e1bf1f74744cfc79bfafa81332942"

--- a/S/StateSelection/WeakDeps.toml
+++ b/S/StateSelection/WeakDeps.toml
@@ -1,0 +1,2 @@
+[0]
+DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"


### PR DESCRIPTION
This registers https://github.com/JuliaComputing/StateSelection.jl. This package implements structural transformation and analysis of equation systems. This code has bit of history. It started out as a translation of similar code in Modia.jl in a private package. It was thereafter open sourced and incorporated in MTK, then split out again into this package, which is the version used in Cedar's DAECompiler. The package is currently registered in the Cedar public registry, but not General. This PR moves the registration to General to enable other packages in general to depend on it. Hopefully this will become the canonical version of this code that everybody just uses.

Two versions are being registered, 0.2.0, and 0.2.1, which are the two versions that are public in the Cedar registry. There is also a 0.1.0 version, but this version was never publicly registered, so it is omitted from this registration as well.