### PR TITLE
Org rename/transfer kestrelquantum => harmoniqs

### DIFF
--- a/N/NamedTrajectories/Package.toml
+++ b/N/NamedTrajectories/Package.toml
@@ -1,3 +1,3 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
-repo = "https://github.com/kestrelquantum/NamedTrajectories.jl.git"
+repo = "https://github.com/harmoniqs/NamedTrajectories.jl.git"

--- a/P/Piccolo/Package.toml
+++ b/P/Piccolo/Package.toml
@@ -1,3 +1,3 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-repo = "https://github.com/kestrelquantum/Piccolo.jl.git"
+repo = "https://github.com/harmoniqs/Piccolo.jl.git"

--- a/P/PiccoloPlots/Package.toml
+++ b/P/PiccoloPlots/Package.toml
@@ -1,3 +1,3 @@
 name = "PiccoloPlots"
 uuid = "f42a522c-b487-4f73-ad5a-ad0c3e4a12c8"
-repo = "https://github.com/kestrelquantum/PiccoloPlots.jl.git"
+repo = "https://github.com/harmoniqs/PiccoloPlots.jl.git"

--- a/P/PiccoloQuantumObjects/Package.toml
+++ b/P/PiccoloQuantumObjects/Package.toml
@@ -1,3 +1,3 @@
 name = "PiccoloQuantumObjects"
 uuid = "5a402ddf-f93c-42eb-975e-5582dcda653d"
-repo = "https://github.com/kestrelquantum/PiccoloQuantumObjects.jl.git"
+repo = "https://github.com/harmoniqs/PiccoloQuantumObjects.jl.git"

--- a/Q/QuantumCollocation/Package.toml
+++ b/Q/QuantumCollocation/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumCollocation"
 uuid = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
-repo = "https://github.com/kestrelquantum/QuantumCollocation.jl.git"
+repo = "https://github.com/harmoniqs/QuantumCollocation.jl.git"

--- a/Q/QuantumCollocationCore/Package.toml
+++ b/Q/QuantumCollocationCore/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumCollocationCore"
 uuid = "2b384925-53cb-4042-a8d2-6faa627467e1"
-repo = "https://github.com/kestrelquantum/QuantumCollocationCore.jl.git"
+repo = "https://github.com/harmoniqs/QuantumCollocationCore.jl.git"

--- a/Q/QuantumIterativeLearningControl/Package.toml
+++ b/Q/QuantumIterativeLearningControl/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumIterativeLearningControl"
 uuid = "b2c2a83c-20aa-4d51-8862-bb551092e619"
-repo = "https://github.com/aarontrowbridge/QuantumIterativeLearningControl.jl.git"
+repo = "https://github.com/harmoniqs/QuantumIterativeLearningControl.jl.git"

--- a/Q/QuantumIterativeLearningControl/Package.toml
+++ b/Q/QuantumIterativeLearningControl/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumIterativeLearningControl"
 uuid = "b2c2a83c-20aa-4d51-8862-bb551092e619"
-repo = "https://github.com/harmoniqs/QuantumIterativeLearningControl.jl.git"
+repo = "https://github.com/aarontrowbridge/QuantumIterativeLearningControl.jl.git"

--- a/T/TrajectoryIndexingUtils/Package.toml
+++ b/T/TrajectoryIndexingUtils/Package.toml
@@ -1,3 +1,3 @@
 name = "TrajectoryIndexingUtils"
 uuid = "6dad8b7f-dd9a-4c28-9b70-85b9a079bfc8"
-repo = "https://github.com/kestrelquantum/TrajectoryIndexingUtils.jl.git"
+repo = "https://github.com/harmoniqs/TrajectoryIndexingUtils.jl.git"


### PR DESCRIPTION
The group of packages formerly under the kestrelquantum organization have been moved to the harmoniqs github org.

https://github.com/kestrelquantum/NamedTrajectories.jl.git => https://github.com/harmoniqs/NamedTrajectories.jl.git
https://github.com/kestrelquantum/Piccolo.jl.git => https://github.com/harmoniqs/Piccolo.jl.git
https://github.com/kestrelquantum/PiccoloPlots.jl.git => https://github.com/harmoniqs/PiccoloPlots.jl.git
https://github.com/kestrelquantum/PiccoloQuantumObjects.jl.git => https://github.com/harmoniqs/PiccoloQuantumObjects.jl.git
https://github.com/kestrelquantum/QuantumCollocation.jl.git => https://github.com/harmoniqs/QuantumCollocation.jl.git
https://github.com/kestrelquantum/QuantumCollocationCore.jl.git => https://github.com/harmoniqs/QuantumCollocationCore.jl.git
https://github.com/kestrelquantum/TrajectoryIndexingUtils.jl.git => https://github.com/harmoniqs/TrajectoryIndexingUtils.jl.git
