### PR TITLE
Deprecate CodecBGZF

### DIFF
--- a/C/CodecBGZF/Package.toml
+++ b/C/CodecBGZF/Package.toml
@@ -1,3 +1,7 @@
 name = "CodecBGZF"
 uuid = "d9d91ef6-315d-495b-8131-db2ca24339d6"
 repo = "https://github.com/jakobnissen/CodecBGZF.jl.git"
+
+[metadata.deprecated]
+reason = "This package has hard-to-fix bugs and is not maintained"
+alternative = "BGZFLib"


### PR DESCRIPTION
This package is deprecated in favor of BGZFLib. The reason BGZFLib is not simply a breaking change of this CodecBGZF is that the "Codec*" prefix refers to the TranscodingStreams API, which the BGZF format does not easily fit into, which is what ultimately caused the hard-to-fix bugs.