### PR TITLE
Update package name guidelines (ASCII required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ checks each PR, and if there are no blocking comments when it checks
 
 ### Are there any requirements for package names in the General registry?
 
-There are no hard requirements, but it is *highly recommended* to follow
+Package names can only use ASCII letters and numbers. Beyond that, there are
+no *hard* requirements, but it is *highly recommended* to follow
 the [package naming guidelines][naming-guidelines].
 
 ### What to do when asked to reconsider/update the package name?


### PR DESCRIPTION
The restriction to ASCII is definitely a hard rule.


Technically, we also have packages with underscores in the name, but I think those are restricted to `_jll`. So, for all normal package registrations, I think ASCII letters and numbers is it. One could also add that the first letter can't be a number, but maybe that's understood implicitly.

Ref: https://discourse.julialang.org/t/can-package-names-contain-non-ascii-characters/132965/7