### PR TITLE
DynamicalCorrelators: Update repository URL in Package.toml

### DIFF
--- a/D/DynamicalCorrelators/Package.toml
+++ b/D/DynamicalCorrelators/Package.toml
@@ -1,3 +1,3 @@
 name = "DynamicalCorrelators"
 uuid = "7abe38c7-550a-49b0-ba99-33d1b5164ede"
-repo = "https://github.com/ZongYongyue/DynamicalCorrelators.jl.git"
+repo = "https://github.com/Quantum-Many-Body/DynamicalCorrelators.jl.git"


### PR DESCRIPTION
Update repo URL for DynamicalCorrelators: moved to Quantum-Many-Body organization
