### PR TITLE
ScratchSpaceGargbageCollctor: Fix incorrect UUID

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -2231,6 +2231,7 @@ some amount of consideration when choosing package names.
 2b14c160-480b-11ea-1b58-656063328ff7 = { name = "ImageEdgeDetection", path = "I/ImageEdgeDetection" }
 2b19380a-1f7e-4d7d-b1b8-8aa60b3321c9 = { name = "Wannier", path = "W/Wannier" }
 2b1cd6f4-158b-5933-849b-48df756daf9e = { name = "TenPuzzle", path = "T/TenPuzzle" }
+2b218182-314f-4389-a4eb-69d351d2272a = { name = "ScratchSpaceGarbageCollector", path = "S/ScratchSpaceGarbageCollector" }
 2b23ba43-8213-43cb-b5ea-38c12b45bd45 = { name = "HerbCore", path = "H/HerbCore" }
 2b2c4be0-e38c-5918-b8b4-9a308845a1e9 = { name = "Extrae_jll", path = "jll/E/Extrae_jll" }
 2b3700d1-4306-52e2-a478-c162f0c514be = { name = "aws_c_auth_jll", path = "jll/A/aws_c_auth_jll" }
@@ -6005,7 +6006,6 @@ some amount of consideration when choosing package names.
 732b1220-b3b1-47df-92b9-9aafce73c71b = { name = "LightenQP", path = "L/LightenQP" }
 732b9ffd-ba4a-45cb-82b2-a390f71ea5ac = { name = "CompatDevTools", path = "C/CompatDevTools" }
 7332bcdc-bd2a-5999-b4fe-680b85f40771 = { name = "tree_sitter_bash_jll", path = "jll/T/tree_sitter_bash_jll" }
-73336863-5434-7263-5370-556e61336c43 = { name = "ScratchSpaceGarbageCollector", path = "S/ScratchSpaceGarbageCollector" }
 733f0b2a-2dd6-45a4-80ec-bf2267f2a32d = { name = "MosaikAPIv3", path = "M/MosaikAPIv3" }
 734052d1-fea3-4ffe-af92-b9cc64c3051c = { name = "BranchTests", path = "B/BranchTests" }
 73480bc8-48a2-41cc-880f-208b490ccf65 = { name = "RationalFunctionFields", path = "R/RationalFunctionFields" }

--- a/S/ScratchSpaceGarbageCollector/Package.toml
+++ b/S/ScratchSpaceGarbageCollector/Package.toml
@@ -1,4 +1,4 @@
 name = "ScratchSpaceGarbageCollector"
-uuid = "73336863-5434-7263-5370-556e61336c43"
+uuid = "2b218182-314f-4389-a4eb-69d351d2272a"
 repo = "https://github.com/JuliaPackaging/BinaryBuilder2.jl.git"
 subdir = "ScratchSpaceGarbageCollector.jl"


### PR DESCRIPTION
I accidentally hit "merge" on the registration PR [0] despite AutoMerge (staging) noting that the UUID was malformed.  I fixed it in the upstream package [1] but I guess I accidentally hit merge on the PR without updating the registator PR.

[0] https://github.com/JuliaRegistries/General/pull/147864
[1] https://github.com/JuliaPackaging/BinaryBuilder2.jl/commit/a52b710ba1e5ec65537066b89e2ece98895600c8