### PR TITLE
Update repository URL in Package.toml

### DIFF
--- a/C/ChemistryLab/Package.toml
+++ b/C/ChemistryLab/Package.toml
@@ -1,3 +1,3 @@
 name = "ChemistryLab"
 uuid = "f346e401-14f9-407c-a0e2-c4f64a3e574a"
-repo = "https://github.com/jfbarthelemy/ChemistryLab.jl.git"
+repo = "https://github.com/ChemistryTools/ChemistryLab.jl.git"


### PR DESCRIPTION
The `ChemistryLab` package has been transferred from my personal account to the `ChemistryTools` GitHub organization.