### PR TITLE
Update FunctionWrappersWrappers repo URL to SciML org

### DIFF
--- a/F/FunctionWrappersWrappers/Package.toml
+++ b/F/FunctionWrappersWrappers/Package.toml
@@ -1,3 +1,3 @@
 name = "FunctionWrappersWrappers"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
-repo = "https://github.com/chriselrod/FunctionWrappersWrappers.jl.git"
+repo = "https://github.com/SciML/FunctionWrappersWrappers.jl.git"


### PR DESCRIPTION
The FunctionWrappersWrappers.jl repository was transferred from `chriselrod/FunctionWrappersWrappers.jl` to `SciML/FunctionWrappersWrappers.jl`.

This updates the registry URL so that `@JuliaRegistrator register` works for new versions from the SciML org repo.