### PR TITLE
Change SimpleNonlinearSolve.jl URL

### DIFF
--- a/S/SimpleNonlinearSolve/Package.toml
+++ b/S/SimpleNonlinearSolve/Package.toml
@@ -1,4 +1,4 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-repo = "https://github.com/SciML/NonlinearSolve.jl.git"
+repo = "https://github.com/SciML/SimpleNonlinearSolve.jl.git"
 subdir = "lib/SimpleNonlinearSolve"

--- a/S/SimpleNonlinearSolve/Package.toml
+++ b/S/SimpleNonlinearSolve/Package.toml
@@ -1,4 +1,3 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 repo = "https://github.com/SciML/SimpleNonlinearSolve.jl.git"
-subdir = "lib/SimpleNonlinearSolve"


### PR DESCRIPTION
This is a bit of an operation. This old repo has the v1. We need to change the repo in order to do the backport release, then we swap it back. https://github.com/SciML/SimpleNonlinearSolve.jl/issues/2#issuecomment-2758169792