### PR TITLE
change URL for FastChebInterp to JuliaMath

### DIFF
--- a/F/FastChebInterp/Package.toml
+++ b/F/FastChebInterp/Package.toml
@@ -1,3 +1,3 @@
 name = "FastChebInterp"
 uuid = "cf66c380-9a80-432c-aff8-4f9c79c0bdde"
-repo = "https://github.com/stevengj/FastChebInterp.jl.git"
+repo = "https://github.com/JuliaMath/FastChebInterp.jl.git"


### PR DESCRIPTION
The repo was moved to the JuliaMath org: https://github.com/JuliaMath/FastChebInterp.jl