### PR TITLE
Change repo URL for the RecurrenceMicrostatesAnalysis.jl package, after repo transfer

### DIFF
--- a/R/RecurrenceMicrostatesAnalysis/Package.toml
+++ b/R/RecurrenceMicrostatesAnalysis/Package.toml
@@ -1,3 +1,3 @@
 name = "RecurrenceMicrostatesAnalysis"
 uuid = "cb83a08b-85c6-4e94-91aa-4e946c7d4f0c"
-repo = "https://github.com/DynamicsUFPR/RecurrenceMicrostatesAnalysis.jl.git"
+repo = "https://github.com/JuliaDynamics/RecurrenceMicrostatesAnalysis.jl.git"


### PR DESCRIPTION
Repo transferred today to JuliaDynamics, changing this for long-term safety.