### PR TITLE
[CameraCalibrations] Added jl to the repo URL

### DIFF
--- a/C/CameraCalibrations/Package.toml
+++ b/C/CameraCalibrations/Package.toml
@@ -1,3 +1,3 @@
 name = "CameraCalibrations"
 uuid = "70c3cbac-2c23-4b2d-966c-5a25c0a540fb"
-repo = "https://github.com/yakir12/CameraCalibrations.git"
+repo = "https://github.com/yakir12/CameraCalibrations.jl.git"


### PR DESCRIPTION
I added the `.jl` to my package repo in order to follow the 5th rule:
"Repo URL ends with /PackageName.jl.git"
in the Automatic merging guidelines.