### PR TITLE
AutoMerge: update staging workflow for 2nd label job, like regular workflow

### DIFF
--- a/.github/workflows/automerge_staging.yml
+++ b/.github/workflows/automerge_staging.yml
@@ -6,16 +6,38 @@
 name: AutoMerge (staging)
 on:
   pull_request:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    types: [opened, reopened, labeled, synchronize]
 
 # Make sure that the `GITHUB_TOKEN` only has read-only permissions
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
 
+# We have two jobs:
+# 1. AutoMerge_staging-regular:
+#    This includes all PR runs except PR labels.
+# 2. AutoMerge_staging-label:
+#    This only includes PR label runs.
+#    It is important to keep this job separate.
+#    If we don't keep this job separate, then any label action will override the main/regular
+#    AutoMerge job with a "skipped" AutoMerge job, thus making it very difficult for PR authors
+#    to view the CI logs (which they need to do if they e.g. want to figure out why `import MyPackageName`
+#    failed during the AutoMerge run.)
 jobs:
-  AutoMerge_staging:
+  AutoMerge_staging-regular:
+    # Run if:
+    # - not from a PR event
+    # - or it is from a PR event AND it is not from a fork AND we are not triggered by a label
+    # Note: since the label contains a colon, we need to use a workaround like https://github.com/actions/runner/issues/1019#issuecomment-810482716
+    # for the syntax to parse correctly.
+    if: "${{ github.event_name != 'pull_request' || (github.repository == github.event.pull_request.head.repo.full_name && (github.event.action != 'labeled')) }}"
     timeout-minutes: 60
-    if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ${{ matrix.os }}
+    concurrency:
+      # Skip intermediate builds: always.
+      # Cancel intermediate builds: only pull request builds
+      group: automerge-staging-${{ github.ref }}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     strategy:
       matrix:
         version:
@@ -82,5 +104,91 @@ jobs:
               "https://github.com/HolyLab/HolyLabRegistry",
               "https://github.com/cossio/CossioJuliaRegistry"
             ],
+            check_breaking_explanation = true,
+          )
+        shell: julia --color=yes --project=.ci/AutoMerge/ {0}
+  AutoMerge_staging-label:
+    # Run this job only if ALL of the following conditions are true:
+    # 1. It is from a PR event, AND
+    # 2. The PR is not from a fork, AND
+    # 3. We are being triggered by a label, AND
+    # 4. The label is one that affects the execution of the workflow
+    # Note: since the label contains a colon, we need to use a workaround like https://github.com/actions/runner/issues/1019#issuecomment-810482716
+    # for the syntax to parse correctly.
+    if: "${{ (github.event_name == 'pull_request') && (github.repository == github.event.pull_request.head.repo.full_name) && (github.event.action == 'labeled') && (github.event.label.name == 'Override AutoMerge: name similarity is okay' || github.event.label.name == 'Override AutoMerge: package author approved') }}"
+    timeout-minutes: 60
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      # Skip intermediate builds: always.
+      # Cancel intermediate builds: only pull request builds
+      group: automerge-staging-${{ github.ref }}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+    strategy:
+      matrix:
+        version:
+          - '1.12'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
+        with:
+          version: ${{ matrix.version }}
+      # No Project/Manifest for staging run
+      - run: rm -rf .ci/AutoMerge/JuliaManifest*.toml
+      - run: rm -rf .ci/AutoMerge/Manifest*.toml
+      - run: rm -rf .ci/AutoMerge/JuliaProject*.toml
+      - run: rm -rf .ci/AutoMerge/Project*.toml
+      - name: Cache artifacts
+        uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.add("General")'
+        env:
+          JULIA_PKG_SERVER: ""
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'
+      - run: .ci/instantiate.sh .ci/AutoMerge/
+      - run: |
+          import Pkg
+          name = "AutoMerge"
+          uuid = "c5732277-7834-41e3-8e1f-5f375898cfe1"
+          rev = "master"
+          subdir = "AutoMerge"
+          url = "https://github.com/JuliaRegistries/RegistryCI.jl"
+          Pkg.add(; name, uuid, rev, subdir, url)
+        shell: julia --color=yes --project=.ci/AutoMerge/ {0}
+      - run: julia --color=yes --project=.ci/AutoMerge/ -e 'import Pkg; Pkg.update()'
+      - run: julia --color=yes --project=.ci/AutoMerge/ -e 'import Pkg; Pkg.precompile()'
+      - name: AutoMerge.run
+        env:
+          AUTOMERGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOMERGE_TAGBOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JULIA_DEBUG: RegistryCI,AutoMerge
+        run: |
+          using AutoMerge
+          using Dates
+
+          AutoMerge.run(
+            read_only = true,           # run in read-only mode
+
+            merge_new_packages = false, # don't merge any PRs
+            merge_new_versions = false, # don't merge any PRs
+            new_package_waiting_period = Day(3),
+            new_jll_package_waiting_period = Minute(20),
+            new_version_waiting_period = Minute(10),
+            new_jll_version_waiting_period = Minute(10),
+            registry = "JuliaRegistries/General",
+            tagbot_enabled = true,
+            authorized_authors = String["JuliaRegistrator"],
+            authorized_authors_special_jll_exceptions = String["jlbuild"],
+            suggest_onepointzero = false,
+            additional_statuses = String[],
+            additional_check_runs = String[],
+            check_license = true,
+            public_registries = String[
+              "https://github.com/HolyLab/HolyLabRegistry",
+              "https://github.com/cossio/CossioJuliaRegistry"
+            ],
+            check_breaking_explanation = true,
           )
         shell: julia --color=yes --project=.ci/AutoMerge/ {0}


### PR DESCRIPTION
This aligns the staging workflow better to the prod workflow. The prod workflow has 2 jobs since https://github.com/JuliaRegistries/General/pull/130112.

This means when someone adds a behavior-affecting label, we run the separate AutoMerge job to rerun automerge and update the status check with the new info (eg skipping name similarity). This uses the same logic for the new `AutoMerge_staging-label:` job. That way we won't get a red check from the staging workflow when overriding automerge name similarity, like in https://github.com/JuliaRegistries/General/pull/140267.

Discussed on slack here: https://julialang.slack.com/archives/C02174EA421/p1760359829796529?thread_ts=1760359404.837439&cid=C02174EA421