### PR TITLE
add `subdir` to `ColorSchemes`

### DIFF
--- a/C/ColorSchemes/Package.toml
+++ b/C/ColorSchemes/Package.toml
@@ -1,3 +1,4 @@
 name = "ColorSchemes"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 repo = "https://github.com/JuliaGraphics/ColorSchemes.jl.git"
+subdir = "ColorSchemes"


### PR DESCRIPTION
Following https://github.com/JuliaGraphics/ColorSchemes.jl/pull/154 (files were only moved within the same repository, without rewriting history).

The test script (https://github.com/JuliaRegistries/General/blob/master/CONTRIBUTING.md#appendix-checking-if-a-repository-contains-all-registered-versions-of-a-package) **ran on the fork** correctly finds all the `ColorSchemes` versions:

```julia
registry.name = "General"
registry.path = "[...]/_codes_/General"  # fork : t-bltg:subdir-colorschemes
ColorSchemes: v2.0.0 found
ColorSchemes: v2.0.1 found
ColorSchemes: v2.0.2 found
ColorSchemes: v3.0.0 found
ColorSchemes: v3.0.1 found
ColorSchemes: v3.1.0 found
ColorSchemes: v3.2.0 found
ColorSchemes: v3.3.0 found
ColorSchemes: v3.4.0 found
ColorSchemes: v3.5.0 found
ColorSchemes: v3.6.0 found
ColorSchemes: v3.7.0 found
ColorSchemes: v3.8.0 found
ColorSchemes: v3.9.0 found
ColorSchemes: v3.10.0 found
ColorSchemes: v3.10.1 found
ColorSchemes: v3.10.2 found
ColorSchemes: v3.11.0 found
ColorSchemes: v3.12.0 found
ColorSchemes: v3.12.1 found
ColorSchemes: v3.13.0 found
ColorSchemes: v3.14.0 found
ColorSchemes: v3.15.0 found
ColorSchemes: v3.16.0 found
ColorSchemes: v3.17.0 found
ColorSchemes: v3.17.1 found
ColorSchemes: v3.18.0 found
ColorSchemes: v3.19.0 found
ColorSchemes: v3.20.0 found
ColorSchemes: v3.21.0 found
ColorSchemes: v3.22.0 found
ColorSchemes: v3.23.0 found
ColorSchemes: v3.24.0 found
ColorSchemes: v3.25.0 found
ColorSchemes: v3.26.0 found
ColorSchemes: v3.27.0 found
ColorSchemes: v3.27.1 found
ColorSchemes: v3.28.0 found
ColorSchemes: v3.29.0 found
ColorSchemes: v3.30.0 found
ColorSchemes: v3.31.0 found
```