### PR TITLE
Update package URL of NautyGraphs

### DIFF
--- a/N/NautyGraphs/Package.toml
+++ b/N/NautyGraphs/Package.toml
@@ -1,3 +1,3 @@
 name = "NautyGraphs"
 uuid = "7509a0a4-015a-4167-b44b-0799a1a2605e"
-repo = "https://github.com/mxhbl/NautyGraphs.jl.git"
+repo = "https://github.com/JuliaGraphs/NautyGraphs.jl.git"


### PR DESCRIPTION
The package was moved to to JuliaGraphs org. cc @Krastanov 