### PR TITLE
Update DelayDiffEq repo URL to OrdinaryDiffEq.jl monorepo

### DIFF
--- a/D/DelayDiffEq/Package.toml
+++ b/D/DelayDiffEq/Package.toml
@@ -1,3 +1,4 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
-repo = "https://github.com/SciML/DelayDiffEq.jl.git"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
+subdir = "lib/DelayDiffEq"


### PR DESCRIPTION
DelayDiffEq has been moved into the [SciML/OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo (subdir `lib/DelayDiffEq`).

Old repo git history has been imported into OrdinaryDiffEq.jl via `archive/delaydiffeq` branch, so all registered tree hashes are resolvable.

Split from #151276 as requested.