### PR TITLE
Update repo URLs for DiffEqBase, DelayDiffEq, StochasticDiffEq

### DIFF
--- a/D/DelayDiffEq/Package.toml
+++ b/D/DelayDiffEq/Package.toml
@@ -1,3 +1,4 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
-repo = "https://github.com/SciML/DelayDiffEq.jl.git"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
+subdir = "lib/DelayDiffEq"

--- a/D/DiffEqBase/Package.toml
+++ b/D/DiffEqBase/Package.toml
@@ -1,3 +1,4 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-repo = "https://github.com/SciML/DiffEqBase.jl.git"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
+subdir = "lib/DiffEqBase"

--- a/S/StochasticDiffEq/Package.toml
+++ b/S/StochasticDiffEq/Package.toml
@@ -1,3 +1,4 @@
 name = "StochasticDiffEq"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-repo = "https://github.com/SciML/StochasticDiffEq.jl.git"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
+subdir = "lib/StochasticDiffEq"


### PR DESCRIPTION
These packages have been moved into the [SciML/OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo (see SciML/OrdinaryDiffEq.jl#3234, SciML/OrdinaryDiffEq.jl#3235).

Updates `Package.toml` for:
- **DiffEqBase** — `JuliaDiffEq/DiffEqBase.jl` → `SciML/OrdinaryDiffEq.jl` (subdir `lib/DiffEqBase`)
- **DelayDiffEq** — `JuliaDiffEq/DelayDiffEq.jl` → `SciML/OrdinaryDiffEq.jl` (subdir `lib/DelayDiffEq`)
- **StochasticDiffEq** — `JuliaDiffEq/StochasticDiffEq.jl` → `SciML/OrdinaryDiffEq.jl` (subdir `lib/StochasticDiffEq`)

This is needed before new versions of these packages can be registered from the monorepo.