### PR TITLE
Add HYPRE_jll compat to HYPRE.jl

### DIFF
--- a/H/HYPRE/Compat.toml
+++ b/H/HYPRE/Compat.toml
@@ -8,6 +8,9 @@ CEnum = "0.4"
 SparseMatricesCSR = "0.6"
 julia = "1.6.0-1"
 
+["1-1.7"]
+HYPRE_jll = "2"
+
 ["1.0"]
 MPI = "0.19"
 


### PR DESCRIPTION
This is a manual PR to add a compat entry following the discussion in https://github.com/fredrikekre/HYPRE.jl/pull/39

I am adding a new version of the HYPRE_jll here: https://github.com/JuliaPackaging/Yggdrasil/pull/12254

Existing released versions of HYPRE.jl does not have any bounds on the _jll and may break if the new HYPRE_jll version gets merged.