### PR TITLE
JuliaFormatter: Yank versions 2.2.1 and 2.2.2

### DIFF
--- a/J/JuliaFormatter/Versions.toml
+++ b/J/JuliaFormatter/Versions.toml
@@ -751,9 +751,11 @@ git-tree-sha1 = "ca9470360f51697fc1bde747760b2d99936619ea"
 
 ["2.2.1"]
 git-tree-sha1 = "eeb150b63d8bfdca04a0c367a8b95d3863fdc892"
+yanked = true
 
 ["2.2.2"]
 git-tree-sha1 = "4e0b0331ba052e486b868ef910af273c99aa327d"
+yanked = true
 
 ["2.3.0"]
 git-tree-sha1 = "ec5e99ad66c51b6fcd3dbab6655b17118a29a588"


### PR DESCRIPTION
Mark versions 2.2.1 and 2.2.2 as yanked in Versions.toml.

These two releases break precommit CI