### PR TITLE
Move the naming guidelines into this repo (from the Pkg docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ You can register your package!
 See [Registering a package in General](https://github.com/JuliaRegistries/General#registering-a-package-in-general) in the README for how to do that.
 The "FAQ" section in the README helps answer many more questions, like [do I need to register a package to install it?](https://github.com/JuliaRegistries/General#do-i-need-to-register-a-package-to-install-it), [should I register my package?](https://github.com/JuliaRegistries/General#should-i-register-my-package), and more.
 
-* Please be aware of the [package naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules)
+* Please be aware of the [package naming guidelines][naming-guidelines]
 * We strongly encourage authors to follow best practices like having documentation (or a descriptive README), tests, and continuous integration.
 
 ## As a Julia community member
@@ -50,7 +50,7 @@ Any comment without `[noblock]` included in it will block AutoMerge from automat
     Since registration is a mechanism to share code with the whole Julia community, such a description is important for the package to be useful.
     While we don't strictly require such documentation, it can help to give a polite and gentle nudge in the PR comments, or show folks how to write documentation and/or what is helpful to include in a README.
     We want to encourage best practices (in an inclusive and friendly way!) even when they are not strict requirements.
-    * Sometimes package names are possibly confusing or don't conform to our [naming guidelines](naming-guidelines), but AutoMerge does not detect this.
+    * Sometimes package names are possibly confusing or don't conform to our [naming guidelines][naming-guidelines], but AutoMerge does not detect this.
     Feel free to comment, describing what you think is confusing or non-compliant about the current name, and any suggestions you have for a more clear name.
 
 ### Other PRs to General
@@ -166,6 +166,6 @@ check_package_versions("FastParzenWindows", ".")
 ```
 
 [FAQ]: https://github.com/JuliaRegistries/General#faq]
-[naming-guidelines]: https://pkgdocs.julialang.org/dev/creating-packages/#Package-naming-guidelines-1
+[naming-guidelines]: ./NAMING_GUIDELINES.md
 [permissions]: https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization
 [RegistryCI]: https://github.com/JuliaRegistries/RegistryCI.jl/

--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -38,7 +38,7 @@ Since the `General` registry belongs to the entire community, people may have op
 7. <a id="rule-avoid-close-names" href="#rule-avoid-close-names">§</a> Avoid naming a package closely to an existing package.
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `ConcurrentWebsockets` that is descriptive of what distinguishes the package.
 
-8. <a id="rule-avoid-unrelated-project-names" href="rule-avoid-unrelated-project-names">§</a> Avoid using a distinctive name that is already in use in a well-known, unrelated project.
+8. <a id="rule-avoid-unrelated-project-names" href="#rule-avoid-unrelated-project-names">§</a> Avoid using a distinctive name that is already in use in a well-known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc., for a package that is unrelated to the popular `tkinter` Python package, even if it provides bindings to Tcl/Tk. A package name of `Tkinter.jl` would only be appropriate if the package used Python's library to accomplish its work or was spearheaded by the same community of developers.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular Rust crate `http` because, in most usages, the name "http" refers to the hypertext transfer protocol, not to the `http` rust crate.
      * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL library, even without explicit affiliation with the creators of the OpenSSL (provided there's no copyright or trademark infringement, etc.)

--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -48,7 +48,7 @@ may fit your package better.
      * `LibABC`
 
 7. Avoid naming a package closely to an existing package
-     * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `SimpleWebsockets`.
+     * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `ConcurrentWebsockets` that is descriptive of what distinguishes the package.
 
 8. Avoid using a distinctive name that is already in use in a well known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated

--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -1,71 +1,57 @@
-# Package naming guidelines
+# Package Naming Guidelines
 
-Package names should be sensible to most Julia users, *even to those who are not domain experts*.
-The following guidelines apply to the `General` registry but may be useful for other package
-registries as well.
+Package names should be sensible to most Julia users, *even to those who are not domain experts*. The following guidelines apply to the `General` registry but may be useful for other package registries as well.
 
-Since the `General` registry belongs to the entire community, people may have opinions about
-your package name when you publish it, especially if it's ambiguous or can be confused with
-something other than what it is. Usually, you will then get suggestions for a new name that
-may fit your package better.
+Since the `General` registry belongs to the entire community, people may have opinions about your package name when you publish it, especially if it's ambiguous or can be confused with something other than what it is. Usually, you will then get suggestions for a new name that may fit your package better.
 
-1. Avoid jargon. In particular, avoid acronyms unless there is minimal possibility of confusion.
+1. <a id="rule-avoid-jargon"></a>Avoid jargon. In particular, avoid acronyms unless there is minimal possibility of confusion.
 
-     * It's ok for package names to contain `DNA` if you're talking about the DNA, which has a universally agreed upon definition.
+     * It's okay for package names to contain `DNA` if you're talking about the DNA, which has a universally agreed-upon definition.
      * It's more difficult to justify package names containing the acronym `CI` for instance, which may mean continuous integration, confidence interval, etc.
-     * If there is risk of confusion it may be best to disambiguate an acronym with additional words such as a lab group or field.
-     * If your acronym is unambiguous, easily searchable, and/or unlikely to be confused across domains a good justification is often enough for approval.
-2. Avoid using `Julia` in your package name or prefixing it with `Ju`.
+     * If there is a risk of confusion, it may be best to disambiguate an acronym with additional words, such as a lab group or field.
+     * If your acronym is unambiguous, easily searchable, and/or unlikely to be confused across domains, a good justification is often enough for approval.
+
+2. <a id="rule-avoid-julia"></a>Avoid using `Julia` in your package name or prefixing it with `Ju`.
 
      * It is usually clear from context and to your users that the package is a Julia package.
      * Package names already have a `.jl` extension, which communicates to users that `Package.jl` is a Julia package.
-     * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors
-       to the Julia language itself.
-3. Packages that provide most of their functionality in association with a new type should have pluralized
-   names.
+     * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors to the Julia language itself.
+
+3. <a id="rule-pluralize"></a>Packages that provide most of their functionality in association with a new type should have pluralized names.
 
      * `DataFrames` provides the `DataFrame` type.
      * `BloomFilters` provides the `BloomFilter` type.
-     * In contrast, `JuliaParser` provides no new type, but instead new functionality in the `JuliaParser.parse()`
-       function.
-4. Err on the side of clarity, even if clarity seems long-winded to you.
+     * In contrast, `JuliaParser` provides no new type, but instead new functionality in the `JuliaParser.parse()` function.
+
+4. <a id="rule-clarity"></a>Err on the side of clarity, even if clarity seems long-winded to you.
 
      * `RandomMatrices` is a less ambiguous name than `RndMat` or `RMT`, even though the latter are shorter.
-     *  Generally package names should be at least 5 characters long not including the `.jl` extension
-5. A less systematic name may suit a package that implements one of several possible approaches to
-   its domain.
+     * Generally, package names should be at least 5 characters long, not including the `.jl` extension.
 
-     * Julia does not have a single comprehensive plotting package. Instead, `Gadfly`, `PyPlot`, `Winston`
-       and other packages each implement a unique approach based on a particular design philosophy.
-     * In contrast, `SortingAlgorithms` provides a consistent interface to use many well-established
-       sorting algorithms.
+5. <a id="rule-less-systematic"></a>A less systematic name may suit a package that implements one of several possible approaches to its domain.
 
-6. Packages that wrap external libraries or programs can be named after those libraries or programs. However, as of February 2026, we now request that these packages indicate in their package name (in some way) that they are wrapping an external library or program. For example, consider a hypothetical package that wraps a library or program named `ABC`. Possible names for the Julia package might include:
+     * Julia does not have a single comprehensive plotting package. Instead, `Gadfly`, `PyPlot`, `Winston`, and other packages each implement a unique approach based on a particular design philosophy.
+     * In contrast, `SortingAlgorithms` provides a consistent interface to use many well-established sorting algorithms.
+
+6. <a id="rule-wrappers"></a>Packages that wrap external libraries or programs can be named after those libraries or programs. However, as of February 2026, we now request that these packages indicate in their package name (in some way) that they are wrapping an external library or program. For example, consider a hypothetical package that wraps a library or program named `ABC`. Possible names for the Julia package might include:
      * `ABCWrapper`
      * `ABCInterface`
      * `ExternalABC`
      * `ABCLibrary`
      * `LibABC`
 
-7. Avoid naming a package closely to an existing package
+7. <a id="rule-avoid-close-names"></a>Avoid naming a package closely to an existing package.
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `ConcurrentWebsockets` that is descriptive of what distinguishes the package.
 
-8. Avoid using a distinctive name that is already in use in a well known, unrelated project.
-     * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
-       to the popular `tkinter` python package, even if it provides bindings to Tcl/Tk.
-       A package name of `Tkinter.jl` would only be appropriate if the package used Python's
-       library to accomplish its work or was spearheaded by the same community of developers.
-     * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
-       crate `http` because in most usages the name "http" refers to the hypertext transfer
-       protocol, not to the `http` rust crate.
-     * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL
-       library, even without explicit affiliation with the creators of the OpenSSL (provided
-       there's no copyright or trademark infringement etc.)
+8. <a id="rule-avoid-distinctive-names"></a>Avoid using a distinctive name that is already in use in a well-known, unrelated project.
+     * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc., for a package that is unrelated to the popular `tkinter` Python package, even if it provides bindings to Tcl/Tk. A package name of `Tkinter.jl` would only be appropriate if the package used Python's library to accomplish its work or was spearheaded by the same community of developers.
+     * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular Rust crate `http` because, in most usages, the name "http" refers to the hypertext transfer protocol, not to the `http` rust crate.
+     * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL library, even without explicit affiliation with the creators of the OpenSSL (provided there's no copyright or trademark infringement, etc.)
 
-9. Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
-     * The package name should begin with a capital letter and word separation is shown with upper camel case
-     * Only ASCII characters are allowed in a package name
-     * Packages that provide the functionality of a project from another language should use the Julia convention
-     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep their original name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages is handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system.
+9. <a id="rule-style"></a>Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
+     * The package name should begin with a capital letter, and word separation is shown with upper camel case.
+     * Only ASCII characters are allowed in a package name.
+     * Packages that provide the functionality of a project from another language should use the Julia convention.
+     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep their original name, but should get `_jll` as a suffix. For example, `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages is handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system.
 
-10. For the complete list of rules for automatic merging into the General registry, see [the AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+10. <a id="rule-see-automerge"></a>For the complete list of rules for automatic merging into the General registry, see [the AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).

--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -4,54 +4,49 @@ Package names should be sensible to most Julia users, *even to those who are not
 
 Since the `General` registry belongs to the entire community, people may have opinions about your package name when you publish it, especially if it's ambiguous or can be confused with something other than what it is. Usually, you will then get suggestions for a new name that may fit your package better.
 
-1. <a id="rule-avoid-jargon"></a>Avoid jargon. In particular, avoid acronyms unless there is minimal possibility of confusion.
-
+1. <a id="rule-avoid-jargon" href="#rule-avoid-jargon">§</a> Avoid jargon. In particular, avoid acronyms unless there is minimal possibility of confusion.
      * It's okay for package names to contain `DNA` if you're talking about the DNA, which has a universally agreed-upon definition.
      * It's more difficult to justify package names containing the acronym `CI` for instance, which may mean continuous integration, confidence interval, etc.
      * If there is a risk of confusion, it may be best to disambiguate an acronym with additional words, such as a lab group or field.
      * If your acronym is unambiguous, easily searchable, and/or unlikely to be confused across domains, a good justification is often enough for approval.
 
-2. <a id="rule-avoid-julia"></a>Avoid using `Julia` in your package name or prefixing it with `Ju`.
-
+2. <a id="rule-avoid-julia" href="#rule-avoid-julia">§</a> Avoid using `Julia` in your package name or prefixing it with `Ju`.
      * It is usually clear from context and to your users that the package is a Julia package.
      * Package names already have a `.jl` extension, which communicates to users that `Package.jl` is a Julia package.
      * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors to the Julia language itself.
 
-3. <a id="rule-pluralize"></a>Packages that provide most of their functionality in association with a new type should have pluralized names.
-
+3. <a id="rule-pluralize" href="#rule-pluralize">§</a> Packages that provide most of their functionality in association with a new type should have pluralized names.
      * `DataFrames` provides the `DataFrame` type.
      * `BloomFilters` provides the `BloomFilter` type.
      * In contrast, `JuliaParser` provides no new type, but instead new functionality in the `JuliaParser.parse()` function.
 
-4. <a id="rule-clarity"></a>Err on the side of clarity, even if clarity seems long-winded to you.
-
+4. <a id="rule-clarity" href="#rule-clarity">§</a> Err on the side of clarity, even if clarity seems long-winded to you.
      * `RandomMatrices` is a less ambiguous name than `RndMat` or `RMT`, even though the latter are shorter.
      * Generally, package names should be at least 5 characters long, not including the `.jl` extension.
 
-5. <a id="rule-less-systematic"></a>A less systematic name may suit a package that implements one of several possible approaches to its domain.
-
+5. <a id="rule-less-systematic" href="#rule-less-systematic">§</a> A less systematic name may suit a package that implements one of several possible approaches to its domain.
      * Julia does not have a single comprehensive plotting package. Instead, `Gadfly`, `PyPlot`, `Winston`, and other packages each implement a unique approach based on a particular design philosophy.
      * In contrast, `SortingAlgorithms` provides a consistent interface to use many well-established sorting algorithms.
 
-6. <a id="rule-wrappers"></a>Packages that wrap external libraries or programs can be named after those libraries or programs. However, as of February 2026, we now request that these packages indicate in their package name (in some way) that they are wrapping an external library or program. For example, consider a hypothetical package that wraps a library or program named `ABC`. Possible names for the Julia package might include:
+6. <a id="rule-wrappers" href="#rule-wrappers">§</a> Packages that wrap external libraries or programs can be named after those libraries or programs. However, as of February 2026, we now request that these packages indicate in their package name (in some way) that they are wrapping an external library or program. For example, consider a hypothetical package that wraps a library or program named `ABC`. Possible names for the Julia package might include:
      * `ABCWrapper`
      * `ABCInterface`
      * `ExternalABC`
      * `ABCLibrary`
      * `LibABC`
 
-7. <a id="rule-avoid-close-names"></a>Avoid naming a package closely to an existing package.
+7. <a id="rule-avoid-close-names" href="#rule-avoid-close-names">§</a> Avoid naming a package closely to an existing package.
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `ConcurrentWebsockets` that is descriptive of what distinguishes the package.
 
-8. <a id="rule-avoid-distinctive-names"></a>Avoid using a distinctive name that is already in use in a well-known, unrelated project.
+8. <a id="rule-avoid-distinctive-names" href="#rule-avoid-distinctive-names">§</a> Avoid using a distinctive name that is already in use in a well-known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc., for a package that is unrelated to the popular `tkinter` Python package, even if it provides bindings to Tcl/Tk. A package name of `Tkinter.jl` would only be appropriate if the package used Python's library to accomplish its work or was spearheaded by the same community of developers.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular Rust crate `http` because, in most usages, the name "http" refers to the hypertext transfer protocol, not to the `http` rust crate.
      * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL library, even without explicit affiliation with the creators of the OpenSSL (provided there's no copyright or trademark infringement, etc.)
 
-9. <a id="rule-style"></a>Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
+9. <a id="rule-style" href="#rule-style">§</a> Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
      * The package name should begin with a capital letter, and word separation is shown with upper camel case.
      * Only ASCII characters are allowed in a package name.
      * Packages that provide the functionality of a project from another language should use the Julia convention.
      * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep their original name, but should get `_jll` as a suffix. For example, `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages is handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system.
 
-10. <a id="rule-see-automerge"></a>For the complete list of rules for automatic merging into the General registry, see [the AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).
+10. <a id="rule-see-automerge" href="#rule-see-automerge">§</a> For the complete list of rules for automatic merging into the General registry, see [the AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).

--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -38,12 +38,12 @@ Since the `General` registry belongs to the entire community, people may have op
 7. <a id="rule-avoid-close-names" href="#rule-avoid-close-names">§</a> Avoid naming a package closely to an existing package.
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `ConcurrentWebsockets` that is descriptive of what distinguishes the package.
 
-8. <a id="rule-avoid-distinctive-names" href="#rule-avoid-distinctive-names">§</a> Avoid using a distinctive name that is already in use in a well-known, unrelated project.
+8. <a id="rule-avoid-unrelated-project-names" href="rule-avoid-unrelated-project-names">§</a> Avoid using a distinctive name that is already in use in a well-known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc., for a package that is unrelated to the popular `tkinter` Python package, even if it provides bindings to Tcl/Tk. A package name of `Tkinter.jl` would only be appropriate if the package used Python's library to accomplish its work or was spearheaded by the same community of developers.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular Rust crate `http` because, in most usages, the name "http" refers to the hypertext transfer protocol, not to the `http` rust crate.
      * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL library, even without explicit affiliation with the creators of the OpenSSL (provided there's no copyright or trademark infringement, etc.)
 
-9. <a id="rule-style" href="#rule-style">§</a> Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
+9. <a id="rule-stylistic-conventions" href="#rule-stylistic-conventions">§</a> Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
      * The package name should begin with a capital letter, and word separation is shown with upper camel case.
      * Only ASCII characters are allowed in a package name.
      * Packages that provide the functionality of a project from another language should use the Julia convention.

--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -1,0 +1,71 @@
+# Package naming guidelines
+
+Package names should be sensible to most Julia users, *even to those who are not domain experts*.
+The following guidelines apply to the `General` registry but may be useful for other package
+registries as well.
+
+Since the `General` registry belongs to the entire community, people may have opinions about
+your package name when you publish it, especially if it's ambiguous or can be confused with
+something other than what it is. Usually, you will then get suggestions for a new name that
+may fit your package better.
+
+1. Avoid jargon. In particular, avoid acronyms unless there is minimal possibility of confusion.
+
+     * It's ok for package names to contain `DNA` if you're talking about the DNA, which has a universally agreed upon definition.
+     * It's more difficult to justify package names containing the acronym `CI` for instance, which may mean continuous integration, confidence interval, etc.
+     * If there is risk of confusion it may be best to disambiguate an acronym with additional words such as a lab group or field.
+     * If your acronym is unambiguous, easily searchable, and/or unlikely to be confused across domains a good justification is often enough for approval.
+2. Avoid using `Julia` in your package name or prefixing it with `Ju`.
+
+     * It is usually clear from context and to your users that the package is a Julia package.
+     * Package names already have a `.jl` extension, which communicates to users that `Package.jl` is a Julia package.
+     * Having Julia in the name can imply that the package is connected to, or endorsed by, contributors
+       to the Julia language itself.
+3. Packages that provide most of their functionality in association with a new type should have pluralized
+   names.
+
+     * `DataFrames` provides the `DataFrame` type.
+     * `BloomFilters` provides the `BloomFilter` type.
+     * In contrast, `JuliaParser` provides no new type, but instead new functionality in the `JuliaParser.parse()`
+       function.
+4. Err on the side of clarity, even if clarity seems long-winded to you.
+
+     * `RandomMatrices` is a less ambiguous name than `RndMat` or `RMT`, even though the latter are shorter.
+     *  Generally package names should be at least 5 characters long not including the `.jl` extension
+5. A less systematic name may suit a package that implements one of several possible approaches to
+   its domain.
+
+     * Julia does not have a single comprehensive plotting package. Instead, `Gadfly`, `PyPlot`, `Winston`
+       and other packages each implement a unique approach based on a particular design philosophy.
+     * In contrast, `SortingAlgorithms` provides a consistent interface to use many well-established
+       sorting algorithms.
+
+6. Packages that wrap external libraries or programs can be named after those libraries or programs. However, as of February 2026, we now request that these packages indicate in their package name (in some way) that they are wrapping an external library or program. For example, consider a hypothetical package that wraps a library or program named `ABC`. Possible names for the Julia package might include:
+     * `ABCWrapper`
+     * `ABCInterface`
+     * `ExternalABC`
+     * `ABCLibrary`
+     * `LibABC`
+
+7. Avoid naming a package closely to an existing package
+     * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `SimpleWebsockets`.
+
+8. Avoid using a distinctive name that is already in use in a well known, unrelated project.
+     * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
+       to the popular `tkinter` python package, even if it provides bindings to Tcl/Tk.
+       A package name of `Tkinter.jl` would only be appropriate if the package used Python's
+       library to accomplish its work or was spearheaded by the same community of developers.
+     * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
+       crate `http` because in most usages the name "http" refers to the hypertext transfer
+       protocol, not to the `http` rust crate.
+     * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL
+       library, even without explicit affiliation with the creators of the OpenSSL (provided
+       there's no copyright or trademark infringement etc.)
+
+9. Packages should follow the [Stylistic Conventions](https://docs.julialang.org/en/v1/manual/variables/#Stylistic-Conventions).
+     * The package name should begin with a capital letter and word separation is shown with upper camel case
+     * Only ASCII characters are allowed in a package name
+     * Packages that provide the functionality of a project from another language should use the Julia convention
+     * Packages that [provide pre-built libraries and executables](https://docs.binarybuilder.org/stable/jll/) can keep their original name, but should get `_jll`as a suffix. For example `pandoc_jll` wraps pandoc. However, note that the generation and release of most JLL packages is handled by the [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil) system.
+
+10. For the complete list of rules for automatic merging into the General registry, see [the AutoMerge guidelines](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dependencies and compatibility constraints.
 The General registry is open for everyone to use and provides access to a large ecosystem
 of packages.
 
-If you are registering a new package, please make sure that you have read the [package naming rules](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules).
+If you are registering a new package, please make sure that you have read the [package naming rules][naming-guidelines].
 
 Follow along new package registrations with the `#new-packages-feed` channels in the
 [community Slack](https://julialang.org/slack/) or [Zulip](https://julialang.zulipchat.com/register/)!
@@ -338,7 +338,7 @@ legal to use together, such as GPL2 with Apache2.
 New packages must typically wait for the 3 day timer to expire before they are merged, either automatically by the bot or manually.
 This waiting period allows time for community comment and review, and to provide time to check things like:
 
-- the name is appropriate (e.g. "safe for work", not typosquatting, and fitting with the [Pkg naming guidelines](https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-guidelines))
+- the name is appropriate (e.g. "safe for work", not typosquatting, and fitting with the [Pkg naming guidelines][naming-guidelines])
 - the package is functional and non-empty
 - the code is not malicious (e.g. exploiting security vulnerabilities)
 - there is some form of README or documentation to enable users to use the package
@@ -411,7 +411,7 @@ not a curated list of Julia packages. In particular this means that:
 [registrator-web]: https://github.com/JuliaRegistries/Registrator.jl#via-the-web-interface
 [registrator-readme]: https://github.com/JuliaRegistries/Registrator.jl/blob/master/README.md
 [tagbot]: https://github.com/JuliaRegistries/TagBot
-[naming-guidelines]: https://pkgdocs.julialang.org/v1/creating-packages/#Package-naming-rules
+[naming-guidelines]: ./NAMING_GUIDELINES.md
 [automerge-guidelines]: https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/
 [registryci]: https://github.com/JuliaRegistries/RegistryCI.jl
 [github-rename]: https://help.github.com/en/github/administering-a-repository/renaming-a-repository


### PR DESCRIPTION
Here's the corresponding PR to remove the naming guidelines from the Pkg docs. See that PR for the motivation.
- [x] https://github.com/JuliaLang/Pkg.jl/pull/4626