### PR TITLE
SpeedyWeather: Add subdir to Package.toml

### DIFF
--- a/S/SpeedyWeather/Package.toml
+++ b/S/SpeedyWeather/Package.toml
@@ -1,3 +1,4 @@
 name = "SpeedyWeather"
 uuid = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 repo = "https://github.com/SpeedyWeather/SpeedyWeather.jl.git"
+subdir = "SpeedyWeather"


### PR DESCRIPTION
SpeedyWeather's monorepo structure has changed in favour of a subdirectory. `subdir` added following https://github.com/JuliaRegistries/General/pull/145437