### PR TITLE
Update JSXGraph.jl repo URL to JuliaJSXGraph org

### DIFF
--- a/J/JSXGraph/Package.toml
+++ b/J/JSXGraph/Package.toml
@@ -1,3 +1,3 @@
 name = "JSXGraph"
 uuid = "97e4c2e4-f0cb-461e-a268-312dec255b76"
-repo = "https://github.com/tlienart/JSXGraph.jl.git"
+repo = "https://github.com/JuliaJSXGraph/JSXGraph.jl.git"


### PR DESCRIPTION
## Summary
- Update `repo` URL in `J/JSXGraph/Package.toml` from `https://github.com/tlienart/JSXGraph.jl.git` to `https://github.com/JuliaJSXGraph/JSXGraph.jl.git`

The package has been transferred from @tlienart's personal account to the JuliaJSXGraph organization. Maintainership has been updated - Thibaut Lienart is the original author, Sébastien Celles (@s-celles) is now the active maintainer.

This URL change is needed before we can register v0.1.7 via JuliaRegistrator and breaking changes from develop branch in a next release.