### PR TITLE
JuliaBUGS.jl: moved package to subdirectory

### DIFF
--- a/J/JuliaBUGS/Package.toml
+++ b/J/JuliaBUGS/Package.toml
@@ -1,3 +1,4 @@
 name = "JuliaBUGS"
 uuid = "ba9fb4c0-828e-4473-b6a1-cd2560fee5bf"
 repo = "https://github.com/TuringLang/JuliaBUGS.jl.git"
+subdir = "JuliaBUGS"


### PR DESCRIPTION
Separating subdirectory changes for this PR: https://github.com/JuliaRegistries/General/pull/136146

```julia
julia> check_package_versions("JuliaBUGS", "https://github.com/TuringLang/JuliaBUGS.jl.git");
Cloning into 'C:\Users\seeker\AppData\Local\Temp\jl_Ymm76h'...
remote: Enumerating objects: 6248, done.
remote: Counting objects: 100% (1223/1223), done.
remote: Compressing objects: 100% (512/512), done.
remote: Total 6248 (delta 1012), reused 726 (delta 679), pack-reused 5025 (from 4)
Receiving objects: 100% (6248/6248), 7.58 MiB | 1.03 MiB/s, done.
Resolving deltas: 100% (3119/3119), done.
Updating files: 100% (753/753), done.
JuliaBUGS: v0.1.0 found
JuliaBUGS: v0.1.1 found
JuliaBUGS: v0.2.0 found
JuliaBUGS: v0.2.1 found
JuliaBUGS: v0.2.2 found
JuliaBUGS: v0.2.3 found
JuliaBUGS: v0.2.4 found
JuliaBUGS: v0.3.0 found
JuliaBUGS: v0.4.0 found
JuliaBUGS: v0.4.1 found
JuliaBUGS: v0.5.0 found
JuliaBUGS: v0.5.1 found
JuliaBUGS: v0.5.2 found
JuliaBUGS: v0.5.3 found
JuliaBUGS: v0.6.0 found
JuliaBUGS: v0.6.1 found
JuliaBUGS: v0.6.2 found
JuliaBUGS: v0.6.3 found
JuliaBUGS: v0.6.4 found
JuliaBUGS: v0.7.0 found
JuliaBUGS: v0.7.1 found
JuliaBUGS: v0.7.2 found
JuliaBUGS: v0.7.3 found
JuliaBUGS: v0.7.4 found
JuliaBUGS: v0.7.5 found
JuliaBUGS: v0.8.0 found
JuliaBUGS: v0.8.1 found
JuliaBUGS: v0.8.2 found
JuliaBUGS: v0.9.0 found

julia>
```