### PR TITLE
TuringBenchmarking: Updating repo url

### DIFF
--- a/T/TuringBenchmarking/Package.toml
+++ b/T/TuringBenchmarking/Package.toml
@@ -1,4 +1,4 @@
 name = "TuringBenchmarking"
 uuid = "0db1332d-5c25-4deb-809f-459bc696f94f"
-repo = "https://github.com/TuringLang/depreciated.git"
+repo = "https://github.com/TuringLang/Deprecated.git"
 subdir = "TuringBenchmarking"


### PR DESCRIPTION
All versions are accessible, please feel free to merge this PR:
```julia
julia> check_package_versions("TuringBenchmarking", "https://github.com/TuringLang/Deprecated.git")
Cloning into '/tmp/jl_Pf6wnf'...
remote: Enumerating objects: 624, done.
remote: Counting objects: 100% (624/624), done.
remote: Compressing objects: 100% (298/298), done.
remote: Total 624 (delta 291), reused 556 (delta 247), pack-reused 0 (from 0)
Receiving objects: 100% (624/624), 466.76 KiB | 499.00 KiB/s, done.
Resolving deltas: 100% (291/291), done.
TuringBenchmarking: v0.1.0 found
TuringBenchmarking: v0.1.1 found
TuringBenchmarking: v0.2.0 found
TuringBenchmarking: v0.3.0 found
TuringBenchmarking: v0.3.1 found
TuringBenchmarking: v0.3.2 found
TuringBenchmarking: v0.3.3 found
TuringBenchmarking: v0.3.4 found
TuringBenchmarking: v0.4.0 found
TuringBenchmarking: v0.5.0 found
TuringBenchmarking: v0.5.1 found
TuringBenchmarking: v0.5.2 found
TuringBenchmarking: v0.5.3 found
TuringBenchmarking: v0.5.4 found
TuringBenchmarking: v0.5.5 found
TuringBenchmarking: v0.5.6 found
TuringBenchmarking: v0.5.7 found
TuringBenchmarking: v0.5.8 found
TuringBenchmarking: v0.5.9 found
```

cc @yebai 