### PR TITLE
move GeoCotrans package to its own repository

### DIFF
--- a/G/GeoCotrans/Package.toml
+++ b/G/GeoCotrans/Package.toml
@@ -1,4 +1,3 @@
 name = "GeoCotrans"
 uuid = "4624b3bc-fe35-44f8-bfa8-722ff9c0e307"
-repo = "https://github.com/Beforerr/SPEDAS.jl.git"
-subdir = "lib/GeoCotrans"
+repo = "https://github.com/JuliaSpacePhysics/GeoCotrans.jl.git"


### PR DESCRIPTION
Following the Github documentation guide, it seems fine.

```
julia> check_package_versions("GeoCotrans", "https://github.com/JuliaSpacePhysics/GeoCotrans.jl.git")
Cloning into '/var/folders/lc/6fb8rgv96tsdlvxjrldpx0bm0000gn/T/jl_f7zLVh'...
remote: Enumerating objects: 71, done.
remote: Counting objects: 100% (71/71), done.
remote: Compressing objects: 100% (52/52), done.
remote: Total 71 (delta 20), reused 64 (delta 18), pack-reused 0 (from 0)
Receiving objects: 100% (71/71), 26.88 KiB | 13.44 MiB/s, done.
Resolving deltas: 100% (20/20), done.
GeoCotrans: v0.0.1 found
GeoCotrans: v0.1.0 found
2-element Vector{@NamedTuple{pkg_name::String, version::VersionNumber, found::Bool, tree_sha::Base.SHA1}}:
 (pkg_name = "GeoCotrans", version = v"0.0.1", found = 1, tree_sha = SHA1("58c8363d2cb685a5912532ab686e63f63b9d7571"))
 (pkg_name = "GeoCotrans", version = v"0.1.0", found = 1, tree_sha = SHA1("90b92a46a5857b60869521b5ab8867e84cf89956"))
```