### PR TITLE
 Update repo URL for the BlindingIndex.jl package, after transfer to JuliaHealth org

### DIFF
--- a/B/BlindingIndex/Package.toml
+++ b/B/BlindingIndex/Package.toml
@@ -1,3 +1,3 @@
 name = "BlindingIndex"
 uuid = "67be77aa-8e15-4dcd-9068-de5e3adff985"
-repo = "https://codeberg.org/AdamWysokinski/BlindingIndex.jl"
+repo = "https://github.com/JuliaHealth/BlindingIndex.jl.git"


### PR DESCRIPTION
This PR updates the repository URL in the Julia General Registry for **BlindingIndex.jl** @giordano.

The package is now maintained under the **JuliaHealth** organization, but the registry entry still points to the codeberg URL

This update was identified as part of an ecosystem-wide audit conducted under a NumFOCUS Small Development Grant for JuliaHealth.

CC: @AdamWysokinski 
