### PR TITLE
Cap compat for Kmers.jl v0.x at 3.3 to avoid installing old version

### DIFF
--- a/K/Kmers/Compat.toml
+++ b/K/Kmers/Compat.toml
@@ -1,5 +1,5 @@
 [0]
-BioSequences = "3"
+BioSequences = "3-3.3"
 julia = "1.5.0-1"
 
 [1]


### PR DESCRIPTION
Issue is that Kmers 1.x added a too-narrow compat bound on BioSequences, so that when the BioSequences 3.5 was released, Pkg installs BioSequences 3.5 and Kmers 0.1.