### PR TITLE
Yank GDAL_jll 301.1000.1

### DIFF
--- a/jll/G/GDAL_jll/Versions.toml
+++ b/jll/G/GDAL_jll/Versions.toml
@@ -131,3 +131,4 @@ git-tree-sha1 = "038ba1e842c00fee1f1710bd027451bf20c72b81"
 
 ["301.1000.0+0"]
 git-tree-sha1 = "eee99d2f207d8149fb71df5a024feef2e8613d01"
+yanked = true


### PR DESCRIPTION
This version provides GDAL 3.10, but is incompatible with GDAL_jll 301.900.x. It should have been released as GDAL_jll 302.1000.1.