### PR TITLE
Fix typo in BaseCompiler URL

### DIFF
--- a/C/Compiler/Package.toml
+++ b/C/Compiler/Package.toml
@@ -1,3 +1,3 @@
 name = "Compiler"
 uuid = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
-repo = "https://github.com/JuliaLang/BaseCompiler.git"
+repo = "https://github.com/JuliaLang/BaseCompiler.jl.git"


### PR DESCRIPTION
#130304 had a typo, causing the package to not be found when cloning:
```julia
(Pkg) pkg> add Compiler@0.0.0
   Resolving package versions...
     Cloning [807dbc54-b67e-4c79-8afb-eafe4df6f2e1] Compiler from https://github.com/JuliaLang/BaseCompiler.git
remote: Repository not found.
fatal: repository 'https://github.com/JuliaLang/BaseCompiler.git/' not found
```

A manual merge would be highly appreciated. cc @DilumAluthge