### PR TITLE
Change SimpleNonlinearSolve.jl URL

### DIFF
--- a/S/SimpleNonlinearSolve/Package.toml
+++ b/S/SimpleNonlinearSolve/Package.toml
@@ -1,4 +1,3 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-repo = "https://github.com/SciML/NonlinearSolve.jl.git"
-subdir = "lib/SimpleNonlinearSolve"
+repo = "https://github.com/SciML/SimpleNonlinearSolve.jl.git"


### PR DESCRIPTION
Round 2 of https://github.com/JuliaRegistries/General/pull/127810 since it needs another patch. Since it's the same backport method as before which was already discussed and approved, I'll just go ahead with the same procedure: do the URL change, do the version bump, and then revert the URL change.