### PR TITLE
Move PkgDevTools to CliMA org

### DIFF
--- a/P/PkgDevTools/Package.toml
+++ b/P/PkgDevTools/Package.toml
@@ -1,3 +1,3 @@
 name = "PkgDevTools"
 uuid = "2afb0842-1d6c-4499-8b39-71b06199676f"
-repo = "https://github.com/charleskawczynski/PkgDevTools.jl.git"
+repo = "https://github.com/CliMA/PkgDevTools.jl.git"


### PR DESCRIPTION
This PR moves PkgDevTools to the CliMA org