### PR TITLE
transfer package `EnforcedTypeSignatureCallables` from Gitlab to Github

### DIFF
--- a/E/EnforcedTypeSignatureCallables/Package.toml
+++ b/E/EnforcedTypeSignatureCallables/Package.toml
@@ -1,3 +1,3 @@
 name = "EnforcedTypeSignatureCallables"
 uuid = "e0a517c1-78b8-4e0b-8db9-584d87c611c9"
-repo = "https://gitlab.com/nsajko/EnforcedTypeSignatureCallables.jl.git"
+repo = "https://github.com/JuliaFunctional/EnforcedTypeSignatureCallables.jl.git"


### PR DESCRIPTION
Old Gitlab repo page:

* https://gitlab.com/nsajko/EnforcedTypeSignatureCallables.jl

New Github repo page:

* https://github.com/JuliaFunctional/EnforcedTypeSignatureCallables.jl