### PR TITLE
Update repo URL for the DICOMTree.jl package, after transfer to JuliaHealth org

### DIFF
--- a/D/DICOMTree/Package.toml
+++ b/D/DICOMTree/Package.toml
@@ -1,3 +1,3 @@
 name = "DICOMTree"
 uuid = "c4d2416d-3439-49b0-a3b3-18bf95df003e"
-repo = "https://github.com/fdekerme/DICOMTree.jl.git"
+repo = "https://github.com/JuliaHealth/DICOMTree.jl.git"


### PR DESCRIPTION


This PR updates the repository URL in the Julia General Registry for DICOMTree.jl @giordano.

The package is now maintained under the JuliaHealth organization, but the registry entry still points to the old repository URL. While GitHub redirects currently work, keeping registry metadata aligned with the canonical repository helps avoid confusion and prevents potential issues.

This update was identified as part of an ecosystem-wide audit conducted under a NumFOCUS Small Development Grant for JuliaHealth.

CC: @fdekerme
