### PR TITLE
Yank RegistryTools 2.4.0

### DIFF
--- a/R/RegistryTools/Versions.toml
+++ b/R/RegistryTools/Versions.toml
@@ -102,6 +102,7 @@ git-tree-sha1 = "c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1"
 
 ["2.4.0"]
 git-tree-sha1 = "9d40f0a9b4d74006dd0b9acbc238a7fd4dc48f37"
+yanked = true
 
 ["2.4.1"]
 git-tree-sha1 = "3087a02cf7baffe55fc5d26573bfd9ab8833c613"


### PR DESCRIPTION
RegistryTools 2.4.0 can write broken registry files and should not be used. 2.3.0 and 2.4.1 are both good.
Cf. https://github.com/JuliaRegistries/RegistryTools.jl/pull/106
