### PR TITLE
CI: In the `.ci/AutoMerge` project, add `[compat]` entries for both RegistryCI.jl and AutoMerge.jl

### DIFF
--- a/.ci/AutoMerge/Manifest-v1.12.toml
+++ b/.ci/AutoMerge/Manifest-v1.12.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "505f34c17e9a4e71ac13484188d4f6a023f56a11"
+project_hash = "69d6e82434da95ef8745dcc827f17fc443e44b40"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"

--- a/.ci/AutoMerge/Project.toml
+++ b/.ci/AutoMerge/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 AutoMerge = "c5732277-7834-41e3-8e1f-5f375898cfe1"
+RegistryCI = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
 
 [compat]
 AutoMerge = "1"
+RegistryCI = "10, 11"

--- a/.ci/AutoMerge/Project.toml
+++ b/.ci/AutoMerge/Project.toml
@@ -2,4 +2,4 @@
 AutoMerge = "c5732277-7834-41e3-8e1f-5f375898cfe1"
 
 [compat]
-AutoMerge = "10"
+AutoMerge = "1"

--- a/.ci/AutoMerge/Project.toml
+++ b/.ci/AutoMerge/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 AutoMerge = "c5732277-7834-41e3-8e1f-5f375898cfe1"
+
+[compat]
+AutoMerge = "10"


### PR DESCRIPTION
In this repo, we have three different CI projects:
1. `.ci/Project.toml`: The main CI project. This is the project that runs the RegistryCI registry consistency tests.
2. `.ci/AutoMerge/Project.toml`: The AutoMerge-specific project.
3. `.ci/Treecheck/Project.toml`: The Treecheck-specific project.

This PR only affects the second item: `.ci/AutoMerge/Project.toml`: The AutoMerge-specific project.

Before this PR, `.ci/AutoMerge/Project.toml` does not have a `[compat]` entry for RegistryCI.jl.

After this PR, `.ci/AutoMerge/Project.toml` has the following:

```toml
[compat]
AutoMerge = "10"
```