### PR TITLE
TinyEigvals.jl: Update repository URL in Package.toml

### DIFF
--- a/T/TinyEigvals/Package.toml
+++ b/T/TinyEigvals/Package.toml
@@ -1,3 +1,3 @@
 name = "TinyEigvals"
 uuid = "7dc15f10-ef5b-4bb7-b45f-6ac6462fc3a6"
-repo = "https://github.com/weishansu011017/TinyEigvals.jl.git"
+repo = "https://github.com/AstroPostprocess/TinyEigvals.jl.git"


### PR DESCRIPTION
This PR updates the repository URL for TinyEigvals.jl after transferring the repository to the AstroPostprocess organization.

New URL:
https://github.com/AstroPostprocess/TinyEigvals.jl.git