### PR TITLE
URL change for the NextLA package

### DIFF
--- a/N/NextLA/Package.toml
+++ b/N/NextLA/Package.toml
@@ -1,3 +1,3 @@
 name = "NextLA"
 uuid = "d37ed344-79c4-486d-9307-6d11355a15a3"
-repo = "https://github.com/Rabab53/NextLA.jl.git"
+repo = "https://github.com/NextLinearAlgebra/NextLA.jl" 

--- a/N/NextLA/Package.toml
+++ b/N/NextLA/Package.toml
@@ -1,3 +1,3 @@
 name = "NextLA"
 uuid = "d37ed344-79c4-486d-9307-6d11355a15a3"
-repo = "https://github.com/NextLinearAlgebra/NextLA.jl" 
+repo = "https://github.com/NextLinearAlgebra/NextLA.jl.git"


### PR DESCRIPTION
The package changed repos, but it's still the same. This is needed  for a new version publication.