### PR TITLE
PETSc_jll: Restrict SCALAPACK32_jll compat bounds

### DIFF
--- a/jll/P/PETSc_jll/Compat.toml
+++ b/jll/P/PETSc_jll/Compat.toml
@@ -27,7 +27,7 @@ SuperLU_DIST_jll = "8.0.1-8"
 SCALAPACK32_jll = "2-2.2.1"
 
 ["3.16.8-3.22"]
-SCALAPACK32_jll = "2.2.1-2.2.1"
+SCALAPACK32_jll = "2.2.1"
 
 ["3.16.8-3.18.6"]
 MUMPS_jll = "5.5.1-5.6.1"

--- a/jll/P/PETSc_jll/Compat.toml
+++ b/jll/P/PETSc_jll/Compat.toml
@@ -23,8 +23,11 @@ MPItrampoline_jll = "5.0.1-5"
 PARMETIS_jll = "4.0.5-4"
 SuperLU_DIST_jll = "8.0.1-8"
 
-["3.16.8-3.18"]
-SCALAPACK32_jll = "2.2.1"
+["3-3.16.7"]
+SCALAPACK32_jll = "2-2.2.1"
+
+["3.16.8-3.22"]
+SCALAPACK32_jll = "2.2.1-2.2.1"
 
 ["3.16.8-3.18.6"]
 MUMPS_jll = "5.5.1-5.6.1"


### PR DESCRIPTION
Prevent segfaults with the new `SCALAPACK32_jll 2.2.2`.