### PR TITLE
Update SimSpread.jl repository URL

### DIFF
--- a/S/SimSpread/Package.toml
+++ b/S/SimSpread/Package.toml
@@ -1,3 +1,3 @@
 name = "SimSpread"
 uuid = "afa5cc60-bf5a-45b9-aa6c-27158a106b2a"
-repo = "https://github.com/cvigilv/SimSpread.jl.git"
+repo = "https://github.com/schuellerlab/SimSpread.jl.git"


### PR DESCRIPTION
This PR updates the URL for the package SimSpread.jl because ownership was transferred to an organization.

github.com/cvigilv/SimSpread.jl to github.com/schuellerlab/SimSpread.jl
