### PR TITLE
[ClimaOcean] Cap compatibility with Thermodynamics@0.15.{0-2}

### DIFF
--- a/C/ClimaOcean/Compat.toml
+++ b/C/ClimaOcean/Compat.toml
@@ -208,7 +208,7 @@ Glob = "1"
 
 ["0.8.6 - 0.8.7"]
 MeshArrays = "0.3"
-Thermodynamics = "0.15"
+Thermodynamics = "0.15 - 0.15.2"
 
 ["0.8.7"]
 Oceananigans = "0.100.4 - 0.100"


### PR DESCRIPTION
[Thermodynamics v0.15.3](https://github.com/CliMA/Thermodynamics.jl/releases/tag/v0.15.3) changed fields of a struct used by ClimaOcean, thus causing precompile-time error in the latter: https://github.com/CliMA/Thermodynamics.jl/issues/301.  Breakage was also acknowledged in https://github.com/CliMA/Thermodynamics.jl/pull/293#issue-3779536086.