### PR TITLE
restrict ObjectiveC compat in MakieExtra

### DIFF
--- a/M/MakieExtra/Compat.toml
+++ b/M/MakieExtra/Compat.toml
@@ -21,7 +21,7 @@ StructHelpers = "1"
 AccessorsExtra = "0.1.75-0.1"
 
 ["0.1.33-0"]
-ObjectiveC = "3.1.0-3"
+ObjectiveC = "3.1.0-3.3.0"
 
 ["0.1.33-0.1.36"]
 Makie = "0.21.10-0.21"


### PR DESCRIPTION
the yesterday's version causes precompilation issues