### PR TITLE
Update repo URL for TensND: jfbarthelemy → MicMacTools organization

### DIFF
--- a/T/TensND/Package.toml
+++ b/T/TensND/Package.toml
@@ -1,3 +1,3 @@
 name = "TensND"
 uuid = "474b5345-2588-4284-8a58-2430a1a40cb0"
-repo = "https://github.com/jfbarthelemy/TensND.jl.git"
+repo = "https://github.com/MicMacTools/TensND.jl.git"


### PR DESCRIPTION
## Summary

The `TensND` package has been transferred from my personal account to
the [`MicMacTools`](https://github.com/MicMacTools) GitHub organization
alongside a growing set of related packages for micromechanics and
mean-field homogenization.

|     | URL                                                |
|-----|----------------------------------------------------|
| Old | `https://github.com/jfbarthelemy/TensND.jl.git`    |
| New | `https://github.com/MicMacTools/TensND.jl.git`     |

No version bump — this PR only updates the `repo` field in
`T/TensND/Package.toml` to reflect the new canonical location. The
GitHub redirect currently keeps existing installations working, but
registering future versions requires the registry URL to match the
actual repository owner (AutoMerge ownership check).

This is the same situation as
[#152553](https://github.com/JuliaRegistries/General/pull/152553) for
`ChemistryLab` (still awaiting review).

Sorry for the direct ping — if anyone has a moment, a quick review
would be really appreciated, since new releases are currently blocked
on this change.

cc @DilumAluthge @KristofferC @ericphanson @fredrikekre

Thanks for your time and for maintaining the registry!
