### PR TITLE
Change repo URL for the OMOPVocabMapper.jl package, after repo transfer to JuliaHealth org 

### DIFF
--- a/O/OMOPVocabMapper/Package.toml
+++ b/O/OMOPVocabMapper/Package.toml
@@ -1,3 +1,3 @@
 name = "OMOPVocabMapper"
 uuid = "fc9e345c-e35d-43ed-87a7-513e2d0ff273"
-repo = "https://github.com/bcbi/OMOPVocabMapper.jl.git"
+repo = "https://github.com/JuliaHealth/OMOPVocabMapper.jl.git"


### PR DESCRIPTION
This PR updates the repository URL in the Julia General Registry for **OMOPVocabMapper.jl** @giordano.

The package is now maintained under the **JuliaHealth** organization, but the registry entry still points to the old repository URL. While GitHub redirects currently work, keeping registry metadata aligned with the canonical repository helps avoid confusion and prevents potential issues.

This update was identified as part of an ecosystem-wide audit conducted under a NumFOCUS Small Development Grant for JuliaHealth.

CC: @DilumAluthge @Mounika-Thakkallapally
