### PR TITLE
Metadata: Deprecate StatPlots (singular) in favor of StatsPlots (plural)

### DIFF
--- a/S/StatPlots/Package.toml
+++ b/S/StatPlots/Package.toml
@@ -1,3 +1,7 @@
 name = "StatPlots"
 uuid = "60ddc479-9b66-56df-82fc-76a74619b69c"
 repo = "https://github.com/JuliaPlots/StatsPlots.jl.git"
+
+[metadata.deprecated]
+reason = "StatPlots (singular) is deprecated in favor of StatsPlots (plural)"
+alternative = "StatsPlots"


### PR DESCRIPTION
Follow-up to #39292

See also: https://github.com/JuliaPlots/Plots.jl/issues/5518