### PR TITLE
Yank SQLite 3.49.0

### DIFF
--- a/jll/S/SQLite_jll/Versions.toml
+++ b/jll/S/SQLite_jll/Versions.toml
@@ -78,3 +78,4 @@ git-tree-sha1 = "9a325057cdb9b066f1f96dc77218df60fe3007cb"
 
 ["3.49.0+0"]
 git-tree-sha1 = "0f86553116166b8923e0978d450abc18f1330dec"
+yanked = true


### PR DESCRIPTION
The shared library names changed unexpectedly in this version. This breaks other packages.