### PR TITLE
flux_core_jll: Declare libsodium_jll compat bounds

### DIFF
--- a/jll/F/flux_core_jll/Compat.toml
+++ b/jll/F/flux_core_jll/Compat.toml
@@ -2,3 +2,4 @@
 JLLWrappers = "1.2.0-1"
 Lua_jll = "5.3"
 julia = "1"
+libsodium_jll = "1"


### PR DESCRIPTION
There is a new, incompatible version of `libsodium_jll`. Declare a compat bound so that `flux_core_jll` doesn't break in the future.