### PR TITLE
Update StochasticDiffEq repo URL to OrdinaryDiffEq.jl monorepo

### DIFF
--- a/S/StochasticDiffEq/Package.toml
+++ b/S/StochasticDiffEq/Package.toml
@@ -1,3 +1,4 @@
 name = "StochasticDiffEq"
 uuid = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-repo = "https://github.com/SciML/StochasticDiffEq.jl.git"
+repo = "https://github.com/SciML/OrdinaryDiffEq.jl.git"
+subdir = "lib/StochasticDiffEq"


### PR DESCRIPTION
StochasticDiffEq has been moved into the [SciML/OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo (subdir `lib/StochasticDiffEq`).

Old repo git history has been imported into OrdinaryDiffEq.jl via `archive/stochasticdiffeq` branch, so all registered tree hashes are resolvable.

Split from #151276 as requested.