### PR TITLE
Remove incorrect `subdir` for Twistronics.jl package

### DIFF
--- a/T/Twistronics/Package.toml
+++ b/T/Twistronics/Package.toml
@@ -1,4 +1,3 @@
 name = "Twistronics"
 uuid = "e64eaefb-b7d3-45fb-a1e6-d686d91076ba"
 repo = "https://github.com/GUANGZECHEN/Twistronics.jl.git"
-subdir = "https://github.com/GUANGZECHEN/Twistronics.jl/tree/master/src"


### PR DESCRIPTION
H/t @ericphanson for finding this.

We now have AutoMerge checks that catch this (see https://github.com/JuliaRegistries/RegistryCI.jl/issues/618#issuecomment-3340503368), but this package was registered before we had that check.

From looking at the package's repo (https://github.com/GUANGZECHEN/Twistronics.jl), it doesn't seem like a `subdir` is needed.