### PR TITLE
Add CODEOWNERS entry for StaticArrays.jl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,8 @@ L/LLD_jj/ @vchuravy @staticfloat
 L/libLLVM_assert_jll/ @vchuravy @staticfloat
 L/libLLVM_jll/ @vchuravy @staticfloat
 M/MLIR_jll/ @vchuravy @staticfloat
+
+# StaticArrays.jl is used in the Pkg.jl test suite.
+# Thus, changes here can break Pkg tests (and thus Base Julia CI).
+# So ping some General registry and/or Pkg folks
+S/StaticArrays/ @DilumAluthge


### PR DESCRIPTION
Changes here can (and did) break Base Julia CI, which can end up blocking Julia releases. So ping some General registry and/or Pkg folks, to increase visibility of these changes.

I just added myself to start - @KristofferC @fredrikekre let me know if you also want to be added.