### PR TITLE
[SciMLBase] Fix compatibility with ScimlOperators

### DIFF
--- a/S/SciMLBase/Compat.toml
+++ b/S/SciMLBase/Compat.toml
@@ -105,7 +105,7 @@ ADTypes = "0.1.3-0.1"
 CommonSolve = "0.2.4-0.2"
 
 ["1.93-2.10"]
-SciMLOperators = "0.1.18-0.3"
+SciMLOperators = "0.1.18-0.3.12"
 
 ["1.95-2.10"]
 ADTypes = "0.1.3-0.2"
@@ -150,7 +150,7 @@ ADTypes = "0.2.5-0.2"
 Tables = "1.11.0-1"
 
 ["2.11-2.77"]
-SciMLOperators = "0.3.7-0.3"
+SciMLOperators = "0.3.7-0.3.12"
 
 ["2.11.0"]
 QuasiMonteCarlo = "0.2.19-0.3"


### PR DESCRIPTION
[`SciMLOperators@0.3.13`](https://github.com/SciML/SciMLOperators.jl/commit/b5f8fa62f70886e8a9d386c74767c09ba8a8ad94) introduced a method for `isConstant(::Any)` which is overwritten by the method introduced by [`SciMLBase@1.82.0`](https://github.com/SciML/SciMLBase.jl/commit/3010f794a58db88eb732ef8e14196f0a8086f79a#diff-e9c11fcd7d24c2ee6381bc5700170521b889e8434f24555f49238f2dc8fe0637) (and then removed in `SciMLBase@2.78.0`), causing endless precompilation when combining packages defining the same method.

I hope this is the last one.

CC @ChrisRackauckas