### PR TITLE
SSMProblems.jl: Updating repo url (moved package to subdirectory)

### DIFF
--- a/S/SSMProblems/Package.toml
+++ b/S/SSMProblems/Package.toml
@@ -1,3 +1,4 @@
 name = "SSMProblems"
 uuid = "26aad666-b158-4e64-9d35-0e672562fa48"
 repo = "https://github.com/TuringLang/SSMProblems.jl.git"
+subdir = "SSMProblems"


### PR DESCRIPTION
We have moved [`SSMProblems.jl`](https://github.com/TuringLang/SSMProblems.jl) to subdirectory named SSMProblems, so this PR updated the URL of repo by adding `subdir` in `Package.toml` of `SSMProblems.jl`.

Closes https://github.com/TuringLang/SSMProblems.jl/issues/54

cc @yebai 