### PR TITLE
Update DWaveNeal repository URL

### DIFF
--- a/D/DWaveNeal/Package.toml
+++ b/D/DWaveNeal/Package.toml
@@ -1,3 +1,3 @@
 name = "DWaveNeal"
 uuid = "870cdf72-5502-4b10-839c-127ceab78f22"
-repo = "https://github.com/psrenergy/DWaveNeal.jl.git"
+repo = "https://github.com/JuliaQUBO/DWaveNeal.jl.git"


### PR DESCRIPTION
This updates the `DWaveNeal` registry entry to the current repository URL.

The package is now maintained under `JuliaQUBO/DWaveNeal.jl`, but the General entry still points to the older `psrenergy/DWaveNeal.jl` URL.

No version metadata is changed in this PR. This is only a repository URL correction.
