### PR TITLE
Update Repo: FuzzifiED

### DIFF
--- a/F/FuzzifiED/Package.toml
+++ b/F/FuzzifiED/Package.toml
@@ -1,3 +1,3 @@
 name = "FuzzifiED"
 uuid = "b45b6d2d-92f2-400f-a7df-d2d897927e5f"
-repo = "https://github.com/mankai-chow/FuzzifiED.jl.git"
+repo = "https://github.com/FuzzifiED/FuzzifiED.jl.git"


### PR DESCRIPTION
The GitHub repo for the package FuzzifiED has been moved to an organisation account. I am updating the registry accordingly. 