### PR TITLE
Fix typo in GPUToolbox repo URL

### DIFF
--- a/G/GPUToolbox/Package.toml
+++ b/G/GPUToolbox/Package.toml
@@ -1,3 +1,3 @@
 name = "GPUToolbox"
 uuid = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
-repo = "https://github.com/juliaGPU/GPUToolbox.jl.git"
+repo = "https://github.com/JuliaGPU/GPUToolbox.jl.git"


### PR DESCRIPTION
I believe this is what is preventing me from registering a new version.

https://github.com/JuliaGPU/GPUToolbox.jl/commit/4cdaedb0f0650e20008c5c767e73cfe1ecb59cda#commitcomment-153556993