### PR TITLE
Yank NLPModels.jl 0.22

### DIFF
--- a/N/NLPModels/Versions.toml
+++ b/N/NLPModels/Versions.toml
@@ -147,3 +147,4 @@ git-tree-sha1 = "448a0b078832f49f2564f070fb57af70794cf0f9"
 
 ["0.22.0"]
 git-tree-sha1 = "ba4dc2f35529fa31d7e026e680ee3a5104585632"
+yanked = true


### PR DESCRIPTION
We have decided to yank release 0.22 of `NLPModels.jl` because the breaking change only affected the removal of a parameter (`x`) from three functions in the public API. This breaking release disrupts compatibility with the existing ecosystem — over 50 registered packages depend on this package.

A non-breaking alternative is possible and straightforward (e.g., deprecating the parameter instead of removing it), which allows us to:

* maintain ecosystem stability;
* avoid unnecessary disruption for users;
* give downstream maintainers time to adapt without urgency.

In hindsight, the release was pushed a bit hastily. Yank 0.22 allows us to preserve compatibility and ensures that breaking releases are made only for substantial, justified changes.