### PR TITLE
Upgrade AutoMerge-label job to run Julia 1.12.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Harmonize AutoMerge-regular and AutoMerge-label jobs to both run Julia 1.12. Otherwise things can get weird and the install/load checks start to fail just because a label, e.g. override-name-similarity, was added. Cf. #151472.