### PR TITLE
Test if #137833 catches bad registry PRs

### DIFF
--- a/O/OrdinaryDiffEqCore/Versions.toml
+++ b/O/OrdinaryDiffEqCore/Versions.toml
@@ -131,7 +131,7 @@ git-tree-sha1 = "e579c9a4f9102e82da3d97c349a74d6bc11cf8dc"
 
 ["1.31.0"]
 git-tree-sha1 = "0dbcf81a1bf3b2393cbabe7276b80a2d36c69273"
-yanked = true
+yanked = "true"
 
 ["1.32.0"]
 git-tree-sha1 = "89316a2589f856a2d4de48a8c1e336f5a7a87b88"


### PR DESCRIPTION
> Revert "Fix OrdinaryDiffEqCore yank (#137826)"
> This reverts commit 20b778710e3c9a8f4c2045bb25ab92175f781316.

Targets `dpa/pkg-add-example` (#137833).