### PR TITLE
Update repository URL for KiteControllers

### DIFF
--- a/K/KiteControllers/Package.toml
+++ b/K/KiteControllers/Package.toml
@@ -1,3 +1,3 @@
 name = "KiteControllers"
 uuid = "b19fd437-5b3a-4cca-b199-c3ded0f20ded"
-repo = "https://github.com/aenarete/KiteControllers.jl.git"
+repo = "https://github.com/OpenSourceAWE/KiteControllers.jl.git"


### PR DESCRIPTION
Moved repo to the OpenSourceAWE organization.