### PR TITLE
CI: Treecheck: Require package repo URLs to end in .git (except for repos hosted on Sourcehut)

### DIFF
--- a/.ci/Treecheck/Project.toml
+++ b/.ci/Treecheck/Project.toml
@@ -5,6 +5,7 @@ LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 CodecZlib = "0.7"
@@ -13,4 +14,5 @@ LibGit2 = "< 0.0.1, 1"
 TOML = "< 0.0.1, 1"
 Tar = "< 0.0.1, 1"
 Test = "< 0.0.1, 1"
+URIs = "1"
 julia = "1"

--- a/.ci/Treecheck/Treecheck.jl
+++ b/.ci/Treecheck/Treecheck.jl
@@ -186,7 +186,7 @@ function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
         end
 
         @testset "Repo URL must end in .git" begin
-            if !is_sourcehut_repo(pkg["repo"])
+            if !is_sourcehut_repo(package_git_repo_url)
                 # For all non-Sourcehut repos, we require that the repo URL ends in `.git`
                 #
                 # Sourcehut does not seem to support the URL form that ends in `.git`

--- a/.ci/Treecheck/Treecheck.jl
+++ b/.ci/Treecheck/Treecheck.jl
@@ -191,7 +191,7 @@ function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
                 #
                 # Sourcehut does not seem to support the URL form that ends in `.git`
                 # So we have to skip Sourcehut repos for this check
-                @test endswith(pkg["repo"], ".git")
+                @test endswith(package_git_repo_url, ".git")
             end
         end
     end;

--- a/.ci/Treecheck/Treecheck.jl
+++ b/.ci/Treecheck/Treecheck.jl
@@ -6,6 +6,7 @@ import LibGit2
 import TOML
 import Tar
 import Test
+import URIs
 
 # Bring some names into scope, just for convenience:
 using Test: @testset, @test
@@ -143,6 +144,10 @@ function verify_archive_tree_hash(tar_gz::AbstractString, expected_hash::String)
     return true
 end
 
+function is_sourcehut_repo(repo_url::AbstractString)
+    return lowercase(URIs.URI(repo_url).host) == "git.sr.ht"
+end
+
 check(package_uuid_str::AbstractString) = check(RegistryToml(), package_uuid_str)
 function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
     package_name = registrytoml.dict["packages"][package_uuid_str]["name"]
@@ -155,6 +160,13 @@ function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
     package_git_repo_url = package_dict["repo"]
     @testset "Treecheck for package: $(package_name)" begin
         @test !isempty(versions_dict)
+        if !is_sourcehut_repo(pkg["repo"])
+            # Sourcehut does not seem to support the URL form that ends in `.git`
+            # So we have to skip Sourcehut repos for this check
+            #
+            # For all non-Sourcehut repo, we require that the repo URL ends in `.git`
+            @test endswith(pkg["repo"], ".git")
+        end
         mktempdir() do tmpdir
             run(`git clone "$(package_git_repo_url)" "$(tmpdir)"`)
             gitrepo_libgit2 = LibGit2.GitRepo(tmpdir)

--- a/.ci/Treecheck/Treecheck.jl
+++ b/.ci/Treecheck/Treecheck.jl
@@ -160,13 +160,6 @@ function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
     package_git_repo_url = package_dict["repo"]
     @testset "Treecheck for package: $(package_name)" begin
         @test !isempty(versions_dict)
-        if !is_sourcehut_repo(pkg["repo"])
-            # Sourcehut does not seem to support the URL form that ends in `.git`
-            # So we have to skip Sourcehut repos for this check
-            #
-            # For all non-Sourcehut repo, we require that the repo URL ends in `.git`
-            @test endswith(pkg["repo"], ".git")
-        end
         mktempdir() do tmpdir
             run(`git clone "$(package_git_repo_url)" "$(tmpdir)"`)
             gitrepo_libgit2 = LibGit2.GitRepo(tmpdir)
@@ -189,6 +182,16 @@ function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
                     treehash = v["git-tree-sha1"]
                     @test does_the_archive_roundtrip(tmpdir, treehash)
                 end
+            end
+        end
+
+        @testset "Repo URL must end in .git" begin
+            if !is_sourcehut_repo(pkg["repo"])
+                # For all non-Sourcehut repos, we require that the repo URL ends in `.git`
+                #
+                # Sourcehut does not seem to support the URL form that ends in `.git`
+                # So we have to skip Sourcehut repos for this check
+                @test endswith(pkg["repo"], ".git")
             end
         end
     end;

--- a/.ci/Treecheck/Treecheck.jl
+++ b/.ci/Treecheck/Treecheck.jl
@@ -6,6 +6,7 @@ import LibGit2
 import TOML
 import Tar
 import Test
+import URIs
 
 # Bring some names into scope, just for convenience:
 using Test: @testset, @test
@@ -143,6 +144,10 @@ function verify_archive_tree_hash(tar_gz::AbstractString, expected_hash::String)
     return true
 end
 
+function is_sourcehut_repo(repo_url::AbstractString)
+    return lowercase(URIs.URI(repo_url).host) == "git.sr.ht"
+end
+
 check(package_uuid_str::AbstractString) = check(RegistryToml(), package_uuid_str)
 function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
     package_name = registrytoml.dict["packages"][package_uuid_str]["name"]
@@ -177,6 +182,16 @@ function check(registrytoml::RegistryToml, package_uuid_str::AbstractString)
                     treehash = v["git-tree-sha1"]
                     @test does_the_archive_roundtrip(tmpdir, treehash)
                 end
+            end
+        end
+
+        @testset "Repo URL must end in .git" begin
+            if !is_sourcehut_repo(package_git_repo_url)
+                # For all non-Sourcehut repos, we require that the repo URL ends in `.git`
+                #
+                # Sourcehut does not seem to support the URL form that ends in `.git`
+                # So we have to skip Sourcehut repos for this check
+                @test endswith(package_git_repo_url, ".git")
             end
         end
     end;

--- a/D/DataFrames/Package.toml
+++ b/D/DataFrames/Package.toml
@@ -1,3 +1,5 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 repo = "https://github.com/JuliaData/DataFrames.jl.git"
+
+# Hello world

--- a/D/DataFrames/Package.toml
+++ b/D/DataFrames/Package.toml
@@ -1,5 +1,5 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-repo = "https://github.com/JuliaData/DataFrames.jl"
+repo = "https://github.com/JuliaData/DataFrames.jl.git"
 
 # Hello world

--- a/D/DataFrames/Package.toml
+++ b/D/DataFrames/Package.toml
@@ -1,5 +1,5 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-repo = "https://github.com/JuliaData/DataFrames.jl.git"
+repo = "https://github.com/JuliaData/DataFrames.jl"
 
 # Hello world


### PR DESCRIPTION
Ported over from https://github.com/JuliaRegistries/RegistryCI.jl/pull/671

🤖 Co-authored-by: Codex

I have manually reviewed the code in this PR.

TODO before merging:
- [x] Drop the three "DROPME" commits