### PR TITLE
change ownership of `FortranFiles`

### DIFF
--- a/F/FortranFiles/Package.toml
+++ b/F/FortranFiles/Package.toml
@@ -1,3 +1,3 @@
 name = "FortranFiles"
 uuid = "c58ffaec-ab22-586d-bfc5-781a99fd0b10"
-repo = "https://github.com/traktofon/FortranFiles.jl.git"
+repo = "https://github.com/JuliaData/FortranFiles.jl.git"


### PR DESCRIPTION
Was moved as discussed in https://github.com/JuliaData/FortranFiles.jl/pull/10.

Lives now at https://github.com/JuliaData/FortranFiles.jl.