### PR TITLE
Fix OrdinaryDiffEqRosenbrock v1.23+ Differentiation lower bound

### DIFF
--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -117,7 +117,7 @@ OrdinaryDiffEqCore = "3"
 
 ["1.23 - 1"]
 DiffEqBase = "6.194.0 - 6"
-OrdinaryDiffEqDifferentiation = "2"
+OrdinaryDiffEqDifferentiation = "2.8"
 SciMLBase = "2.116.0 - 2"
 
 ["1.28 - 1"]


### PR DESCRIPTION
## Summary

`OrdinaryDiffEqRosenbrock` v1.23 through v1.31.1 call `calc_rosenbrock_differentiation` (no-bang, out-of-place variant). That symbol was only added in `OrdinaryDiffEqDifferentiation` **v2.8.0**; v2.7.0 and earlier only define `calc_rosenbrock_differentiation!` (bang variant).

The registered compat for Rosenbrock v1.23+ was:
```toml
["1.23 - 1"]
OrdinaryDiffEqDifferentiation = "2"
```

This allows the resolver to pick `OrdinaryDiffEqDifferentiation` v2.0–v2.7, which causes precompile failure:
```
UndefVarError: `calc_rosenbrock_differentiation` not defined in `OrdinaryDiffEqRosenbrock`
```

This is actively breaking downstream CI, e.g. [DiffEqBayes.jl#374](https://github.com/SciML/DiffEqBayes.jl/pull/374) fails on Julia LTS / pre / Stan-lts with exactly this error.

## Fix

Tighten the lower bound from `"2"` to `"2.8"`:

```diff
 ["1.23 - 1"]
 DiffEqBase = "6.194.0 - 6"
-OrdinaryDiffEqDifferentiation = "2"
+OrdinaryDiffEqDifferentiation = "2.8"
 SciMLBase = "2.116.0 - 2"
```

This is a **retroactive compat tightening only** — no versions are yanked. The resolver will simply exclude `OrdinaryDiffEqDifferentiation` v2.0–v2.7 when selecting Rosenbrock v1.23+.

## Other entries reviewed

All other `OrdinaryDiffEqDifferentiation` compat entries in this file target the v1.x line of Differentiation (e.g. `"1.12.0 - 1"` for Rosenbrock `["1.16 - 1.22"]`) and are correct. The `[2]` entry pins to `"3"` which is also correct. Only the `["1.23 - 1"]` entry was broken.