### PR TITLE
[Healpix] Update repo URL

### DIFF
--- a/H/Healpix/Package.toml
+++ b/H/Healpix/Package.toml
@@ -1,3 +1,3 @@
 name = "Healpix"
 uuid = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
-repo = "https://github.com/ziotom78/Healpix.jl.git"
+repo = "https://github.com/JuliaAstro/Healpix.jl.git"


### PR DESCRIPTION
Healpix.jl has been moved within the JuliaAstro organization.

This PR implements point 2 in the guide at <https://github.com/JuliaRegistries/General#how-do-i-transfer-a-package-to-an-organization-or-another-user>.