### PR TITLE
yank StructArrays@0.7.0

### DIFF
--- a/S/StructArrays/Versions.toml
+++ b/S/StructArrays/Versions.toml
@@ -115,3 +115,4 @@ git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 
 ["0.7.0"]
 git-tree-sha1 = "5a3a31c41e15a1e042d60f2f4942adccba05d3c9"
+yanked = true


### PR DESCRIPTION
The version was tagged as breaking but actually isn't. To fix that, it has been released as 0.6.20 afterwards (same exact content).
Meanwhile, 0.7.0 should probably be yanked to avoid further confusion – this PR.