### PR TITLE
Generate Redirects CI: Add a once-daily fallback cron job

### DIFF
--- a/.github/workflows/redirects_page.yml
+++ b/.github/workflows/redirects_page.yml
@@ -2,6 +2,8 @@ name: Generate and Deploy Redirects
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
Right now, we only update the redirects when either `Package.toml` is touched or when a manual run is triggered. But GitHub CI jobs sometimes just fails randomly. If the CI job fails when `E/Example/Package.toml` is touched, then the redirect for Example.jl won't get updated until either a manual run is triggered or some other package has their `Package.toml` file touched.

So, as a fallback, let's rebuild the pages once per day. That way, if the CI job fails when a new package is merged (or an existing package is updated), worst case we have to wait at most 1 day before the redirect is automatically updated.