### PR TITLE
Update ParetoSmooth.jl repository URL in Package.toml

### DIFF
--- a/P/ParetoSmooth/Package.toml
+++ b/P/ParetoSmooth/Package.toml
@@ -1,3 +1,3 @@
 name = "ParetoSmooth"
 uuid = "a68b5a21-f429-434e-8bfa-46b447300aac"
-repo = "https://github.com/TuringLang/ParetoSmooth.jl.git"
+repo = "https://github.com/chalk-lab/ParetoSmooth.jl.git"


### PR DESCRIPTION
1. [x] I have confirmed that the old URL automatically redirects to the new URL in the web browser.
2. [x] The PR preserves the trailing `.git` at the end of the URL.
3. [x] The Treecheck CI job ran on this PR and is green.

Verification of availablility of all versions (ref: https://github.com/JuliaRegistries/General/blob/master/CONTRIBUTING.md#appendix-checking-if-a-repository-contains-all-registered-versions-of-a-package):
```julia
julia> check_package_versions("ParetoSmooth", "https://github.com/chalk-lab/ParetoSmooth.jl.git");
...clone-logs...
ParetoSmooth: v0.1.0 found
ParetoSmooth: v0.1.1 found
ParetoSmooth: v0.1.2 found
ParetoSmooth: v0.1.3 found
ParetoSmooth: v0.2.0 found
ParetoSmooth: v0.2.1 found
ParetoSmooth: v0.2.2 found
ParetoSmooth: v0.2.3 found
ParetoSmooth: v0.2.4 found
ParetoSmooth: v0.3.0 found
ParetoSmooth: v0.3.1 found
ParetoSmooth: v0.3.2 found
ParetoSmooth: v0.4.0 found
ParetoSmooth: v0.5.0 found
ParetoSmooth: v0.5.1 found
ParetoSmooth: v0.5.2 found
ParetoSmooth: v0.6.0 found
ParetoSmooth: v0.6.1 found
ParetoSmooth: v0.6.2 found
ParetoSmooth: v0.6.3 found
ParetoSmooth: v0.6.4 found
ParetoSmooth: v0.6.5 found
ParetoSmooth: v0.6.6 found
ParetoSmooth: v0.7.0 found
ParetoSmooth: v0.7.1 found
ParetoSmooth: v0.7.2 found
ParetoSmooth: v0.7.3 found
ParetoSmooth: v0.7.4 found
ParetoSmooth: v0.7.5 found
ParetoSmooth: v0.7.6 found
ParetoSmooth: v0.7.7 found
ParetoSmooth: v0.7.8 found
ParetoSmooth: v0.7.9 found
ParetoSmooth: v0.7.10 found
ParetoSmooth: v0.7.11 found
ParetoSmooth: v0.7.12 found
ParetoSmooth: v0.7.13 found
ParetoSmooth: v0.7.14 found
ParetoSmooth: v0.7.15 found
ParetoSmooth: v0.7.16 found

julia> 
```