### PR TITLE
Move package: TBLIS.jl

### DIFF
--- a/T/TBLIS/Package.toml
+++ b/T/TBLIS/Package.toml
@@ -1,3 +1,3 @@
 name = "TBLIS"
 uuid = "48530278-0828-4a49-9772-0f3830dfa1e9"
-repo = "https://github.com/FermiQC/TBLIS.jl.git"
+repo = "https://github.com/QuantumKitHub/TBLIS.jl.git"


### PR DESCRIPTION
This PR updates the location of the TBLIS.jl package, to reflect the transfer of TBLIS.jl to the QuantumKitHub organization.