### PR TITLE
Tighten JumpProcesses OrdinaryDiffEqCore compat (v9.24–v9.26.0): require ≥ 3.17

### DIFF
--- a/J/JumpProcesses/WeakCompat.toml
+++ b/J/JumpProcesses/WeakCompat.toml
@@ -5,8 +5,11 @@ FastBroadcast = "0.3"
 Adapt = "4"
 KernelAbstractions = "0.9"
 
-["9.23.2 - 9.25"]
+["9.23.2"]
 OrdinaryDiffEqCore = "3"
 
+["9.24 - 9.25"]
+OrdinaryDiffEqCore = "3.17 - 3"
+
 ["9.26 - 9"]
-OrdinaryDiffEqCore = "3 - 4"
+OrdinaryDiffEqCore = "3.17 - 4"


### PR DESCRIPTION
Retroactive registry edit fixing a missing version bound in already-released JumpProcesses versions.

## The bug

JumpProcesses' weak extension `JumpProcessesOrdinaryDiffEqCoreExt` (added in v9.24.0 by SciML/JumpProcesses.jl@31ca00b1) imports `StochasticDiffEqAlgorithm` and `StochasticDiffEqRODEAlgorithm` from `OrdinaryDiffEqCore`. Those abstract types were only added in **OrdinaryDiffEqCore v3.17.0**.

The release-time `OrdinaryDiffEqCore` compat allowed:
- v9.24.0 – v9.25.1: `"3"`  → permits v3.0.x – v3.16.x
- v9.26.0: `"3 - 4"` → also permits v3.0.x – v3.16.x

When the resolver picks an older `OrdinaryDiffEqCore` (typically forced by an OrdinaryDiffEq-v6 / ModelingToolkit-v9 cascade pinning it to v3.1.x), the extension precompile dies:

```
UndefVarError: ` + '`StochasticDiffEqAlgorithm`' + ` not defined in ` + '`JumpProcessesOrdinaryDiffEqCoreExt`' + `
```

## What this does

`J/JumpProcesses/WeakCompat.toml`:

- v9.23.2 stays at `"3"` (the broken SDE imports were not yet present in that release).
- v9.24 – v9.25 tightened to `"3.17 - 3"`.
- v9.26 – v9 tightened to `"3.17 - 4"`.

## Reproductions

Confirmed in CI logs of SciML/SBMLToolkit.jl#199 (Julia 1.10 LTS and Julia 1.12) and SciML/SBMLToolkitTestSuite.jl#63 — in both, the resolver downgrades `OrdinaryDiffEqCore` v3.33.1 → v3.1.0 and the precompile then fails.

## Companion patch release

A patch bump JumpProcesses v9.26.1 with the equivalent Project.toml fix is in flight at SciML/JumpProcesses.jl. The registry edit is needed in addition because installed versions (v9.24.0, v9.25.0, v9.25.1, v9.26.0) are still in the wild and would otherwise continue pulling in the broken combination.

## Why no Compat.toml change

The `OrdinaryDiffEqCore` entry lives in `WeakCompat.toml` (it's a weak dependency for the package extension), not `Compat.toml`. No other entries need to change.