### PR TITLE
Cap DelayDiffEq 5.68-5.73 at OrdinaryDiffEqCore <= 3.30

### DIFF
--- a/D/DelayDiffEq/Compat.toml
+++ b/D/DelayDiffEq/Compat.toml
@@ -348,7 +348,7 @@ FastBroadcast = "1.3.0 - 1"
 RecursiveArrayTools = "3.52.0 - 3"
 
 ["5.74 - 5"]
-OrdinaryDiffEqCore = "3"
+OrdinaryDiffEqCore = "3.31.0 - 3"
 
 ["5.8 - 5.10"]
 OrdinaryDiffEq = "5.12.0-5"

--- a/D/DelayDiffEq/Compat.toml
+++ b/D/DelayDiffEq/Compat.toml
@@ -328,7 +328,7 @@ ConcreteStructs = "0.2.3 - 0.2"
 OrdinaryDiffEqDifferentiation = "2"
 
 ["5.68 - 5.69"]
-OrdinaryDiffEqCore = "3.2.0 - 3"
+OrdinaryDiffEqCore = "3.2.0 - 3.30"
 
 ["5.69 - 5"]
 OrdinaryDiffEqDifferentiation = "2.2.1 - 2"
@@ -339,7 +339,9 @@ OrdinaryDiffEq = "5.11.1-5"
 ["5.70 - 5"]
 DiffEqBase = "6.209.0 - 6"
 ForwardDiff = ["0.10.38 - 0.10", "1"]
-OrdinaryDiffEqCore = "3"
+
+["5.70 - 5.73"]
+OrdinaryDiffEqCore = "3.0.0 - 3.30"
 
 ["5.71 - 5"]
 FastBroadcast = "1.3.0 - 1"

--- a/D/DelayDiffEq/Compat.toml
+++ b/D/DelayDiffEq/Compat.toml
@@ -347,5 +347,8 @@ OrdinaryDiffEqCore = "3.0.0 - 3.30"
 FastBroadcast = "1.3.0 - 1"
 RecursiveArrayTools = "3.52.0 - 3"
 
+["5.74 - 5"]
+OrdinaryDiffEqCore = "3"
+
 ["5.8 - 5.10"]
 OrdinaryDiffEq = "5.12.0-5"


### PR DESCRIPTION
## Summary

Caps `OrdinaryDiffEqCore` compat at `3.30` for `DelayDiffEq 5.68 - 5.73`. These versions are broken when resolved against the newly-released `OrdinaryDiffEqCore 3.31.0`.

## Why

`OrdinaryDiffEqCore 3.31.0` introduced `shift_past_discontinuity!` ([SciML/OrdinaryDiffEq.jl#3392](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3392)) which nudges `integrator.t` by one ULP past each discontinuity so user RHS branches written as `if t > t_d` pick up the post-discontinuity regime. DDEs propagate a discontinuity at every `constant_lag` step. The DDE-side override needed to keep the ODE sub-integrator in sync (and the corresponding relaxed sync check) landed on master in [SciML/OrdinaryDiffEq.jl#3394](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3394) — in the same commit that bumped the in-tree subpackage version to `5.73.0` — but the **registered** `5.73.0` (tree `eeb17bb034e…`) was cut from the prior minor-bump commit and does **not** have the fix.

Result: any DDE with `constant_lags` and a default solver fails with `ERROR: cannot advance ODE integrator` as soon as integration crosses `t = n * tau`. Reported in [SciML/OrdinaryDiffEq.jl#3426](https://github.com/SciML/OrdinaryDiffEq.jl/issues/3426) with a minimal reproducer.

Versions `5.68 - 5.72` are from the pre-monorepo repository and similarly predate the fix; their existing `OrdinaryDiffEqCore = "3.2.0 - 3"` / `"3"` compat also allows `3.31`, so they hit the same bug.

The fix shipped as `DelayDiffEq 5.74.0`, which was registered shortly after this PR was opened with `OrdinaryDiffEqCore = "3"` (see [SciML/OrdinaryDiffEq.jl#3427](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3427) which adds a regression test and swaps in the lockstep approach).

## Change

```diff
 ["5.68 - 5.69"]
-OrdinaryDiffEqCore = "3.2.0 - 3"
+OrdinaryDiffEqCore = "3.2.0 - 3.30"

 ["5.70 - 5"]
 DiffEqBase = "6.209.0 - 6"
 ForwardDiff = ["0.10.38 - 0.10", "1"]
-OrdinaryDiffEqCore = "3"
+
+["5.70 - 5.73"]
+OrdinaryDiffEqCore = "3.0.0 - 3.30"
+
+["5.74 - 5"]
+OrdinaryDiffEqCore = "3"
```

`OrdinaryDiffEqCore` is split out of the open-ended `["5.70 - 5"]` block into a bounded `["5.70 - 5.73"]` block for the broken versions and a `["5.74 - 5"]` block that restores the `"3"` compat already registered for `5.74.0`. Splitting avoids overlapping compat ranges (Pkg rejects those with `Overlapping ranges for ...`).

## Verification

Patched the registry locally in an isolated depot and confirmed:
- `DelayDiffEq = "=5.73"` + `OrdinaryDiffEqCore = "3.31"` → now `Unsatisfiable requirements` (correctly refuses).
- Without pins, resolves `DelayDiffEq 5.73` + `OrdinaryDiffEqCore` in `3.0 - 3.30` (no breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
