### PR TITLE
[LinearSolve] Fix compatibility with SciMLBase

### DIFF
--- a/L/LinearSolve/Compat.toml
+++ b/L/LinearSolve/Compat.toml
@@ -169,7 +169,7 @@ EnzymeCore = "0.6"
 ["2.17-2.22"]
 DocStringExtensions = "0.9"
 LinearAlgebra = "1.9.0-1"
-SciMLBase = "2"
+SciMLBase = "2-2.77"
 SciMLOperators = "0.3"
 SparseArrays = "1.9.0-1"
 
@@ -199,7 +199,7 @@ RecursiveFactorization = "0.2.14-0.2"
 Preferences = "1.4.0-1"
 
 ["2.23-2.24"]
-SciMLBase = "2.23.0-2"
+SciMLBase = "2.23.0-2.77"
 
 ["2.23-2.25"]
 KLU = "0.5"
@@ -226,7 +226,7 @@ SciMLOperators = "0.3.7-0.3"
 SparseArrays = "1.10.0-1"
 
 ["2.25-2"]
-SciMLBase = "2.26.3-2"
+SciMLBase = "2.26.3-2.77"
 
 ["2.25-3"]
 ChainRulesCore = "1.22.0-1"
@@ -254,7 +254,7 @@ GPUArraysCore = "0.1.6-0.2"
 ConcreteStructs = "0.2"
 
 ["2.7-2.16"]
-SciMLBase = "1.82.0-2"
+SciMLBase = "1.82.0-2.77"
 
 ["2.8.0"]
 EnzymeCore = "0.6"


### PR DESCRIPTION
The non-breaking version [`SciMLBase@v2.78`](https://github.com/SciML/SciMLBase.jl/commit/bc5424375ea3c4a63029416b5139c9a409a427d9) removed `AbstractDiffEqOperator`, which was unconditionally used in `LinearSolve` between [`v1.7.0`](https://github.com/SciML/LinearSolve.jl/commit/43c97da5a2f16c8545d89671bfe5bdaac143090e) and for the whole v2 series.

This change prevents combining incompatible versions of `SciMLBase` and `LinearSolve`.

CC @ChrisRackauckas.