### PR TITLE
Yank OrdinaryDiffEqCore v5.0.0 and DiffEqDevTools v4.0.0

### DIFF
--- a/D/DiffEqDevTools/Versions.toml
+++ b/D/DiffEqDevTools/Versions.toml
@@ -238,3 +238,4 @@ git-tree-sha1 = "cc290a2fdad4d332ba6a88953eaf5800687ccd49"
 
 ["4.0.0"]
 git-tree-sha1 = "e8b337fd58d0058e4e8d1e2bbbf437d81df4617f"
+yanked = true

--- a/O/OrdinaryDiffEqCore/Versions.toml
+++ b/O/OrdinaryDiffEqCore/Versions.toml
@@ -291,3 +291,4 @@ git-tree-sha1 = "86c210d134f09139a294f0329006d6cc20275650"
 
 ["5.0.0"]
 git-tree-sha1 = "68cc6ea3cf1f2ff9236cd8836309f20110aa39ad"
+yanked = true


### PR DESCRIPTION
Yank `OrdinaryDiffEqCore v5.0.0` and `DiffEqDevTools v4.0.0`.

Both were registered as part of a sweep for [SciML/OrdinaryDiffEq.jl#3562](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3562), which cascaded major bumps across the monorepo. These two should not have been bumped — their already-released versions (`OrdinaryDiffEqCore v4` and `DiffEqDevTools v3`) were the SciMLBase-v3 versions and the cascade was a mistake. The bad versions cleared AutoMerge before this was caught, hence this yank.

Source-repo followup: [SciML/OrdinaryDiffEq.jl#3565](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3565) reverts the version bumps and the `[compat]` references in the monorepo so further sublib registrations target the correct upstream majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)