### PR TITLE
[Lux] update ComponentArrays compat

### DIFF
--- a/L/Lux/WeakCompat.toml
+++ b/L/Lux/WeakCompat.toml
@@ -39,7 +39,7 @@ Metal = ["0.5", "1"]
 FillArrays = "1"
 
 ["0.5.17-0.5.25"]
-ComponentArrays = "0.15.8-0.15"
+ComponentArrays = "0.15.8-0.15.27"
 
 ["0.5.17-0.5.33"]
 ChainRules = "1.62.0-1"
@@ -63,7 +63,7 @@ ReverseDiff = "1.15.0-1"
 SimpleChains = "0.4.6-0.4"
 
 ["0.5.26-0.5.61"]
-ComponentArrays = "0.15.11-0.15"
+ComponentArrays = "0.15.11-0.15.27"
 
 ["0.5.27-0.5.60"]
 Optimisers = "0.3"
@@ -109,7 +109,7 @@ AMDGPU = "0.9.6-0.9"
 DynamicExpressions = "0.16-0.18"
 
 ["0.5.6-0.5.16"]
-ComponentArrays = "0.15.2-0.15"
+ComponentArrays = "0.15.2-0.15.27"
 
 ["0.5.60-1"]
 SimpleChains = "0.4.7-0.4"
@@ -121,7 +121,7 @@ FunctionWrappers = "1.1.3-1"
 Enzyme = "0.12.26-0.12"
 
 ["0.5.62-1.2"]
-ComponentArrays = "0.15.16-0.15"
+ComponentArrays = "0.15.16-0.15.27"
 
 ["0.5.62-1.5"]
 Zygote = "0.6.70-0.6"
@@ -207,7 +207,7 @@ Reactant = "0.2.6-0.2"
 Tracker = "0.2.36-0.2"
 
 ["1.3-1.5"]
-ComponentArrays = "0.15.18-0.15"
+ComponentArrays = "0.15.18-0.15.27"
 
 ["1.3.4-1.4"]
 Enzyme = "0.13.16-0.13"
@@ -236,7 +236,7 @@ Enzyme = "0.13.28-0.13"
 Reactant = "0.2.21-0.2"
 
 ["1.6-1"]
-ComponentArrays = "0.15.22-0.15"
+ComponentArrays = "0.15.22-0.15.27"
 
 ["1.6-1.9"]
 Zygote = "0.6.70-0.7"


### PR DESCRIPTION
once we fix https://github.com/LuxDL/Lux.jl/issues/1359 with an upstream ComponentArrays patch, it will break older versions of Lux