### PR TITLE
Update repository URL for DisjunctiveProgramming

### DIFF
--- a/D/DisjunctiveProgramming/Package.toml
+++ b/D/DisjunctiveProgramming/Package.toml
@@ -1,3 +1,3 @@
 name = "DisjunctiveProgramming"
 uuid = "0d27d021-0159-4c7d-b4a7-9ccb5d9366cf"
-repo = "https://github.com/hdavid16/DisjunctiveProgramming.jl.git"
+repo = "https://github.com/infiniteopt/DisjunctiveProgramming.jl.git"


### PR DESCRIPTION
DisjunctiveProgramming.jl was moved to the InfiniteOpt organization. This PR updates the URL.