### PR TITLE
remove references to NREL-Sienna

### DIFF
--- a/H/HybridSystemsSimulations/Package.toml
+++ b/H/HybridSystemsSimulations/Package.toml
@@ -1,3 +1,3 @@
 name = "HybridSystemsSimulations"
 uuid = "bed98974-b02a-5e2f-9ee0-a103f5c450dd"
-repo = "https://github.com/NREL-Sienna/HybridSystemsSimulations.jl.git"
+repo = "https://github.com/Sienna-Platform/HybridSystemsSimulations.jl.git"

--- a/H/HydroPowerSimulations/Package.toml
+++ b/H/HydroPowerSimulations/Package.toml
@@ -1,3 +1,3 @@
 name = "HydroPowerSimulations"
 uuid = "fc1677e0-6ad7-4515-bf3a-bd6bf20a0b1b"
-repo = "https://github.com/NREL-Sienna/HydroPowerSimulations.jl.git"
+repo = "https://github.com/Sienna-Platform/HydroPowerSimulations.jl.git"

--- a/I/InfrastructureSystems/Package.toml
+++ b/I/InfrastructureSystems/Package.toml
@@ -1,3 +1,3 @@
 name = "InfrastructureSystems"
 uuid = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
-repo = "https://github.com/NREL-Sienna/InfrastructureSystems.jl.git"
+repo = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"

--- a/P/PowerAnalytics/Package.toml
+++ b/P/PowerAnalytics/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerAnalytics"
 uuid = "56ce1300-00bc-47e4-ba8c-b166ccc19f51"
-repo = "https://github.com/NREL-Sienna/PowerAnalytics.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerAnalytics.jl.git"

--- a/P/PowerApps/Package.toml
+++ b/P/PowerApps/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerApps"
 uuid = "e34cdab0-23c5-4ff6-ba51-717855faf142"
-repo = "https://github.com/NREL-Sienna/PowerApps.jl.git"
+repo = "https://github.com/NLR-Sienna/PowerApps.jl.git"

--- a/P/PowerFlowFileParser/Package.toml
+++ b/P/PowerFlowFileParser/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerFlowFileParser"
 uuid = "bed98974-b02e-5e2f-9ee0-a103f5c450dd"
-repo = "https://github.com/NREL-Sienna/PowerFlowFileParser.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl.git"

--- a/P/PowerFlows/Package.toml
+++ b/P/PowerFlows/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerFlows"
 uuid = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
-repo = "https://github.com/NREL-Sienna/PowerFlows.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerFlows.jl.git"

--- a/P/PowerGraphics/Package.toml
+++ b/P/PowerGraphics/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerGraphics"
 uuid = "5f7eddb3-86b1-49e8-a95a-ddc0f45eea41"
-repo = "https://github.com/NREL-Sienna/PowerGraphics.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerGraphics.jl.git"

--- a/P/PowerModelsInterface/Package.toml
+++ b/P/PowerModelsInterface/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerModelsInterface"
 uuid = "7a4b9400-1441-4f08-9626-3f96e0a9a29b"
-repo = "https://github.com/NREL-Sienna/PowerModelsInterface.jl.git"
+repo = "https://github.com/NLR-Sienna/PowerModelsInterface.jl.git"

--- a/P/PowerNetworkMatrices/Package.toml
+++ b/P/PowerNetworkMatrices/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerNetworkMatrices"
 uuid = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
-repo = "https://github.com/NREL-Sienna/PowerNetworkMatrices.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git"

--- a/P/PowerSimulations/Package.toml
+++ b/P/PowerSimulations/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerSimulations"
 uuid = "e690365d-45e2-57bb-ac84-44ba829e73c4"
-repo = "https://github.com/NREL-Sienna/PowerSimulations.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerSimulations.jl.git"

--- a/P/PowerSimulationsDynamics/Package.toml
+++ b/P/PowerSimulationsDynamics/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerSimulationsDynamics"
 uuid = "398b2ede-47ed-4edc-b52e-69e4a48b4336"
