### PR TITLE
[Breeze] Restrict comapt with Oceananigans v0.106

### DIFF
--- a/B/Breeze/Compat.toml
+++ b/B/Breeze/Compat.toml
@@ -35,4 +35,4 @@ julia = "1.11.9 - 1"
 Oceananigans = "0.105.1 - 0.105"
 
 ["0.4.3 - 0"]
-Oceananigans = "0.105.1 - 0.106"
+Oceananigans = "0.105.1 - 0.106.2"


### PR DESCRIPTION
Compatibility broken by https://github.com/CliMA/Oceananigans.jl/pull/5420, ref https://github.com/NumericalEarth/Breeze.jl/pull/583 and fix https://github.com/NumericalEarth/Breeze.jl/issues/584.