### PR TITLE
[Enzyme] Cap compat of `EnzymeCore` to v0.8.8 where necessary

### DIFF
--- a/E/Enzyme/Compat.toml
+++ b/E/Enzyme/Compat.toml
@@ -261,7 +261,7 @@ Enzyme_jll = "0.0.117"
 EnzymeCore = "0.7.3-0.7"
 
 ["0.13 - 0.13.3"]
-EnzymeCore = "0.8"
+EnzymeCore = "0.8-0.8.8"
 Enzyme_jll = "0.0.150"
 
 ["0.13 - 0.13.51"]
@@ -289,11 +289,11 @@ Enzyme_jll = "0.0.159"
 Enzyme_jll = "0.0.163"
 
 ["0.13.15 - 0.13.16"]
-EnzymeCore = "0.8.6-0.8"
+EnzymeCore = "0.8.6-0.8.8"
 Enzyme_jll = "0.0.165"
 
 ["0.13.17 - 0.13.18"]
-EnzymeCore = "0.8.7-0.8"
+EnzymeCore = "0.8.7-0.8.8"
 Enzyme_jll = "0.0.166"
 
 ["0.13.19"]
@@ -303,7 +303,7 @@ Enzyme_jll = "0.0.167"
 PrecompileTools = "1"
 
 ["0.13.19 - 0.13.44"]
-EnzymeCore = "0.8.8-0.8"
+EnzymeCore = "0.8.8"
 
 ["0.13.20 - 0.13.24"]
 Enzyme_jll = "0.0.168"
@@ -333,7 +333,7 @@ Enzyme_jll = "0.0.151"
 SparseArrays = "1"
 
 ["0.13.4 - 0.13.14"]
-EnzymeCore = "0.8.4-0.8"
+EnzymeCore = "0.8.4-0.8.8"
 
 ["0.13.42"]
 Enzyme_jll = "0.0.178"


### PR DESCRIPTION
[`EnzymeCore@v0.8.9` was effectively a breaking change](https://github.com/EnzymeAD/Enzyme.jl/issues/2483#issuecomment-3240071589), cap compat bounds which allow `EnzymeCore < v0.8.9` to `v0.8.8`.  Fix https://github.com/EnzymeAD/Enzyme.jl/issues/2483.