### PR TITLE
Yank RestrictedBoltzmannMachines v0.5.0–v0.33.1 (bloated git history)

### DIFF
--- a/R/RestrictedBoltzmannMachines/Versions.toml
+++ b/R/RestrictedBoltzmannMachines/Versions.toml
@@ -108,45 +108,59 @@ git-tree-sha1 = "9fecaa686b322f636b02c08667dc98bf7e4fae57"
 
 ["0.5.0"]
 git-tree-sha1 = "06cbc50d821103bc9012841e0e833d7aab6cf8f4"
+yanked = true
 
 ["0.6.0"]
 git-tree-sha1 = "625698e507d62bd19cb225d32be6fbbad9252b42"
+yanked = true
 
 ["0.6.1"]
 git-tree-sha1 = "ac5d1ec83c1e82285a0053a79f7c5b25eb4be1cc"
+yanked = true
 
 ["0.6.2"]
 git-tree-sha1 = "262e9d6951a01311e543c77ca7df98c84161bb8e"
+yanked = true
 
 ["0.6.3"]
 git-tree-sha1 = "d8e0a004187549102f88991b993b13f4a01e5482"
+yanked = true
 
 ["0.7.0"]
 git-tree-sha1 = "68ce78bc1dd1dc4ee6f1b15240d81071ff6b784d"
+yanked = true
 
 ["0.7.1"]
 git-tree-sha1 = "32a404735ce475a41972815d28022221136eae66"
+yanked = true
 
 ["0.8.0"]
 git-tree-sha1 = "90bc5f215a4a8582f7adbc9c1860bc747a97d171"
+yanked = true
 
 ["0.8.1"]
 git-tree-sha1 = "3e967cc337f951906dd2830c191f12d84111e862"
+yanked = true
 
 ["0.9.0"]
 git-tree-sha1 = "4a936411eb199c59e24d359a2998cd90b3a65f0c"
+yanked = true
 
 ["0.10.0"]
 git-tree-sha1 = "161ed7dece75bae8152ad4a1178d86d4b5f86479"
+yanked = true
 
 ["0.11.0"]
 git-tree-sha1 = "d04a50450b4e2c60534bf1fb095fcf85c83b2d13"
+yanked = true
 
 ["0.12.0"]
 git-tree-sha1 = "6c3fd2e5fa3efbea5ef8eb841ca231013dd8cb85"
+yanked = true
 
 ["0.13.0"]
 git-tree-sha1 = "bcab57526636b1c1b38765a603141e920472a2ac"
+yanked = true
 
 ["0.14.0"]
 git-tree-sha1 = "b905e0cda2b4adda085111ce09010dffeece6c69"
@@ -154,135 +168,179 @@ yanked = true
 
 ["0.14.1"]
 git-tree-sha1 = "2f1255a57f1c1bd64a42100aff53416cafdcd092"
+yanked = true
 
 ["0.15.0"]
 git-tree-sha1 = "88d1e2bdbf88ad9437530e9089e1cdce5af6fbd9"
+yanked = true
 
 ["0.15.1"]
 git-tree-sha1 = "98ada830c36aa115ec9de005b0025cbfb9f53e2b"
+yanked = true
 
 ["0.15.2"]
 git-tree-sha1 = "10f3ba600d7a4a5ebcdb56598bde68a221826329"
+yanked = true
 
 ["0.16.0"]
 git-tree-sha1 = "a6885bb80ddb78447e09d81788866b8c3b513c1c"
+yanked = true
 
 ["0.17.0"]
 git-tree-sha1 = "0d1eddd920632d1357b96ba892ff742661a672c1"
+yanked = true
 
 ["0.17.1"]
 git-tree-sha1 = "48098849b77dca03bfe45d8911acda8903614cde"
+yanked = true
 
 ["0.17.2"]
 git-tree-sha1 = "83e807481121de999d3a7b7f30e3bfd19fe76880"
+yanked = true
 
 ["0.17.3"]
 git-tree-sha1 = "19340beddf2652a4eba8e180011cb6360504155f"
+yanked = true
 
 ["0.18.0"]
 git-tree-sha1 = "6ee7bcda541dd727acafccf694b747372a863679"
+yanked = true
 
 ["0.18.1"]
 git-tree-sha1 = "8c365006716980cffd3b72c82b04fb85747bf309"
+yanked = true
 
 ["0.18.2"]
 git-tree-sha1 = "7c822412584270fbf912714b80879315e4f6d050"
+yanked = true
 
 ["0.19.0"]
 git-tree-sha1 = "b1b18ea910aec2be4e195ee41933d7a8f337fc45"
+yanked = true
 
 ["0.20.0"]
 git-tree-sha1 = "2a42dbc775b03d40d3b943c759b17f5c9aa5db3e"
+yanked = true
 
 ["0.21.0"]
 git-tree-sha1 = "8537f023aeadc00b033e8bba37e8d64438ecf05d"
+yanked = true
 
 ["0.21.1"]
 git-tree-sha1 = "4b23e0190bef0dfd989336f76b656847c3398ad8"
