### PR TITLE
CI: Start generating an AutoMerge CI manifest for Julia 1.12 (keep the 1.11 manifest also)

### DIFF
--- a/.github/workflows/update_manifests.yml
+++ b/.github/workflows/update_manifests.yml
@@ -83,6 +83,7 @@ jobs:
       matrix:
         version:
           - '1.11'
+          - '1.12'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1


### PR DESCRIPTION
To make it smoother to upgrade AutoMerge, when we do so in the future.