### PR TITLE
Yank QRacahSymbols v1.0.0

### DIFF
--- a/Q/QRacahSymbols/Versions.toml
+++ b/Q/QRacahSymbols/Versions.toml
@@ -1,2 +1,3 @@
 ["1.0.0"]
 git-tree-sha1 = "bb1eb19631a30ea5d82807db7fdcc97d8f3c8010"
+yanked = true


### PR DESCRIPTION
See https://github.com/JuliaRegistries/General/pull/150218

Since the `v1.0.0` release has already made it to the package servers, we can no longer revert. The result of a discussion on Slack was that yanking was the best course of action.