### PR TITLE
Update the repo URL for the SindbadTEM.jl package: specifically, add the `.jl` in the URL

### DIFF
--- a/S/SindbadTEM/Package.toml
+++ b/S/SindbadTEM/Package.toml
@@ -1,4 +1,4 @@
 name = "SindbadTEM"
 uuid = "6686e6de-2010-4bf8-9178-b2bcc470766e"
-repo = "https://github.com/LandEcosystems/Sindbad.git"
+repo = "https://github.com/LandEcosystems/Sindbad.jl.git"
 subdir = "SindbadTEM"


### PR DESCRIPTION
While trying to register a new version of this package (which lives in a monorepo) I keep getting 

```
Error while trying to register: Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.
```

then I noticed that the outer package/project has the correct url (note the .`jl`)

```
name = "Sindbad"
uuid = "36c3e672-7dee-4606-99b5-7e5d8d85a313"
repo = "https://github.com/LandEcosystems/Sindbad.jl.git"
```

but `SindbadTEM` is missing the `.jl`, that might explain the error. Please advise / confirm.

https://github.com/LandEcosystems/Sindbad.jl/commit/ae01281d7eb71841a1d55a7dbdaea64f59c5e875