### PR TITLE
Update MacroEconometricModels repo URL: chung9207 → FriedmanJP

### DIFF
--- a/M/MacroEconometricModels/Package.toml
+++ b/M/MacroEconometricModels/Package.toml
@@ -1,3 +1,3 @@
 name = "MacroEconometricModels"
 uuid = "14a6ec33-bcac-448e-845f-2fb6769698f1"
-repo = "https://github.com/chung9207/MacroEconometricModels.jl.git"
+repo = "https://github.com/FriedmanJP/MacroEconometricModels.jl.git"


### PR DESCRIPTION
Update repository URL for MacroEconometricModels.jl following GitHub transfer to org.

- **Old URL**: `https://github.com/chung9207/MacroEconometricModels.jl.git`
- **New URL**: `https://github.com/FriedmanJP/MacroEconometricModels.jl.git`
- **UUID**: `14a6ec33-bcac-448e-845f-2fb6769698f1`

The package was tranferred from `chung9207` to `FriedmanJP` (org).