### PR TITLE
transfer GraphNeuralNetworks.jl to JuliaGraphs org

### DIFF
--- a/G/GraphNeuralNetworks/Package.toml
+++ b/G/GraphNeuralNetworks/Package.toml
@@ -1,3 +1,4 @@
 name = "GraphNeuralNetworks"
 uuid = "cffab07f-9bc2-4db1-8861-388f63bf7694"
-repo = "https://github.com/CarloLucibello/GraphNeuralNetworks.jl.git"
+repo = "https://github.com/JuliaGraphs/GraphNeuralNetworks.jl.git"
+subdir = "GraphNeuralNetworks"


### PR DESCRIPTION
updating the repo after the transfer
https://github.com/JuliaGraphs/GraphNeuralNetworks.jl