### PR TITLE
update the tree hash of Compiler.jl stdlib v0.1.0

### DIFF
--- a/C/Compiler/Versions.toml
+++ b/C/Compiler/Versions.toml
@@ -1,2 +1,2 @@
 ["0.1.0"]
-git-tree-sha1 = "f251406f8c327e9dbb4fdb4108c8f5f7b033dd7e"
+git-tree-sha1 = "34d243f805bb74759f9b9856413834a9871b0952"


### PR DESCRIPTION
I have modified the implementation of the Compiler.jl stdlib so that it can be installed on v1.10, and updated the tree hash for installation from General.

The Compiler.jl stdlib follows a special versioning policy and, for various reasons, is currently operated to have only v0.1.0 version. Therefore, instead of releasing a patch version, we are making a special accommodation by updating the tree hash on the General side.

I apologize for any recent inconvenience regarding the Compiler.jl stdlib, but such accommodations should not occur in the future.