### PR TITLE
Enable release note requirement for breaking releases

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -97,6 +97,7 @@ jobs:
               "https://github.com/cossio/CossioJuliaRegistry"
             ],
             point_to_slack = true,
+            check_breaking_explanation = true,
           )
         shell: julia --color=yes --project=.ci/ {0}
   AutoMerge-stopwatch:


### PR DESCRIPTION
turns on the check from https://github.com/JuliaRegistries/RegistryCI.jl/pull/586