### PR TITLE
Fix Registry.toml update missing from PR #134866

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -700,6 +700,7 @@ some amount of consideration when choosing package names.
 0e04eddd-96ac-454e-8372-d12cc190ad6e = { name = "SurrogatedDistanceModels", path = "S/SurrogatedDistanceModels" }
 0e08944d-e94e-41b1-9406-dcf66b6a9d2e = { name = "PencilArrays", path = "P/PencilArrays" }
 0e112785-0821-598c-8835-9f07837e8d7b = { name = "object_store_ffi_jll", path = "jll/O/object_store_ffi_jll" }
+0e168e98-d76b-4d03-b07e-2b13986b2fd0 = { name = "FrictionProviders", path = "F/FrictionProviders" }
 0e18b5df-1f6d-5218-abdd-6febb37acc78 = { name = "FluxJS", path = "F/FluxJS" }
 0e1b5cf3-e725-4f3c-b25f-c55f40573e77 = { name = "UKCarbonIntensityData", path = "U/UKCarbonIntensityData" }
 0e1eec36-3e51-505b-9453-8db846dc2724 = { name = "Nord", path = "N/Nord" }
@@ -2040,6 +2041,7 @@ some amount of consideration when choosing package names.
 29a986be-02c6-4525-aec4-84b980013641 = { name = "FastLapackInterface", path = "F/FastLapackInterface" }
 29b5916a-a76c-4e73-9657-3c8fd22e65e6 = { name = "ClimaAnalysis", path = "C/ClimaAnalysis" }
 29b9b1b6-efa6-450e-8188-a5a2c25df071 = { name = "MatricesForHomalg", path = "M/MatricesForHomalg" }
+29bafc4c-4f38-420f-a153-8a5a5e0bd5f6 = { name = "MACEModels", path = "M/MACEModels" }
 29be08bc-e5fd-4da2-bbc1-72011c6ea2c9 = { name = "JlrsCore", path = "J/JlrsCore" }
 29bf0bfc-420f-4fa5-b441-811fd9e6e11d = { name = "SpaceLiDAR", path = "S/SpaceLiDAR" }
 29c08b6a-42b0-4a71-84c9-d93be35dae53 = { name = "RunBinary", path = "R/RunBinary" }
@@ -2669,6 +2671,7 @@ some amount of consideration when choosing package names.
 35fd387a-780d-5580-bc3c-2dd06d6487c2 = { name = "LCIO_jll", path = "jll/L/LCIO_jll" }
 36161bb8-d084-4d22-844f-8ce7d076efe9 = { name = "Microstates", path = "M/Microstates" }
 36230cab-47f6-4611-a9ad-d42316f9a74f = { name = "Repotomata", path = "R/Repotomata" }
+36248dfb-79eb-4f4d-ab9c-e29ea5f33e14 = { name = "NQCDynamics", path = "N/NQCDynamics" }
 3632ec16-99db-4259-aa88-30b9105699f8 = { name = "CoinbasePro", path = "C/CoinbasePro" }
 36347407-b186-4a6a-8c98-4f4567861712 = { name = "ZigZagBoomerang", path = "Z/ZigZagBoomerang" }
 36348300-93cb-4f02-beb5-3c3902f8871e = { name = "OptimizationOptimJL", path = "O/OptimizationOptimJL" }
@@ -3446,6 +3449,7 @@ some amount of consideration when choosing package names.
 45f359ea-796d-4f51-95a5-deb1a414c586 = { name = "MLJBalancing", path = "M/MLJBalancing" }
 45f42fbc-210c-4ecc-9452-59ec793b9bfd = { name = "LinearRationalExpectations", path = "L/LinearRationalExpectations" }
 45fdfeda-9075-4319-90b5-f13bf67f1b3c = { name = "Lunettes", path = "L/Lunettes" }
