### PR TITLE
Add deprecation notice to unzip_jll

### DIFF
--- a/jll/U/unzip_jll/Package.toml
+++ b/jll/U/unzip_jll/Package.toml
@@ -1,3 +1,7 @@
 name = "unzip_jll"
 uuid = "88f77b66-78eb-5ed0-bc16-ebba0796830d"
 repo = "https://github.com/JuliaBinaryWrappers/unzip_jll.jl.git"
+
+[metadata.deprecated]
+reason = "This package does not handle UTF-8 correctly on Windows"
+alternative = "p7zip_jll"


### PR DESCRIPTION
Added deprecation metadata indicating issues with UTF-8 handling on Windows and suggesting an alternative package.

This PR is based on https://github.com/JuliaRegistries/General/pull/141098

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/12337 https://github.com/JuliaPackaging/Yggdrasil/issues/7679#issuecomment-3419079074