### PR TITLE
[GHA] Set concurrency groups for automerge and registry consistency jobs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,5 @@
 name: AutoMerge
+
 on:
   pull_request:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
@@ -11,6 +12,7 @@ on:
     # We will choose to run the fallback job every 4 hours.
     - cron:  '0 */4 * * *'
   workflow_dispatch:
+
 env:
     JULIA_PKG_USE_CLI_GIT: true
     # We only need the merging token
@@ -19,6 +21,13 @@ env:
     # See also the same logic inside RegistryCI:
     # https://github.com/JuliaRegistries/RegistryCI.jl/blob/ee1d7cdb165202f4f3929a122c3188fbdd7afc16/src/AutoMerge/ciservice.jl#L53-L67
     NEED_MERGE_TOKEN: ${{ github.ref == 'refs/heads/master' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   AutoMerge:
     # Run if:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,9 +24,10 @@ env:
 
 concurrency:
   # Skip intermediate builds: always.
-  # Cancel intermediate builds: always.
+  # Cancel intermediate builds: only pull request builds
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+env:
 
 jobs:
   AutoMerge:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,7 +27,6 @@ concurrency:
   # Cancel intermediate builds: only pull request builds
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-env:
 
 jobs:
   AutoMerge:

--- a/.github/workflows/registry-consistency-ci.yml
+++ b/.github/workflows/registry-consistency-ci.yml
@@ -1,4 +1,5 @@
 name: Registry Consistency
+
 on:
   pull_request:
     branches:
@@ -7,10 +8,19 @@ on:
     branches:
       - master
   workflow_dispatch:
+
 env:
     JULIA_PKG_USE_CLI_GIT: true
+
 permissions:
   contents: read
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/registry-consistency-ci.yml
+++ b/.github/workflows/registry-consistency-ci.yml
@@ -20,7 +20,6 @@ concurrency:
   # Cancel intermediate builds: only pull request builds
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-env:
 
 jobs:
   check:

--- a/.github/workflows/registry-consistency-ci.yml
+++ b/.github/workflows/registry-consistency-ci.yml
@@ -17,9 +17,10 @@ permissions:
 
 concurrency:
   # Skip intermediate builds: always.
-  # Cancel intermediate builds: always.
+  # Cancel intermediate builds: only pull request builds
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+env:
 
 jobs:
   check:


### PR DESCRIPTION
This will save some useless cycles when submitting multiple commits to a PR branch in a rapid sequence.