### PR TITLE
Restrict CURL compat

### DIFF
--- a/jll/C/CURL_jll/Compat.toml
+++ b/jll/C/CURL_jll/Compat.toml
@@ -21,10 +21,10 @@ Libdl = ["0.0.0", "1"]
 OpenSSL_jll = "3.0.15-3"
 
 ["8.11.0"]
-LibCURL_jll = "8.11.0-8"
+LibCURL_jll = "8.11.0-8.11"
 
 ["8.11.1-8"]
-LibCURL_jll = "8.11.1-8"
+LibCURL_jll = "8.11.1-8.11"
 
 ["8.6"]
 LibCURL_jll = "8.6.0-8.6"
@@ -33,7 +33,7 @@ LibCURL_jll = "8.6.0-8.6"
 OpenSSL_jll = "3.0.8-3"
 
 ["8.9.0"]
-LibCURL_jll = "8.9.0-8"
+LibCURL_jll = "8.9.0-8.9"
 
 ["8.9.1-8.9"]
-LibCURL_jll = "8.9.1-8"
+LibCURL_jll = "8.9.1-8.9"


### PR DESCRIPTION
CURL doesn't work well with different versions of LibCURL, so let's restrict those more.

I have been testing this with the following script:

```
using BinaryBuilderSources, Base.BinaryPlatforms
using BinaryBuilderSources: PackageSpec
using Pkg.Types: VersionSpec

platform = HostPlatform()
jlls = [
    JLLSource(PackageSpec(;name="CURL_jll", version=v"8.11.0+0"), platform),
    JLLSource(PackageSpec(;name="LibCURL_jll", version=v"8.9.0+0"), platform),
]

mktempdir() do prefix
    prepare(jlls)
    deploy(jlls, prefix)
    cd(joinpath(prefix, "bin")) do
        run(`curl -L https://cflo.at`)
    end
end
```
