### PR TITLE
DifferentiationInterface: Fix broken Mooncake version

### DIFF
--- a/D/DifferentiationInterface/WeakCompat.toml
+++ b/D/DifferentiationInterface/WeakCompat.toml
@@ -152,7 +152,7 @@ Symbolics = "5.27.1 - 7"
 Mooncake = "0.4.175 - 0.4"
 
 ["0.7.16 - 0"]
-Mooncake = "0.5.1 - 0.5"
+Mooncake = "0.5.1 - 0.5.24"
 
 ["0.7.2"]
 SparseConnectivityTracer = "0.6.14 - 0.6"


### PR DESCRIPTION
cc @gdalle this will prevent usage of the breaking but not tagged as breaking mooncake release that was causing you issues