### PR TITLE
Update URL for `SlurmClusterManager.jl` after transfer to the JuliaParallel org

### DIFF
--- a/S/SlurmClusterManager/Package.toml
+++ b/S/SlurmClusterManager/Package.toml
@@ -1,3 +1,3 @@
 name = "SlurmClusterManager"
 uuid = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
-repo = "https://github.com/kleinhenz/SlurmClusterManager.jl.git"
+repo = "https://github.com/JuliaParallel/SlurmClusterManager.jl.git"


### PR DESCRIPTION
cc: @kleinhenz

We won't merge this PR until after we have transferred the GitHub repo to the JuliaParallel org.