### PR TITLE
Add compat bounds for JLL packages compiled with SCALAPACK32_jll

### DIFF
--- a/jll/M/MUMPS_jll/Compat.toml
+++ b/jll/M/MUMPS_jll/Compat.toml
@@ -9,6 +9,7 @@ JLLWrappers = "1.2.0-1"
 
 ["5.4.2-5"]
 julia = "1.6.0-1"
+SCALAPACK32_jll = "2.1.0-2.2.1"
 
 ["5.4.2-5.5"]
 SCOTCH_jll = "6.1.3-6"

--- a/jll/P/PETSc_jll/Compat.toml
+++ b/jll/P/PETSc_jll/Compat.toml
@@ -24,7 +24,7 @@ PARMETIS_jll = "4.0.5-4"
 SuperLU_DIST_jll = "8.0.1-8"
 
 ["3.16.8-3.18"]
-SCALAPACK32_jll = "2.2.1-2"
+SCALAPACK32_jll = "2.2.1"
 
 ["3.16.8-3.18.6"]
 MUMPS_jll = "5.5.1-5.6.1"

--- a/jll/Q/QuantumEspresso_jll/Compat.toml
+++ b/jll/Q/QuantumEspresso_jll/Compat.toml
@@ -9,6 +9,7 @@ JLLWrappers = "1.2.0-1"
 
 ["7.0.1-7"]
 MPIPreferences = "0.1"
+SCALAPACK32_jll = "2.1.0-2.2.1"
 
 ["7.0.1-7.0"]
 JLLWrappers = "1.4.0-1"


### PR DESCRIPTION
We plan to compile the next release of `SCALAPACK32_jll` with `libblastrampoline` (LBT) and because it requires an LP64 BLAS / LAPACK like `OpenBLAS32_jll` to be loaded manually, we want to ensure that we don't break current users of `MUMPS`, `QuantumEspresso` and `PETSc`.

Related PR in Yggsrasil: https://github.com/JuliaPackaging/Yggdrasil/pull/12231