+4606675f-2246-4a0b-99d5-75b910de637b = { name = "NQCDInterfASE", path = "N/NQCDInterfASE" }
 460b0459-f81d-40f2-a460-3486927c7399 = { name = "OneHot", path = "O/OneHot" }
 460bff9d-24e4-43bc-9d9f-a8973cb893f4 = { name = "ExceptionUnwrapping", path = "E/ExceptionUnwrapping" }
 460c41e3-6112-5d7f-b78c-b6823adb3f2d = { name = "QhullMiniWrapper_jll", path = "jll/Q/QhullMiniWrapper_jll" }
@@ -4974,6 +4978,7 @@ some amount of consideration when choosing package names.
 656d14af-56e4-5275-8e68-4e861d7b5043 = { name = "AMGX_jll", path = "jll/A/AMGX_jll" }
 656e9f32-718a-11e9-002e-018f26774860 = { name = "LabViewXML", path = "L/LabViewXML" }
 656ef2d0-ae68-5445-9ca0-591084a874a2 = { name = "OpenBLAS32_jll", path = "jll/O/OpenBLAS32_jll" }
+657014a1-bd25-4aa2-92cb-cbcede0310ad = { name = "NQCDistributions", path = "N/NQCDistributions" }
 657d34fe-3196-4c2a-8906-b42f7ce4733b = { name = "ArtSet", path = "A/ArtSet" }
 65888b18-ceab-5e60-b2b9-181511a3b968 = { name = "ParameterizedFunctions", path = "P/ParameterizedFunctions" }
 658cac36-ff0f-48ad-967c-110375d98c9d = { name = "ObjectPools", path = "O/ObjectPools" }
@@ -9853,6 +9858,7 @@ c7fc2d14-d53c-5e81-ac30-66aba9c03525 = { name = "RNGPool", path = "R/RNGPool" }
 c8045c5a-940e-4537-a0b9-cab4a5eb5ca1 = { name = "KdotP", path = "K/KdotP" }
 c804724b-8c18-5caa-8579-6025a0767c70 = { name = "TimeseriesSurrogates", path = "T/TimeseriesSurrogates" }
 c8109be6-b162-4503-8829-8b6b29b93f50 = { name = "SpatialGraphs", path = "S/SpatialGraphs" }
+c814dc9f-a51f-4eaf-877f-82eda4edad48 = { name = "NQCModels", path = "N/NQCModels" }
 c817782e-172a-44cc-b673-b171935fbb9e = { name = "ImageBase", path = "I/ImageBase" }
 c8189ad9-0349-5cbb-98f2-579781f27e5c = { name = "Pathogen", path = "P/Pathogen" }
 c823fa1f-8872-4af5-b810-2b9b72bbbf56 = { name = "DirectTrajOpt", path = "D/DirectTrajOpt" }
@@ -10874,6 +10880,7 @@ ddc7317b-88db-5cb5-a849-8449e5df04f9 = { name = "GeoDatasets", path = "G/GeoData
 ddcadc53-6d93-5ff2-a689-b0a21eea8355 = { name = "nghttp3_jll", path = "jll/N/nghttp3_jll" }
 ddcc5653-dcaa-48f1-be98-eb2dafe13740 = { name = "PhysicsInformedML", path = "P/PhysicsInformedML" }
 ddcda2f0-0770-5eff-b02e-03a583a735ee = { name = "BladeRFHardwareDriver_jll", path = "jll/B/BladeRFHardwareDriver_jll" }
+ddd1f41d-9621-41e2-91a4-6b87cc8989f3 = { name = "NQCCalculators", path = "N/NQCCalculators" }
 ddd84059-9b64-5d1b-85eb-da48df743e32 = { name = "KeyedFrames", path = "K/KeyedFrames" }
 dddc953c-20d8-47dd-8cc1-765c34677cac = { name = "PowerLaws", path = "P/PowerLaws" }
 dde13934-061e-461b-aa91-2c0fad390a0d = { name = "NURBS", path = "N/NURBS" }


### PR DESCRIPTION
I somehow managed to forget to include an updated `Registry.toml` in https://github.com/JuliaRegistries/General/pull/134866, which wasn't caught while merging. 

This PR includes the missing update to the Registry to finish registering the new packages. 