### PR TITLE
Yank Blosc2_jll

### DIFF
--- a/jll/B/Blosc2_jll/Versions.toml
+++ b/jll/B/Blosc2_jll/Versions.toml
@@ -84,3 +84,4 @@ git-tree-sha1 = "a3d8ca590df0c60cfca8faf8be14789aab0a8d61"
 
 ["201.2000.0+0"]
 git-tree-sha1 = "8c4441b46115d8355198abe97ef498d12e866892"
+yanked = true


### PR DESCRIPTION
Version 201.2000 is binary incompatible with version 201.1800. Yank it, to be re-released as 202.2000.