### PR TITLE
Update URLs of TensorKit and TensorOperations to reflect transfer

### DIFF
--- a/T/TensorKit/Package.toml
+++ b/T/TensorKit/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorKit"
 uuid = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
-repo = "https://github.com/Jutho/TensorKit.jl.git"
+repo = "https://github.com/QuantumKitHub/TensorKit.jl.git"

--- a/T/TensorOperations/Package.toml
+++ b/T/TensorOperations/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorOperations"
 uuid = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
-repo = "https://github.com/Jutho/TensorOperations.jl.git"
+repo = "https://github.com/QuantumKitHub/TensorOperations.jl.git"


### PR DESCRIPTION
These have now moved to the @QuantumKitHub org