### PR TITLE
Transfer ownership of SymbolicIntegration.jl (update URL to point to JuliaSymbolics)

### DIFF
--- a/S/SymbolicIntegration/Package.toml
+++ b/S/SymbolicIntegration/Package.toml
@@ -1,3 +1,3 @@
 name = "SymbolicIntegration"
 uuid = "315ce56f-eed0-411d-ab8a-2fbdf9327b51"
-repo = "https://github.com/HaraldHofstaetter/SymbolicIntegration.jl.git"
+repo = "https://github.com/JuliaSymbolics/SymbolicIntegration.jl"

--- a/S/SymbolicIntegration/Package.toml
+++ b/S/SymbolicIntegration/Package.toml
@@ -1,3 +1,3 @@
 name = "SymbolicIntegration"
 uuid = "315ce56f-eed0-411d-ab8a-2fbdf9327b51"
-repo = "https://github.com/JuliaSymbolics/SymbolicIntegration.jl"
+repo = "https://github.com/JuliaSymbolics/SymbolicIntegration.jl.git"


### PR DESCRIPTION
Fixes https://github.com/JuliaRegistries/General/issues/136746