### PR TITLE
Update Powsybl package github URL

### DIFF
--- a/P/Powsybl/Package.toml
+++ b/P/Powsybl/Package.toml
@@ -1,3 +1,3 @@
 name = "Powsybl"
 uuid = "cc5d7637-2d3a-48eb-b6d4-9415154f8200"
-repo = "https://github.com/powsybl/Powsybl.jl.git"
+repo = "https://github.com/powsybl/powsybl.jl.git"


### PR DESCRIPTION
Update the Powsybl package github URL. 
Just remove the upper case P and replace it by a lower case. This is blocking the registrator bot who is detecting an URL change.