### PR TITLE
[QuanEstimation] Move subpackages QuanEstimationBase and NVMagnetometer from src to lib

### DIFF
--- a/N/NVMagnetometer/Package.toml
+++ b/N/NVMagnetometer/Package.toml
@@ -1,4 +1,4 @@
 name = "NVMagnetometer"
 uuid = "28fc4bcf-da03-4841-bbdb-88baaf311b30"
 repo = "https://github.com/QuanEstimation/QuanEstimation.jl.git"
-subdir = "src/NVMagnetometer"
+subdir = "lib/NVMagnetometer"

--- a/Q/QuanEstimationBase/Package.toml
+++ b/Q/QuanEstimationBase/Package.toml
@@ -1,4 +1,4 @@
 name = "QuanEstimationBase"
 uuid = "9769ca81-ed10-4016-bab9-e66dc61d4d60"
 repo = "https://github.com/QuanEstimation/QuanEstimation.jl.git"
-subdir = "src/QuanEstimationBase"
+subdir = "lib/QuanEstimationBase"


### PR DESCRIPTION
We recently reorganized some of our subpackages in [QuanEstimation.jl](https://github.com/QuanEstimation/QuanEstimation.jl), moving them from `src/` to `lib/`. 
Following the README guildlines and also #119978, the checking results:
```julia
julia> check_package_versions("QuanEstimationBase", "https://github.com/QuanEstimation/QuanEstimation.jl.git")
Cloning into '/var/folders/sq/w8x3hkms07936vk_0dqy32wh0000gn/T/jl_eD72A9'...
remote: Enumerating objects: 3029, done.
remote: Counting objects: 100% (403/403), done.
remote: Compressing objects: 100% (261/261), done.
remote: Total 3029 (delta 200), reused 183 (delta 141), pack-reused 2626 (from 1)
Receiving objects: 100% (3029/3029), 943.61 KiB | 6.99 MiB/s, done.
Resolving deltas: 100% (1783/1783), done.
QuanEstimationBase: v0.1.0 found
1-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "QuanEstimationBase", version = v"0.1.0", found = 1)

julia> check_package_versions("NVMagnetometer", "https://github.com/QuanEstimation/QuanEstimation.jl.git")
Cloning into '/var/folders/sq/w8x3hkms07936vk_0dqy32wh0000gn/T/jl_yFQHEP'...
remote: Enumerating objects: 3029, done.
remote: Counting objects: 100% (404/404), done.
remote: Compressing objects: 100% (261/261), done.
remote: Total 3029 (delta 201), reused 184 (delta 142), pack-reused 2625 (from 1)
Receiving objects: 100% (3029/3029), 945.94 KiB | 4.75 MiB/s, done.
Resolving deltas: 100% (1782/1782), done.
NVMagnetometer: v0.1.0 found
1-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool}}:
 (pkg_name = "NVMagnetometer", version = v"0.1.0", found = 1)
```
