### PR TITLE
CodecZlibNG: Change URL after move to JuliaIO

### DIFF
--- a/C/CodecZlibNG/Package.toml
+++ b/C/CodecZlibNG/Package.toml
@@ -1,3 +1,3 @@
 name = "CodecZlibNG"
 uuid = "642d12eb-acb5-4437-bcfc-a25e07ad685c"
-repo = "https://github.com/Drvi/CodecZlibNG.jl.git"
+repo = "https://github.com/JuliaIO/CodecZlibNG.jl.git"


### PR DESCRIPTION
https://github.com/Drvi/CodecZlibNG.jl has been moved to JuliaIO by the author @Drvi.