### PR TITLE
Yank Bioinformatics v0.1.0

### DIFF
--- a/B/Bioinformatics/Versions.toml
+++ b/B/Bioinformatics/Versions.toml
@@ -1,5 +1,6 @@
 ["0.1.0"]
 git-tree-sha1 = "6b879cd7f84a18d845ba6dbebaa7df6e4dd8e440"
+yanked = true
 
 ["0.1.1"]
 git-tree-sha1 = "6f4646f277261658185f474e6e826cad14301b2a"


### PR DESCRIPTION
This git tree sha is not in either https://github.com/mrtkp9993/Bioinformatics.jl or https://github.com/UnofficialJuliaMirrorSnapshots/Bioinformatics.jl-c429c406-9079-5a14-8339-dedc8835de90 or in the public storage servers, so it's not installable in any case.