### PR TITLE
Update package naming guidelines URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ You can register your package!
 See [Registering a package in General](https://github.com/JuliaRegistries/General#registering-a-package-in-general) in the README for how to do that.
 The "FAQ" section in the README helps answer many more questions, like [do I need to register a package to install it?](https://github.com/JuliaRegistries/General#do-i-need-to-register-a-package-to-install-it), [should I register my package?](https://github.com/JuliaRegistries/General#should-i-register-my-package), and more.
 
-* Please be aware of the [package naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-guidelines)
+* Please be aware of the [package naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules)
 * We strongly encourage authors to follow best practices like having documentation (or a descriptive README), tests, and continuous integration.
 
 ## As a Julia community member

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ not a curated list of Julia packages. In particular this means that:
 [registrator-web]: https://github.com/JuliaRegistries/Registrator.jl#via-the-web-interface
 [registrator-readme]: https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.md
 [tagbot]: https://github.com/JuliaRegistries/TagBot
-[naming-guidelines]: https://julialang.github.io/Pkg.jl/v1/creating-packages/#Package-naming-guidelines-1
+[naming-guidelines]: https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules
 [automerge-guidelines]: https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/
 [registryci]: https://github.com/JuliaRegistries/RegistryCI.jl
 [github-rename]: https://help.github.com/en/github/administering-a-repository/renaming-a-repository


### PR DESCRIPTION
The URL for the naming guidelines has changed from

https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-guidelines

to

https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules

.

I am unclear of when this actually changed. https://github.com/JuliaLang/Pkg.jl/pull/3818 by @KristofferC seems to have introduced the change in this repository. It appears that modification was not a pure reversion of https://github.com/JuliaLang/Pkg.jl/pull/3690. The deleted creating-packages.md still referred to "guidelines" rather than "rules". However, the "reverted" creating-packages.md now refers to "rules" instead of "guidelines".

