### PR TITLE
Narrow OrdinaryDiffEqDifferentiation 2.8 floor to OrdinaryDiffEqRosenbrock 1.30+

### DIFF
--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -117,14 +117,19 @@ OrdinaryDiffEqCore = "3"
 
 ["1.23 - 1"]
 DiffEqBase = "6.194.0 - 6"
-OrdinaryDiffEqDifferentiation = "2.8"
 SciMLBase = "2.116.0 - 2"
+
+["1.23 - 1.29"]
+OrdinaryDiffEqDifferentiation = "2"
 
 ["1.28 - 1"]
 RecursiveArrayTools = "3.52.0 - 3"
 
 ["1.28 - 2"]
 FastBroadcast = "1.3.0 - 1"
+
+["1.30 - 1"]
+OrdinaryDiffEqDifferentiation = "2.8"
 
 ["1.4 - 1.11"]
 ADTypes = "1.11.0-1"


### PR DESCRIPTION
## Summary

Follow-up to #154061. That PR raised `OrdinaryDiffEqDifferentiation` to `"2.8"` for the entire `OrdinaryDiffEqRosenbrock` `["1.23 - 1"]` range, but the OOP `calc_rosenbrock_differentiation` symbol that requires `OrdinaryDiffEqDifferentiation 2.8.0` is only **called** starting in `OrdinaryDiffEqRosenbrock 1.30.0`. Versions 1.23.0–1.29.0 only call the bang variant `calc_rosenbrock_differentiation!`, which is defined in every 2.x release of `OrdinaryDiffEqDifferentiation`.

This narrows the `"2.8"` floor to apply only to Rosenbrock 1.30+ and restores the original `"2"` floor for 1.23–1.29.

```diff
 ["1.23 - 1"]
 DiffEqBase = "6.194.0 - 6"
-OrdinaryDiffEqDifferentiation = "2.8"
 SciMLBase = "2.116.0 - 2"
+
+["1.23 - 1.29"]
+OrdinaryDiffEqDifferentiation = "2"
+
…
+["1.30 - 1"]
+OrdinaryDiffEqDifferentiation = "2.8"
```

`DiffEqBase` and `SciMLBase` floors are unchanged across the range, so they stay in the original `["1.23 - 1"]` block; only the `OrdinaryDiffEqDifferentiation` axis splits at the 1.29/1.30 boundary.

## Verification

OOP `calc_rosenbrock_differentiation` was introduced by [SciML/OrdinaryDiffEq.jl#3075](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3075) (commit `689d0b79`, 2026-04-11), which **adds** both the OOP definition (in `lib/OrdinaryDiffEqDifferentiation`) and three OOP call sites (in `lib/OrdinaryDiffEqRosenbrock`) — additive, not replacing the bang variant. The coordinated version-bump commit `dff8c622` shipped this as **Differentiation 2.8.0** + **Rosenbrock 1.30.0**, so the OOP call only exists from Rosenbrock 1.30.0 onwards.

`OrdinaryDiffEqDifferentiation 2.8.0` defines both the bang and OOP variants (additive change in #3075), so 1.23–1.29 callers (bang-only) are compatible with both `2` (pre-2.8) and `2.8+` of Differentiation. The narrower split preserves resolvability for downstream packages that pin Rosenbrock in 1.23–1.29 without weakening protection for 1.30+ where the OOP call actually exists.

## Impact

This affects downstream packages that pin `OrdinaryDiffEqRosenbrock` in the 1.23–1.29 range with combinations that are runtime-correct but newly unresolvable after #154061. [Pumas](https://github.com/PumasAI/Pumas.jl) had its CI broken on every shard at `Pkg.instantiate()` with `Unsatisfiable requirements detected for package OrdinaryDiffEqDifferentiation`, **and** an in-progress development release of Pumas became uninstallable for the same reason. This narrowing restores resolvability for both.

cc @DilumAluthge @ChrisRackauckas

---

This PR was prepared with the assistance of generative AI; the analysis (commit-walk on SciML/OrdinaryDiffEq.jl, identification of the introducing version) and the proposed split were AI-generated and human-reviewed.