### PR TITLE
OpenSSL - yank broken version 1.5.0

### DIFF
--- a/O/OpenSSL/Versions.toml
+++ b/O/OpenSSL/Versions.toml
@@ -51,3 +51,4 @@ git-tree-sha1 = "38cb508d080d21dc1128f7fb04f20387ed4c0af4"
 
 ["1.5.0"]
 git-tree-sha1 = "f1a7e086c677df53e064e0fdd2c9d0b0833e3f6e"
+yanked = true


### PR DESCRIPTION
OpenSSL v1.5.0 uses illegal operations in a finalizer, leading to errors or crashes from corrupting the task runtime state.

See
- https://github.com/JuliaWeb/OpenSSL.jl/issues/44
- https://github.com/JuliaLang/julia/issues/59716
- https://julialang.slack.com/archives/C683N3423/p1759596697784169

The OpenSSL issue has been open for over 3 months without engagement from maintainers.