### PR TITLE
Yank NonlinearSolve@4.15.1 and NonlinearSolveFirstOrder@1.12.0

### DIFF
--- a/N/NonlinearSolve/Versions.toml
+++ b/N/NonlinearSolve/Versions.toml
@@ -332,3 +332,4 @@ git-tree-sha1 = "da41d5cd90c1118f5a8914392cf561263a1d09cb"
 
 ["4.15.1"]
 git-tree-sha1 = "20ce4aa44c07d7a7cb6138fefa7e8d4b3b967214"
+yanked = true

--- a/N/NonlinearSolveFirstOrder/Versions.toml
+++ b/N/NonlinearSolveFirstOrder/Versions.toml
@@ -42,3 +42,4 @@ git-tree-sha1 = "df31d105d8e7254447256a44606f2a7e98b61aba"
 
 ["1.12.0"]
 git-tree-sha1 = "b85f479b7fd9964cb911b2e9c99b42c8d834fd61"
+yanked = true


### PR DESCRIPTION
NonlinearSolveFirstOrder@1.12.0 breaks NonlinearSolve < 4.15.1, however, reverting the change in NonlinearSolveFirstOrder@1.12.0 (methods moved from NonlinearSolve to NonlinearSolveFirstOrder) would break NonlinearSolve@4.15.1. Hence, I propose to yank both releases.

Ref https://github.com/SciML/NonlinearSolve.jl/issues/820
Ref https://github.com/SciML/NonlinearSolve.jl/issues/821