### PR TITLE
New version: InPartSObstacles v0.1.8

### DIFF
--- a/I/InPartSObstacles/Compat.toml
+++ b/I/InPartSObstacles/Compat.toml
@@ -6,3 +6,6 @@ InPartS = "0.4-0.6"
 
 ["0.1.7-0"]
 InPartS = "0.4-0.7"
+
+["0.1.8-0"]
+DocStringExtensions = "0.9"

--- a/I/InPartSObstacles/Deps.toml
+++ b/I/InPartSObstacles/Deps.toml
@@ -2,3 +2,6 @@
 InPartS = "f768f48f-0d8a-415b-80aa-7de5ff9b8474"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+["0.1.8-0"]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/I/InPartSObstacles/Versions.toml
+++ b/I/InPartSObstacles/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "68fba66ddc1a13a48ff904c951bb3cb7b7322faa"
 
 ["0.1.7"]
 git-tree-sha1 = "003f749aed2761790bccedeb9a23e71b872ead40"
+
+["0.1.8"]
+git-tree-sha1 = "389f7b2bf19f2a78f84633a5b03cef424285c093"


### PR DESCRIPTION
- Registering package: InPartSObstacles
- Repository: https://gitlab.gwdg.de/eDLS/InPartS-models/inpartsobstacles
- Version: v0.1.8
- Commit: 70c1e911ca22d9f2488eb896d2f4a885e463c7fa
- Description: Obstacle types for InPartS

*This PR was created using LocalRegistry.jl and a hacky GitLab CI script. If nothing went wrong, it should be similar to a Registrator-generated PR.
I am a machine user 🤖 and I’m currently controlled by @lhupe @philbit and @JonasIsensee.*
