### PR TITLE
Fix neper compat bounds for NLopt

### DIFF
--- a/jll/N/neper_jll/Compat.toml
+++ b/jll/N/neper_jll/Compat.toml
@@ -3,7 +3,7 @@ GSL_jll = "2.7.2-2.7"
 JLLWrappers = "1.2.0-1"
 SCOTCH_jll = "6.1.3-6"
 julia = "1.6.0-1"
-NLopt_jll = "2 - 2.9"
+NLopt_jll = "2.6.2 - 2.9"
 
 ["4.8-4"]
 Artifacts = "1"

--- a/jll/N/neper_jll/Compat.toml
+++ b/jll/N/neper_jll/Compat.toml
@@ -3,6 +3,7 @@ GSL_jll = "2.7.2-2.7"
 JLLWrappers = "1.2.0-1"
 SCOTCH_jll = "6.1.3-6"
 julia = "1.6.0-1"
+NLopt_jll = "2 - 2.9"
 
 ["4.8-4"]
 Artifacts = "1"


### PR DESCRIPTION
xref: https://github.com/JuliaPackaging/Yggdrasil/pull/10721#issuecomment-2713578841

Running run(`$(neper()) -T -n 10`) fails with
dyld[7307]: Library not loaded: @rpath/libnlopt.0.dylib using default installation, but solved by add NLopt_jll@2.9 before loading neper_jll.

However, as explained by @giordano in the referenced comment, it should be updated directly here to avoid having inconsistent broken compat bounds in the registry.

Verified that adding this combat bound on a dev:ed version of `neper_jll` makes it work locally on my Mac M3 (Julia 1.11.4). 
