### PR TITLE
SeqFold.jl: Change URL from HTTP to HTTPS

### DIFF
--- a/S/SeqFold/Package.toml
+++ b/S/SeqFold/Package.toml
@@ -1,3 +1,3 @@
 name = "SeqFold"
 uuid = "b3b2a78d-ef5a-44e0-bc1e-af93888afa44"
-repo = "http://github.com/phlaster/SeqFold.jl.git"
+repo = "https://github.com/phlaster/SeqFold.jl.git"


### PR DESCRIPTION
The package was initially registered in: https://github.com/JuliaRegistries/General/pull/138007

Cross-ref: https://github.com/JuliaRegistries/Registrator.jl/issues/463