### PR TITLE
`GnuPG_jll`: Add `Libassuan_jll` compat bounds

### DIFF
--- a/jll/G/GnuPG_jll/Compat.toml
+++ b/jll/G/GnuPG_jll/Compat.toml
@@ -1,6 +1,7 @@
 ["2-2.2"]
 Bzip2_jll = "1.0.6"
 JLLWrappers = "1.2.0-1"
+Libassuan_jll = "2"
 Libgpg_error_jll = "1.36.0"
 Nettle_jll = "3.4.1-3.4"
 julia = "1"
@@ -9,6 +10,7 @@ julia = "1"
 Artifacts = ["0.0.0", "1"]
 Bzip2_jll = "1.0.8-1"
 JLLWrappers = "1.7.0-1"
+Libassuan_jll = "2"
 Libdl = ["0.0.0", "1"]
 Libgpg_error_jll = "1.51.0-1"
 Nettle_jll = "3.10"


### PR DESCRIPTION
All current `GnuPG_jll` are only compatible with `Libassuan_jll` version 2. (Version 3 has been released but not yet wrapped as jll.)