### PR TITLE
CI: Include `github.event.action` in the AutoMerge job name (to prevent label events from overriding the AutoMerge CI logs with a "skipped" job)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,6 +24,7 @@ env:
 
 jobs:
   AutoMerge:
+    name: "AutoMerge-${{ github.event.action }}"
     # Run if:
     # - not from a PR event
     # - or it is from a PR event AND it is not from a fork, AND either:


### PR DESCRIPTION
Replacement for #130112.