+yanked = true
 
 ["0.22.0"]
 git-tree-sha1 = "d5ed58224e08f5a079a62384237638954c8b058e"
+yanked = true
 
 ["0.22.1"]
 git-tree-sha1 = "c7bc4e90955757c3ac2ab8e2a75fdfa23bc929e8"
+yanked = true
 
 ["0.23.0"]
 git-tree-sha1 = "d0267bbb3350fc6d619187d5defeb4ab77ebfb71"
+yanked = true
 
 ["0.24.0"]
 git-tree-sha1 = "8c44d1e2d66a0cfe3d625ddb3a81237f1fe7bc82"
+yanked = true
 
 ["0.24.1"]
 git-tree-sha1 = "4bb9f9861e3a67e213c0e04c7ade8939938c7f05"
+yanked = true
 
 ["0.24.2"]
 git-tree-sha1 = "f9ca56b1f0950348f72fdc5d64cd6f265ee35b57"
+yanked = true
 
 ["0.24.3"]
 git-tree-sha1 = "84b34304be6f1c37ab170334923c4c2562459602"
+yanked = true
 
 ["0.24.4"]
 git-tree-sha1 = "482579db28b672d3d7f668f7f14cad2960b6890a"
+yanked = true
 
 ["0.24.5"]
 git-tree-sha1 = "f72b9d6d78b5db0c6b064cab1aa0f9ebc1524732"
+yanked = true
 
 ["0.24.6"]
 git-tree-sha1 = "64a632a124735d84c17efee215615e1f98c71caf"
+yanked = true
 
 ["0.25.0"]
 git-tree-sha1 = "b3c6e2de402764d4a8cc1af2396a524e382b5143"
+yanked = true
 
 ["0.25.1"]
 git-tree-sha1 = "72523fc1da547ac500c6cb8a32bd9e6bba7e3c94"
+yanked = true
 
 ["0.25.2"]
 git-tree-sha1 = "a28d432efb8b57d4987cee04814898817e4777f2"
+yanked = true
 
 ["0.25.3"]
 git-tree-sha1 = "3dc1969ca5a35b09710a8879cafea403774fa93c"
+yanked = true
 
 ["0.26.0"]
 git-tree-sha1 = "f2c6816ac7c44b004eb3e0da8d0715ac772c09e5"
+yanked = true
 
 ["0.27.0"]
 git-tree-sha1 = "8626c25b7d8cda60f3d8c997f76979e6ca3c0b63"
+yanked = true
 
 ["0.28.0"]
 git-tree-sha1 = "84b1ff9612425ebe407b46f8fb705133e2cbecfa"
+yanked = true
 
 ["0.28.1"]
 git-tree-sha1 = "e4a19a45da5763e1adb9817edf9f56ba6764a93e"
+yanked = true
 
 ["0.28.2"]
 git-tree-sha1 = "3d2d0ea0a26ef1ae21f88efd136e94392fe2aefb"
+yanked = true
 
 ["0.29.0"]
 git-tree-sha1 = "89d23c59a7cd56829d589de5fcf8b2deb613cd55"
+yanked = true
 
 ["0.29.1"]
 git-tree-sha1 = "8138ed9b1ced6f3a8dfdde40d57faecf2cb4465e"
+yanked = true
 
 ["0.30.0"]
 git-tree-sha1 = "a688ccc95d35bcab5a276f8ed0487ec718227eb8"
+yanked = true
 
 ["0.30.1"]
 git-tree-sha1 = "58054baf490827cd9732297f7755dc5e71d152a7"
+yanked = true
 
 ["0.31.0"]
 git-tree-sha1 = "df2980c36ceaa958cdf23691f70175996bfb6568"
+yanked = true
 
 ["0.32.0"]
 git-tree-sha1 = "c9d70dfd6027dbf44a34be4f617ee55841f87542"
+yanked = true
 
 ["0.32.1"]
 git-tree-sha1 = "a392d6ff9e8e495360ec8d6f6dedf5183701978e"
+yanked = true
 
 ["0.33.0"]
 git-tree-sha1 = "22733251670ac4b931c8190ab6c093fb3268a7fe"
+yanked = true
 
 ["0.33.1"]
 git-tree-sha1 = "d8c514dbe03c6574120897b0391ab8cddf2705ac"
+yanked = true
 
 ["0.34.0"]
 git-tree-sha1 = "92cbd2aeb05b6b9af62d989800fe52da86f9b47b"


### PR DESCRIPTION
## Summary

Yank all versions of RestrictedBoltzmannMachines from v0.5.0 to v0.33.1 (inclusive).

These versions contain a bloated git history (large binary/data files were committed to the repository), causing `Pkg.add` / `Pkg.update` to download an unnecessarily large amount of data. The issue was fixed starting from v0.34.0.

Yanking these versions will steer users toward the newer, lighter versions while keeping the registry entries available for reproducibility.

## Changes

- Added `yanked = true` to 58 version entries in `R/RestrictedBoltzmannMachines/Versions.toml` (v0.5.0 through v0.33.1; v0.14.0 was already yanked).