### PR TITLE
[Breeze] Cap compatibility with Oceananigans

### DIFF
--- a/B/Breeze/Compat.toml
+++ b/B/Breeze/Compat.toml
@@ -41,4 +41,4 @@ Oceananigans = "0.105.1 - 0.106.2"
 Oceananigans = "0.106.3 - 0.106"
 
 ["0.4.8 - 0"]
-Oceananigans = "0.107.3 - 0.107"
+Oceananigans = "0.107.3"


### PR DESCRIPTION
https://github.com/CliMA/Oceananigans.jl/pull/5538, part of v0.107.4, upstreamed some code which was in Breeze v0.4.8.  This code will be removed from Breeze, but in the meantime we don't want to allow the situation where the same code is defined twice, causing warnings about duplicate method definitions.