### PR TITLE
update TensorKitManifolds repository link

### DIFF
--- a/T/TensorKitManifolds/Package.toml
+++ b/T/TensorKitManifolds/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorKitManifolds"
 uuid = "11fa318c-39cb-4a83-b1ed-cdc7ba1e3684"
-repo = "https://github.com/Jutho/TensorKitManifolds.jl.git"
+repo = "https://github.com/QuantumKitHub/TensorKitManifolds.jl.git"


### PR DESCRIPTION
This PR updates the link for TensorKitManifolds, after a repository transfer.