### PR TITLE
CI: In the "manual PRs feed", remove `actions/checkout`

### DIFF
--- a/.github/workflows/feed_manual_prs.yml
+++ b/.github/workflows/feed_manual_prs.yml
@@ -12,7 +12,6 @@ jobs:
     - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
       with:
         version: 1.6.2
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Send to Slack
       shell: julia --color=yes {0}
       run: |


### PR DESCRIPTION
We have no need to checkout any code in this CI workflow.