### PR TITLE
Fix Compat.toml for EzXML after Cap compatibility of XML2_jll

### DIFF
--- a/E/EzXML/Compat.toml
+++ b/E/EzXML/Compat.toml
@@ -19,6 +19,7 @@ BinaryProvider = "0.5"
 julia = "1"
 
 ["1.1"]
+XML2_jll = "2.9.0-2.13"
 julia = "1.3.0-1"
 
 ["1.2-1"]


### PR DESCRIPTION
Fixes a mistake in https://github.com/JuliaRegistries/General/pull/128961

XML2_jll is a dep for versions "1.1-1" of EzXML
https://github.com/JuliaRegistries/General/blob/80148898cd08259dfe64da70b1696ef0be700e85/E/EzXML/Deps.toml#L21-L22

However, https://github.com/JuliaRegistries/General/pull/128961 only updated compat for versions "1.2-1" of EzXML. 