### PR TITLE
Transfer repository: SparseArrayKit

### DIFF
--- a/S/SparseArrayKit/Package.toml
+++ b/S/SparseArrayKit/Package.toml
@@ -1,3 +1,3 @@
 name = "SparseArrayKit"
 uuid = "a9a3c162-d163-4c15-8926-b8794fbefed2"
-repo = "https://github.com/Jutho/SparseArrayKit.jl.git"
+repo = "https://github.com/QuantumKitHub/SparseArrayKit.jl.git"


### PR DESCRIPTION
This is the updated location for SparseArrayKit.jl, which will now be hosted under the QuantumKitHub organisation.

Previously:
https://github.com/Jutho/SparseArrayKit.jl

Now:
https://github.com/QuantumKitHub/SparseArrayKit.jl