### PR TITLE
[ImplicitDiscreteSolve] Tighten OrdinaryDiffEqCore compat for v1.11.0

### DIFF
--- a/I/ImplicitDiscreteSolve/Compat.toml
+++ b/I/ImplicitDiscreteSolve/Compat.toml
@@ -58,8 +58,13 @@ NonlinearSolveFirstOrder = "1.9.0 - 1"
 
 ["1.7 - 1"]
 DiffEqBase = "6.194.0 - 6"
-OrdinaryDiffEqCore = "3.4.0 - 3"
 SciMLBase = "2.116.0 - 2"
+
+["1.7 - 1.10"]
+OrdinaryDiffEqCore = "3.4.0 - 3"
+
+["1.11"]
+OrdinaryDiffEqCore = "3.31.0 - 3"
 
 ["1.8 - 1"]
 NonlinearSolveFirstOrder = "1.9.0 - 2"


### PR DESCRIPTION
## Summary

- ImplicitDiscreteSolve v1.11.0 imports `allows_null_u0` from OrdinaryDiffEqCore, which was introduced in v3.31.0 (SciML/OrdinaryDiffEq.jl#3433)
- The registered compat lower bound of `3.4.0` allows resolving OrdinaryDiffEqCore versions that don't export this trait, causing `UndefVarError` at load time
- This splits the `["1.7 - 1"]` OrdinaryDiffEqCore range: versions 1.7–1.10 keep `3.4.0 - 3`, and v1.11.0 gets `3.31.0 - 3`

Upstream fix: SciML/OrdinaryDiffEq.jl#3453

🤖 Generated with [Claude Code](https://claude.com/claude-code)