### PR TITLE
[Retroactive compat] NonlinearSolve*: bump NonlinearSolveBase lower bound to 2.20

### DIFF
--- a/N/NonlinearSolve/Compat.toml
+++ b/N/NonlinearSolve/Compat.toml
@@ -411,7 +411,6 @@ ReTestItems = "1.24.0 - 1"
 BracketingNonlinearSolve = "1.6.0 - 1"
 ForwardDiff = "1"
 LinearSolve = "3.48.0 - 3"
-NonlinearSolveBase = "2.2.0 - 2"
 NonlinearSolveQuasiNewton = "1.12.0 - 1"
 NonlinearSolveSpectralMethods = "1.6.0 - 1"
 SciMLLogging = "1.7.0 - 1"
@@ -421,6 +420,7 @@ SimpleNonlinearSolve = "2.10.0 - 2"
 NonlinearSolveFirstOrder = "1.11.0 - 1"
 
 ["4.13 - 4.16"]
+NonlinearSolveBase = "2.2.0 - 2"
 SciMLBase = "2.127.0 - 2"
 
 ["4.15.1 - 4.15"]
@@ -430,6 +430,7 @@ NonlinearSolveFirstOrder = "1.12.0 - 1"
 NonlinearSolveFirstOrder = "2"
 
 ["4.17 - 4"]
+NonlinearSolveBase = "2.20.0 - 2"
 SciMLBase = "2.154.0 - 2"
 Setfield = "1.1.2 - 1"
 

--- a/N/NonlinearSolveFirstOrder/Compat.toml
+++ b/N/NonlinearSolveFirstOrder/Compat.toml
@@ -36,7 +36,7 @@ LineSearch = "0.1.4-0.1"
 ["1.10"]
 NonlinearSolveBase = "2.1.0 - 2"
 
-["1.11 - 2"]
+["1.11 - 2.0"]
 NonlinearSolveBase = "2.2.0 - 2"
 
 ["1.2 - 1.5"]
@@ -88,4 +88,5 @@ NonlinearSolveBase = "2"
 SciMLBase = "2.116.0 - 2"
 
 ["2.1 - 2"]
+NonlinearSolveBase = "2.20.0 - 2"
 SciMLBase = "2.153.0 - 2"

--- a/N/NonlinearSolveQuasiNewton/Compat.toml
+++ b/N/NonlinearSolveQuasiNewton/Compat.toml
@@ -31,10 +31,11 @@ NonlinearSolveBase = "2"
 ["1.11"]
 NonlinearSolveBase = "2.1.0 - 2"
 
-["1.12 - 1"]
+["1.12"]
 NonlinearSolveBase = "2.2.0 - 2"
 
 ["1.13 - 1"]
+NonlinearSolveBase = "2.20.0 - 2"
 SciMLBase = "2.153.0 - 2"
 
 ["1.2 - 1.6"]

--- a/N/NonlinearSolveSpectralMethods/Compat.toml
+++ b/N/NonlinearSolveSpectralMethods/Compat.toml
@@ -47,5 +47,5 @@ NonlinearSolveBase = "2"
 NonlinearSolveBase = "2.1.0 - 2"
 
 ["1.7 - 1"]
-NonlinearSolveBase = "2.2.0 - 2"
+NonlinearSolveBase = "2.20.0 - 2"
 SciMLBase = "2.153.0 - 2"


### PR DESCRIPTION
## Summary

- **NonlinearSolveFirstOrder v2.1.0**, **NonlinearSolveQuasiNewton v1.13.0**, **NonlinearSolveSpectralMethods v1.7.0**, and **NonlinearSolve v4.17.0** use `maybe_unwrap_prob_for_enzyme` and other AutoSpecialize infrastructure introduced in NonlinearSolveBase v2.20.0 (via [SciML/NonlinearSolve.jl#838](https://github.com/SciML/NonlinearSolve.jl/pull/838)).
- Their compat entries allowed NonlinearSolveBase >= 2.2.0, causing precompilation failures (`UndefVarError: maybe_unwrap_prob_for_enzyme not defined`) when the resolver picks an older version of NonlinearSolveBase.
- This retroactive compat fix bumps the NonlinearSolveBase lower bound to 2.20.0 for these specific package versions.

## Changes

| Package | Versions | Old compat | New compat |
|---|---|---|---|
| NonlinearSolve | 4.17 | `2.2.0 - 2` | `2.20.0 - 2` |
| NonlinearSolveFirstOrder | 2.1 | `2.2.0 - 2` | `2.20.0 - 2` |
| NonlinearSolveQuasiNewton | 1.13 | `2.2.0 - 2` | `2.20.0 - 2` |
| NonlinearSolveSpectralMethods | 1.7 | `2.2.0 - 2` | `2.20.0 - 2` |

Earlier versions of these packages (released before the AutoSpecialize PR) retain their original compat bounds.

## References

- Root cause PR: https://github.com/SciML/NonlinearSolve.jl/pull/838
- Version bump PRs: https://github.com/SciML/NonlinearSolve.jl/pull/888, https://github.com/SciML/NonlinearSolve.jl/pull/892
- Issue report: https://github.com/SciML/NonlinearSolve.jl/issues/893

🤖 Generated with [Claude Code](https://claude.com/claude-code)