### PR TITLE
Yank ODE solver versions that allow SciMLBase v3 without a major bump

### DIFF
--- a/D/DASKR/Versions.toml
+++ b/D/DASKR/Versions.toml
@@ -39,9 +39,11 @@ git-tree-sha1 = "a2b7745ceccf1b14bae4d82a55f928ccf208b19a"
 
 ["2.10.1"]
 git-tree-sha1 = "16f90000e5b807d15208cac977e6ab2dae4afc5c"
+yanked = true
 
 ["2.11.0"]
 git-tree-sha1 = "32b1c0278df20d348a664bd9a1af00ec57e2153e"
+yanked = true
 
 ["3.0.0"]
 git-tree-sha1 = "96cb205fe55055af366254ccc3ef14de547be6fe"

--- a/D/DASSL/Versions.toml
+++ b/D/DASSL/Versions.toml
@@ -36,12 +36,15 @@ git-tree-sha1 = "313d3af136043d72259c1aac58117cc3488e67f2"
 
 ["2.10.1"]
 git-tree-sha1 = "48d42c0f6576c5164941a7fff36f22aa08c21a38"
+yanked = true
 
 ["2.11.0"]
 git-tree-sha1 = "d12427fc69d33db80760171c5ef5bc643a22ee83"
+yanked = true
 
 ["2.12.0"]
 git-tree-sha1 = "09c06bdab020d170c3816af0dfbf5d87828d81a6"
+yanked = true
 
 ["3.0.0"]
 git-tree-sha1 = "764134026a7a21d4d52bed3c46e8f353d409e194"

--- a/I/IRKGaussLegendre/Versions.toml
+++ b/I/IRKGaussLegendre/Versions.toml
@@ -51,9 +51,11 @@ git-tree-sha1 = "3156f0c7ddaa0e2e7bdbdc63054993673163fa26"
 
 ["0.2.14"]
 git-tree-sha1 = "75580cbdb0324bd85ac017b361efa63691ce739e"
+yanked = true
 
 ["0.2.15"]
 git-tree-sha1 = "92fe9d22fb1f2fd0c18dd2e5c80ef5de2d241cd8"
+yanked = true
 
 ["0.3.0"]
 git-tree-sha1 = "13aab40b9367ae956158ef46e521f88cbc286553"

--- a/O/ODEInterfaceDiffEq/Versions.toml
+++ b/O/ODEInterfaceDiffEq/Versions.toml
@@ -108,12 +108,15 @@ git-tree-sha1 = "7ca947a49a7c51d81169059e9960b248007a8a05"
 
 ["3.18.0"]
 git-tree-sha1 = "227f435974f3e8abc413dfa71d7265fcad25e014"
+yanked = true
 
 ["3.19.0"]
 git-tree-sha1 = "fced5d286e02a1ba7224ccfae0ebbcc6fe361e5f"
+yanked = true
 
 ["3.20.0"]
 git-tree-sha1 = "3697de641943f79f20514cbd40688eab24fcaa83"
+yanked = true
 
 ["4.0.0"]
 git-tree-sha1 = "38fb6b73dcc72515c856cdbdcafb6419b5ea25c2"


### PR DESCRIPTION
## Summary

The SciMLBase v3 / DiffEqBase v7 / OrdinaryDiffEq v7 release is **breaking** across the board (typed `verbose` / `DEVerbosity` instead of `Bool`, `AutoSpecialize` `ODEFunction` default, controllers as objects, RAT v4 array semantics, removed re-exports, etc. — see [the OrdinaryDiffEq v7 NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)).

These ODE / DAE solver wrapper packages widened their `SciMLBase` compat to include v3 in a **non-major** release. As a result, resolvers will silently pick them up against the new ecosystem even though they expose the v3 breakage to their users (e.g. `verbose = false` semantics, `ODEFunction` specialization changes). Per SemVer, that should have been a major bump.

Yanking forces users to either pin to the last pre-v3 release on the old major, or to opt into a future major release that explicitly signals the v3 ecosystem upgrade. Major-bump PRs to each affected repo will follow.

## Yanked versions

| Package | Versions | SciMLBase compat |
| --- | --- | --- |
| [DASKR](https://github.com/SciML/DASKR.jl) | `2.10.1`, `2.11.0` | `["2.119 - 2", "3.1 - 3"]` |
| [DASSL](https://github.com/SciML/DASSL.jl) | `2.10.1`, `2.11.0`, `2.12.0` | `["2", "3.1 - 3"]` |
| [IRKGaussLegendre](https://github.com/SciML/IRKGaussLegendre.jl) | `0.2.14`, `0.2.15` | `["2", "3.1 - 3"]` |
| [ODEInterfaceDiffEq](https://github.com/SciML/ODEInterfaceDiffEq.jl) | `3.18.0`, `3.19.0`, `3.20.0` | `["1.73 - 2", "3.1 - 3"]` |

`Sundials.jl` and `LSODA.jl` were considered but their latest *registered* versions (Sundials 5.1.0, LSODA 0.7.6) still cap at SciMLBase v2 — only their `master` branches add v3 compat, and those have not been registered. Nothing to yank for them; they will get a fresh major-bump release directly.

## Test plan

- [ ] Registry CI passes (TOML parsing / version-table sanity)
- [ ] Follow-up major-bump PRs land in each affected repo: DASKR → 3.0, DASSL → 3.0, IRKGaussLegendre → 0.3, ODEInterfaceDiffEq → 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)