### PR TITLE
Yank JumpProcesses 9.23.2

### DIFF
--- a/J/JumpProcesses/Versions.toml
+++ b/J/JumpProcesses/Versions.toml
@@ -186,3 +186,4 @@ git-tree-sha1 = "310fc6ddd46db8946f988b142fc2821f2f6456ff"
 
 ["9.23.2"]
 git-tree-sha1 = "1d9e36e530080a9f097de67c2576c3f83d418dd0"
+yanked = true


### PR DESCRIPTION
This should not have been released as it contains breaking changes for v10.0 that are not completed yet.