### PR TITLE
Update FastBroadcast repo URL to SciML org

### DIFF
--- a/F/FastBroadcast/Package.toml
+++ b/F/FastBroadcast/Package.toml
@@ -1,3 +1,3 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-repo = "https://github.com/YingboMa/FastBroadcast.jl.git"
+repo = "https://github.com/SciML/FastBroadcast.jl.git"


### PR DESCRIPTION
The FastBroadcast.jl repository has moved from `YingboMa/FastBroadcast.jl` to `SciML/FastBroadcast.jl`.

This updates the registry URL to point to the new location so that new version registrations work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)