### PR TITLE
Transfer DispersiveShallowWater.jl

### DIFF
--- a/D/DispersiveShallowWater/Package.toml
+++ b/D/DispersiveShallowWater/Package.toml
@@ -1,3 +1,3 @@
 name = "DispersiveShallowWater"
 uuid = "4ab875f6-b79a-4e28-9745-4f0293954817"
-repo = "https://github.com/JoshuaLampert/DispersiveShallowWater.jl.git"
+repo = "https://github.com/NumericalMathematics/DispersiveShallowWater.jl.git"


### PR DESCRIPTION
We transferred the package from my personal account to [NumericalMathematics/DispersiveShallowWater.jl](https://github.com/NumericalMathematics/DispersiveShallowWater.jl).

CC @ranocha 