### PR TITLE
[ITK_jll] Restrict compat with HDF5_jll

### DIFF
--- a/I/ITK/Deps.toml
+++ b/I/ITK/Deps.toml
@@ -1,4 +1,5 @@
 [0]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 Cxx = "a0b5b9ef-44b7-5148-a2d1-f6db19f3c3d2"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/I/ITK/Deps.toml
+++ b/I/ITK/Deps.toml
@@ -1,5 +1,4 @@
 [0]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 Cxx = "a0b5b9ef-44b7-5148-a2d1-f6db19f3c3d2"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/jll/I/ITK_jll/Compat.toml
+++ b/jll/I/ITK_jll/Compat.toml
@@ -1,14 +1,13 @@
 [5]
 julia = "1.6.0-1"
+HDF5_jll = "1.14.0-1.14.3"
 
 ["5-5.3.0"]
 Artifacts = "1"
-HDF5_jll = "1.14.0-1.14.3"
 JLLWrappers = "1.2.0-1"
 Libdl = "1"
 
 ["5.3.1-5"]
 Artifacts = ["0.0.0", "1"]
-HDF5_jll = "1.14.0-1.14.3"
 JLLWrappers = "1.7.0-1"
 Libdl = ["0.0.0", "1"]

--- a/jll/I/ITK_jll/Compat.toml
+++ b/jll/I/ITK_jll/Compat.toml
@@ -3,10 +3,12 @@ julia = "1.6.0-1"
 
 ["5-5.3.0"]
 Artifacts = "1"
+HDF5_jll = "1.14"
 JLLWrappers = "1.2.0-1"
 Libdl = "1"
 
 ["5.3.1-5"]
 Artifacts = ["0.0.0", "1"]
+HDF5_jll = "1.14.0-1.14.3"
 JLLWrappers = "1.7.0-1"
 Libdl = ["0.0.0", "1"]

--- a/jll/I/ITK_jll/Compat.toml
+++ b/jll/I/ITK_jll/Compat.toml
@@ -3,7 +3,7 @@ julia = "1.6.0-1"
 
 ["5-5.3.0"]
 Artifacts = "1"
-HDF5_jll = "1.14"
+HDF5_jll = "1.14.0-1.14.3"
 JLLWrappers = "1.2.0-1"
 Libdl = "1"
 


### PR DESCRIPTION
HDF5_jll v1.14.5 broke the ABI compared to previous versions, so we must reflect the compatibility restrictions in the registry. Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/10347#issuecomment-2662923973.