### PR TITLE
XML2_jll: Yank 2.14.1

### DIFF
--- a/jll/X/XML2_jll/Versions.toml
+++ b/jll/X/XML2_jll/Versions.toml
@@ -81,3 +81,4 @@ git-tree-sha1 = "b8b243e47228b4a3877f1dd6aee0c5d56db7fcf4"
 
 ["2.14.1+0"]
 git-tree-sha1 = "9380cd28f093c901600ab70e0201fb18bae226de"
+yanked = true


### PR DESCRIPTION
XML2_jll 2.14.1 is not binary compatible with earlier version.