### PR TITLE
[ActiveInference] Update package URL

### DIFF
--- a/A/ActiveInference/Package.toml
+++ b/A/ActiveInference/Package.toml
@@ -1,3 +1,3 @@
 name = "ActiveInference"
 uuid = "688b0e7a-0122-4325-8669-5ff08899a59e"
-repo = "https://github.com/ilabcode/ActiveInference.jl.git"
+repo = "https://github.com/ComputationalPsychiatry/ActiveInference.jl.git"


### PR DESCRIPTION
We have moved the package to the ComputationalPsychiatry organisation. Please confirm whether this is the correct way to update the URL, and if there is anything else we should do.