### PR TITLE
Moved `TuringBenchmarking` to `TuringLang/depreciated` repo

### DIFF
--- a/T/TuringBenchmarking/Package.toml
+++ b/T/TuringBenchmarking/Package.toml
@@ -1,3 +1,4 @@
 name = "TuringBenchmarking"
 uuid = "0db1332d-5c25-4deb-809f-459bc696f94f"
-repo = "https://github.com/TuringLang/TuringBenchmarking.jl.git"
+repo = "https://github.com/TuringLang/depreciated.git"
+subdir = "TuringBenchmarking"


### PR DESCRIPTION
Moved [`TuringBenchmarking`](https://github.com/TuringLang/TuringBenchmarking.jl) to [`TuringLang/depreciated`](https://github.com/TuringLang/depreciated) repo in subdirectory named `TuringBenchmarking`.

All versions are properly installable after this change, so feel free to merge this PR:

Verified using this: https://github.com/JuliaRegistries/General/blob/ca5691e922b8cb699a3008021eecdaa891180be0/CONTRIBUTING.md#appendix-checking-if-a-repository-contains-all-registered-versions-of-a-package
```julia
julia> check_package_versions("TuringBenchmarking", "https://github.com/TuringLang/depreciated.git")
Cloning into '/tmp/jl_89wPcQ'...
remote: Enumerating objects: 406, done.
remote: Counting objects: 100% (406/406), done.
remote: Compressing objects: 100% (172/172), done.
remote: Total 406 (delta 190), reused 397 (delta 186), pack-reused 0 (from 0)
Receiving objects: 100% (406/406), 85.19 KiB | 1.01 MiB/s, done.
Resolving deltas: 100% (190/190), done.
TuringBenchmarking: v0.1.0 found
TuringBenchmarking: v0.1.1 found
TuringBenchmarking: v0.2.0 found
TuringBenchmarking: v0.3.0 found
TuringBenchmarking: v0.3.1 found
TuringBenchmarking: v0.3.2 found
TuringBenchmarking: v0.3.3 found
TuringBenchmarking: v0.3.4 found
TuringBenchmarking: v0.4.0 found
TuringBenchmarking: v0.5.0 found
TuringBenchmarking: v0.5.1 found
TuringBenchmarking: v0.5.2 found
TuringBenchmarking: v0.5.3 found
TuringBenchmarking: v0.5.4 found
TuringBenchmarking: v0.5.5 found
TuringBenchmarking: v0.5.6 found
TuringBenchmarking: v0.5.7 found
TuringBenchmarking: v0.5.8 found
TuringBenchmarking: v0.5.9 found
```

cc @yebai 