### PR TITLE
Update repository URL in for KiteViewers.jl (moved to org)

### DIFF
--- a/K/KiteViewers/Package.toml
+++ b/K/KiteViewers/Package.toml
@@ -1,3 +1,3 @@
 name = "KiteViewers"
 uuid = "2e593061-95e7-45e4-95f4-df0491f2e601"
-repo = "https://github.com/aenarete/KiteViewers.jl.git"
+repo = "https://github.com/OpenSourceAWE/KiteViewers.jl.git"


### PR DESCRIPTION
I moved the package to our new organisation OpenSourceAWE, see: https://github.com/[OpenSourceAWE](https://github.com/OpenSourceAWE)