### PR TITLE
Redirect pages: Add 404 pages

### DIFF
--- a/.ci/generate_redirects.jl
+++ b/.ci/generate_redirects.jl
@@ -128,8 +128,8 @@ function create_404_page()
                 messageElement.innerHTML = `\
                     There is no package \${packageName} registered in the Julia General Registry.\
                     <br><br>\
-                    Would you like to try searching <a href="https://github.com/search?q=\${packageName}.jl&type=repositories">Github</a>, \
-                    <a href="https://about.gitlab.com/search/?searchText=\${packageName}.jl">Gitlab</a>, \
+                    Would you like to try searching <a href="https://github.com/search?q=\${packageName}.jl&type=repositories">GitHub</a>, \
+                    <a href="https://about.gitlab.com/search/?searchText=\${packageName}.jl">GitLab</a>, \
                     <a href="https://www.google.com/search?q=\${packageName}.jl">Google</a>, \
                     or <a href="https://duckduckgo.com/?q=\${packageName}.jl">DuckDuckGo</a> for it?`;
             }

--- a/.ci/generate_redirects.jl
+++ b/.ci/generate_redirects.jl
@@ -61,17 +61,18 @@ end
 function create_redirect_page(; name, path)
     repo = get_repo(path)
     host = get_host(repo)
+    jlname = name * ".jl"
     should_redirect = known_host(host)
     meta_redirection = should_redirect ? """<meta http-equiv="refresh" content="0; url=$repo">""" : ""
     message = if should_redirect
-        """Redirecting to $name...<br><br>Click the link below if you are not redirected automatically to the registered repository for the Julia package $name<br><br><a href="$repo" rel="nofollow">$repo</a>"""
+        """Redirecting to $jlname...<br><br>Click the link below if you are not redirected automatically to the registered repository for the Julia package $jlname<br><br><a href="$repo" rel="nofollow">$repo</a>"""
     else
-        """Click the link below to go to the registered repository for the Julia package $name<br><br><a href="$repo" rel="nofollow">$repo</a>"""
+        """Click the link below to go to the registered repository for the Julia package $jlname<br><br><a href="$repo" rel="nofollow">$repo</a>"""
     end
     title = if should_redirect
-        "Redirecting to $name..."
+        "Redirecting to $jlname..."
     else
-        "Confirm redirect to $name"
+        "Confirm redirect to $jlname"
     end
 
     open(package_path(name * ".html"), "w") do io
@@ -126,7 +127,7 @@ function create_404_page()
                 const messageElement = document.querySelector(".centered-div p");
                 // Update the paragraph text
                 messageElement.innerHTML = `\
-                    There is no package \${packageName} registered in the Julia General Registry.\
+                    There is no package \${packageName}.jl registered in the Julia General Registry.\
                     <br><br>\
                     Would you like to try searching <a href="https://github.com/search?q=\${packageName}.jl&type=repositories">GitHub</a>, \
                     <a href="https://about.gitlab.com/search/?searchText=\${packageName}.jl">GitLab</a>, \

--- a/.ci/generate_redirects.jl
+++ b/.ci/generate_redirects.jl
@@ -131,7 +131,7 @@ function create_404_page()
                     Would you like to try searching <a href="https://github.com/search?q=\${packageName}.jl&type=repositories">Github</a>, \
                     <a href="https://about.gitlab.com/search/?searchText=\${packageName}.jl">Gitlab</a>, \
                     <a href="https://www.google.com/search?q=\${packageName}.jl">Google</a>, \
-                    or <a href="https://duckduckgo.com/?t=h_&q=\${packageName}.jl">DuckDuckGo</a> for it?`;
+                    or <a href="https://duckduckgo.com/?q=\${packageName}.jl">DuckDuckGo</a> for it?`;
             }
         </script>
         </body>

--- a/.github/workflows/redirects_page.yml
+++ b/.github/workflows/redirects_page.yml
@@ -7,6 +7,9 @@ on:
       - master
     paths:
       - '**/Package.toml' # avoids redeploys on version or compat changes
+      - '.github/workflows/redirects_page.yml'
+      - '.ci/generate_redirects.jl'
+
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Adds a special error mode if the path matches the required format but the package is wrong:

<img width="711" alt="grafik" src="https://github.com/user-attachments/assets/3849e47c-1eae-4cf8-bdc3-c8e9211dd0c8">

And a generic 404 page otherwise

<img width="672" alt="grafik" src="https://github.com/user-attachments/assets/55fc62ae-e7bd-4512-bb2c-8ecf26bb8613">
