### PR TITLE
Change Repo URL 

### DIFF
--- a/T/TuringBenchmarking/Package.toml
+++ b/T/TuringBenchmarking/Package.toml
@@ -1,4 +1,4 @@
 name = "TuringBenchmarking"
 uuid = "0db1332d-5c25-4deb-809f-459bc696f94f"
-repo = "https://github.com/TuringLang/depreciated.git"
+repo = "https://github.com/TuringLang/Deprecated.git"
 subdir = "TuringBenchmarking"


### PR DESCRIPTION
New repo URL: https://github.com/TuringLang/Deprecate.git