### PR TITLE
Move package StarStats from subdir to main directory within the same repo

### DIFF
--- a/S/StarStats/Package.toml
+++ b/S/StarStats/Package.toml
@@ -1,4 +1,3 @@
 name = "StarStats"
 uuid = "3d48db48-6773-11ed-1a7e-43a2532b2fa8"
 repo = "https://github.com/orlox/StarStats.jl.git"
-subdir = "StarStats"


### PR DESCRIPTION
I want to move the StarStats package from a subdir to the root of the repository. Following the github documentation on moving a subdirectory to its own repository (https://github.com/JuliaRegistries/General?tab=readme-ov-file#how-do-i-move-a-subdirectory-package-to-its-own-repository), I moved the files within the repo and then carried out steps 2 and 3. The check for previous versions indicates that 0.12 (the only version previously available) is there
```
check_packages_versions(["StarStats"], "https://github.com/orlox/StarStats.jl.git")
Cloning into '/tmp/jl_qt8t1F'...
remote: Enumerating objects: 292, done.
remote: Counting objects: 100% (135/135), done.
remote: Compressing objects: 100% (101/101), done.
remote: Total 292 (delta 55), reused 99 (delta 31), pack-reused 157 (from 1)
Receiving objects: 100% (292/292), 28.84 MiB | 8.50 MiB/s, done.
Resolving deltas: 100% (110/110), done.
pkg_names = ["StarStats"]
StarStats: v0.12.0 found
1-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "StarStats", version = v"0.12.0", found = 1)

```