### PR TITLE
Fix SciMLBase compat entries of OptimizationBase

### DIFF
--- a/O/OptimizationBase/Compat.toml
+++ b/O/OptimizationBase/Compat.toml
@@ -8,7 +8,7 @@ julia = "1.9.0-1"
 Requires = "1"
 
 ["0 - 2.11"]
-SciMLBase = "2"
+SciMLBase = "2 - 2.120"
 
 ["0 - 2.8"]
 ArrayInterface = "7.6.0-7"
@@ -69,7 +69,10 @@ DifferentiationInterface = "0.6.1-0.6"
 ["2.1 - 2.8"]
 ADTypes = "1.9.0-1"
 
-["2.12 - 3"]
+["2.12"]
+SciMLBase = "2.104.0 - 2.120.0"
+
+["2.13 - 3"]
 SciMLBase = "2.104.0 - 2"
 
 ["2.8 - 4"]


### PR DESCRIPTION
**Please check carefully as I'm editing OptimizationBase/Compat.toml without knowing the exact specs of this file**

Currently, users of MTK@9 (such as every Catalyst user) can only install OptimizationBase@2.11. However, https://github.com/SciML/SciMLBase.jl/pull/1146 (released as SciMLBase@2.121.0) broke OptimizationBase <= 2.12 as these versions of OptimizationBase do not contain the code that was removed from SciMLBase. OptimizationBase@2.13 seems to be a generally broken release, regardless of whether one uses SciMLBase@2.120.0 or SciMLBase@2.121 precompilation warnings show up due to method overwriting, but this might not matter too much since users of OptimizationBase@2.13 should generally be able to update to OptimizationBase@2.14 which fixes these issues (precompilation warnings and SciMLBase compatibility). However, as users of OptimizationBase@2.11 generally can't update to OptimizationBase@2.14, I'm opening this PR to prevent Pkg from ever installing these incompatible versions of OptimizationBase <= 2.12 and SciMLBase >= 2.121.0

You can reproduce the current problems with OptimizationBase <= 2.12 and SciMLBase >= 2.121 by running in a clean Julia environment
```julia
julia> ] add Optimization@4 OptimizationBase@2.12 SciMLBase@2.121 OptimizationOptimJL
```
With these versions the precompilation workflow in OptimizationOptimJL throws a precompilation error; the same happens with older versions of OptimizationBase such as OptimizationBase@2.11.

On the other hand,
```julia
julia> ] add Optimization@4 OptimizationBase@2.12 SciMLBase@2.120 OptimizationOptimJL
```
works fine without precompilation errors.

Ref https://github.com/SciML/SciMLBase.jl/pull/1146
Ref https://github.com/SciML/Optimization.jl/issues/1070