### PR TITLE
Update MomentClosure.jl repo URL to SciML

### DIFF
--- a/M/MomentClosure/Package.toml
+++ b/M/MomentClosure/Package.toml
@@ -1,3 +1,3 @@
 name = "MomentClosure"
 uuid = "01a1b25a-ecf0-48c5-ae58-55bfd5393600"
-repo = "https://github.com/augustinas1/MomentClosure.jl.git"
+repo = "https://github.com/SciML/MomentClosure.jl.git"


### PR DESCRIPTION
## Summary
- Update `repo` URL in `M/MomentClosure/Package.toml` from `augustinas1/MomentClosure.jl` to `SciML/MomentClosure.jl`
- The package has been transferred to the SciML organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)