### PR TITLE
Update URL of AcceleratedKernels.jl after transfer to JuliaGPU

### DIFF
--- a/A/AcceleratedKernels/Package.toml
+++ b/A/AcceleratedKernels/Package.toml
@@ -1,3 +1,3 @@
 name = "AcceleratedKernels"
 uuid = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
-repo = "https://github.com/anicusan/AcceleratedKernels.jl.git"
+repo = "https://github.com/JuliaGPU/AcceleratedKernels.jl.git"


### PR DESCRIPTION
The previous [link](https://github.com/anicusan/AcceleratedKernels.jl) redirects to the [new one](https://github.com/JuliaGPU/AcceleratedKernels.jl).