### PR TITLE
Yank OrdinaryDiffEqNonlinearSolve versions >= 1.20.0

### DIFF
--- a/O/OrdinaryDiffEqNonlinearSolve/Versions.toml
+++ b/O/OrdinaryDiffEqNonlinearSolve/Versions.toml
@@ -84,9 +84,12 @@ git-tree-sha1 = "9f0be4bd586829a28a04c8f923598497f56ac226"
 
 ["1.20.0"]
 git-tree-sha1 = "c2a64b20ab8c6c3d0155b146b02dbc79182d5f09"
+yanked = true
 
 ["1.21.0"]
 git-tree-sha1 = "7c575c5b9783e8c9f070540221cb886d3b306fda"
+yanked = true
 
 ["1.22.0"]
 git-tree-sha1 = "8e567ef5a76928e39912204062c7055743c2a7bc"
+yanked = true


### PR DESCRIPTION
Yank versions 1.20.0, 1.21.0, and 1.22.0. Reference: https://github.com/SciML/OrdinaryDiffEq.jl/commit/3c537ef6ecf3b18033f9abce2515cd9b73a5ecac