### PR TITLE
Retroactively tighten OrdinaryDiffEqCore compat for LowOrderRK and Verner

### DIFF
--- a/O/OrdinaryDiffEqLowOrderRK/Compat.toml
+++ b/O/OrdinaryDiffEqLowOrderRK/Compat.toml
@@ -17,11 +17,12 @@ OrdinaryDiffEqCore = ["0.0.0", "1"]
 ["1.1 - 1.2"]
 OrdinaryDiffEqCore = "1.1.0-1"
 
-["1.10 - 1"]
+["1.10"]
 OrdinaryDiffEqCore = "3"
 
 ["1.11 - 1"]
 DiffEqBase = "6.194.0 - 6"
+OrdinaryDiffEqCore = "3.5.2 - 3"
 SciMLBase = "2.116.0 - 2"
 
 ["1.12 - 1"]

--- a/O/OrdinaryDiffEqVerner/Compat.toml
+++ b/O/OrdinaryDiffEqVerner/Compat.toml
@@ -20,12 +20,15 @@ OrdinaryDiffEqCore = ["0.0.0", "1"]
 ["1.1 - 1.2"]
 OrdinaryDiffEqCore = "1.1.0-1"
 
-["1.10 - 1"]
+["1.10 - 1.11"]
 OrdinaryDiffEqCore = "3"
 
 ["1.11 - 1"]
 DiffEqBase = "6.194.0 - 6"
 SciMLBase = "2.116.0 - 2"
+
+["1.12 - 1"]
+OrdinaryDiffEqCore = "3.5.2 - 3"
 
 ["1.13 - 1"]
 FastBroadcast = "1.3.0 - 1"


### PR DESCRIPTION
## Summary

Retroactively tighten `OrdinaryDiffEqCore` compat bounds for versions of `OrdinaryDiffEqLowOrderRK` and `OrdinaryDiffEqVerner` that introduced `lazy::Val{Bool}` (from PR SciML/OrdinaryDiffEq.jl#3044) but didn't require Core >= 3.5.2 (which added `_unwrap_val`).

Without this fix, the resolver can pick Core < 3.5.2 with these versions, producing:
```
MethodError: no method matching !(::Val{true})
```

See SciML/OrdinaryDiffEq.jl#3253 for the original issue and SciML/OrdinaryDiffEq.jl#3327 for the source fix.

### Changes

| Package | Versions affected | Change |
|---------|-------------------|--------|
| OrdinaryDiffEqLowOrderRK | 1.11.0, 1.12.0 | `OrdinaryDiffEqCore` tightened from `"3"` to `"3.5.2 - 3"` |
| OrdinaryDiffEqVerner | 1.12.0, 1.13.0 | `OrdinaryDiffEqCore` tightened from `"3"` to `"3.5.2 - 3"` |

New versions (LowOrderRK 1.13.0 and Verner 1.14.0) with correct bounds have been registered via SciML/OrdinaryDiffEq.jl#3327.