### PR TITLE
Update compat bounds for MCMCChains 7.2.1

### DIFF
--- a/M/MCMCChains/Compat.toml
+++ b/M/MCMCChains/Compat.toml
@@ -233,16 +233,8 @@ IteratorInterfaceExtensions = ["0.1.1 - 0.1", "1"]
 KernelDensity = "0.6.2 - 0.6"
 MLJModelInterface = ["0.3.5 - 0.4", "1"]
 OrderedCollections = "1.4.0 - 1"
+PrettyTables = ["0.9 - 0.12", "1 - 2"]
 RecipesBase = ["0.7 - 0.8", "1"]
 StatsBase = "0.33.2 - 0.34"
 StatsFuns = ["0.8 - 0.9", "1"]
 julia = "1.6.3 - 1"
-
-["7.2.0"]
-PrettyTables = ["0.9 - 0.12", "1 - 2"]
-
-["7.2.1"]
-PrettyTables = ["0.9 - 0.12", "1 - 3"]
-
-["7.2.2 - 7"]
-PrettyTables = ["0.9 - 0.12", "1 - 2"]


### PR DESCRIPTION
7.2.1 had an overly lax compatibility bound for PrettyTables (https://github.com/TuringLang/MCMCChains.jl/pull/490).