-repo = "https://github.com/NREL-Sienna/PowerSimulationsDynamics.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerSimulationsDynamics.jl.git"

--- a/P/PowerSystemCaseBuilder/Package.toml
+++ b/P/PowerSystemCaseBuilder/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerSystemCaseBuilder"
 uuid = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
-repo = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl.git"

--- a/P/PowerSystems/Package.toml
+++ b/P/PowerSystems/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerSystems"
 uuid = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
-repo = "https://github.com/NREL-Sienna/PowerSystems.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerSystems.jl.git"

--- a/P/PowerSystemsInvestmentsPortfolios/Package.toml
+++ b/P/PowerSystemsInvestmentsPortfolios/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerSystemsInvestmentsPortfolios"
 uuid = "bed98974-b02a-5e2f-9fe0-a103f8c450dd"
-repo = "https://github.com/NREL-Sienna/PowerSystemsInvestmentsPortfolios.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerSystemsInvestmentsPortfolios.jl.git"

--- a/P/PowerSystemsMaps/Package.toml
+++ b/P/PowerSystemsMaps/Package.toml
@@ -1,3 +1,3 @@
 name = "PowerSystemsMaps"
 uuid = "e146f72c-d4f8-45d3-b3ca-12a16cb68a38"
-repo = "https://github.com/NREL-Sienna/PowerSystemsMaps.jl.git"
+repo = "https://github.com/Sienna-Platform/PowerSystemsMaps.jl.git"

--- a/S/SIIP2Marmot/Package.toml
+++ b/S/SIIP2Marmot/Package.toml
@@ -1,3 +1,3 @@
 name = "SIIP2Marmot"
 uuid = "9dbaeea7-558f-4e29-ba60-30a5dee37710"
-repo = "https://github.com/NREL-Sienna/SIIP2Marmot.jl.git"
+repo = "https://github.com/NLR-Sienna/SIIP2Marmot.jl.git"

--- a/S/SIIPExamples/Package.toml
+++ b/S/SIIPExamples/Package.toml
@@ -1,3 +1,3 @@
 name = "SIIPExamples"
 uuid = "2c79006f-6450-48c4-b124-fbadab4f299d"
-repo = "https://github.com/NREL-Sienna/SIIPExamples.jl.git"
+repo = "https://github.com/Sienna-Platform/SIIPExamples.jl.git"

--- a/S/SIIPExamples/Package.toml
+++ b/S/SIIPExamples/Package.toml
@@ -1,3 +1,3 @@
 name = "SIIPExamples"
 uuid = "2c79006f-6450-48c4-b124-fbadab4f299d"
-repo = "https://github.com/Sienna-Platform/SIIPExamples.jl.git"
+repo = "https://github.com/NLR-Sienna/OldExamples.jl.git"

--- a/S/SiennaPRASInterface/Package.toml
+++ b/S/SiennaPRASInterface/Package.toml
@@ -1,3 +1,3 @@
 name = "SiennaPRASInterface"
 uuid = "4b496c86-8d00-441d-b504-079c710e0aa7"
-repo = "https://github.com/NREL-Sienna/SiennaPRASInterface.jl.git"
+repo = "https://github.com/Sienna-Platform/SiennaPRASInterface.jl.git"

--- a/S/StorageSystemsSimulations/Package.toml
+++ b/S/StorageSystemsSimulations/Package.toml
@@ -1,3 +1,3 @@
 name = "StorageSystemsSimulations"
 uuid = "e2f1a126-19d0-4674-9252-42b2384f8e3c"
-repo = "https://github.com/NREL-Sienna/StorageSystemsSimulations.jl.git"
+repo = "https://github.com/Sienna-Platform/StorageSystemsSimulations.jl.git"


### PR DESCRIPTION
Recently the formerly known as National Renewable Energy Laboratory was renamed to National Laboratory of the Rockies. As such the organization containing several libraries used in the Julia ecosystem for power modeling have been also split in two organization according to new policies. 

This PR removes reference to the old NREL-Sienna organization and properly directs the links to the right locations. 