### PR TITLE
Update URLs for transfered packages

### DIFF
--- a/S/SlicedDistributions/Package.toml
+++ b/S/SlicedDistributions/Package.toml
@@ -1,3 +1,3 @@
 name = "SlicedDistributions"
 uuid = "78bc189a-7b6d-4df1-8a23-377b7c6fd0cb"
-repo = "https://github.com/FriesischScott/SlicedDistributions.jl.git"
+repo = "https://github.com/JuliaUQ/SlicedDistributions.jl.git"

--- a/S/SurvivalSignature/Package.toml
+++ b/S/SurvivalSignature/Package.toml
@@ -1,3 +1,3 @@
 name = "SurvivalSignature"
 uuid = "13fa4dc1-3690-464b-a752-a9f12e029c3c"
-repo = "https://github.com/FriesischScott/SurvivalSignature.jl.git"
+repo = "https://github.com/JuliaUQ/SurvivalSignature.jl.git"

--- a/U/UncertaintyQuantification/Package.toml
+++ b/U/UncertaintyQuantification/Package.toml
@@ -1,3 +1,3 @@
 name = "UncertaintyQuantification"
 uuid = "7183a548-a887-11e9-15ce-a56ab60bad7a"
-repo = "https://github.com/FriesischScott/UncertaintyQuantification.jl.git"
+repo = "https://github.com/JuliaUQ/UncertaintyQuantification.jl.git"


### PR DESCRIPTION
I've transferred these three packages from my personal account to the organization [JuliaUQ](https://github.com/JuliaUQ):
 - UncertaintyQuantification,
 - SurvivalSignature,
 - SlicedDistributions.
 
 This PR updates the URLs in the `Package.toml` files accordingly. 