### PR TITLE
[OrdinaryDiffEqRosenbrock] Unblock version range for OrdinaryDiffEqDifferentiation

### DIFF
--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -129,7 +129,7 @@ RecursiveArrayTools = "3.52.0 - 3"
 FastBroadcast = "1.3.0 - 1"
 
 ["1.30 - 1"]
-OrdinaryDiffEqDifferentiation = "2.8"
+OrdinaryDiffEqDifferentiation = "2.8 - 2"
 
 ["1.4 - 1.11"]
 ADTypes = "1.11.0-1"


### PR DESCRIPTION
xref https://github.com/JuliaRegistries/General/pull/154175/changes#r3162145204

Unblocks newer versions of OrdinaryDiffEqDifferentiation within the OrdinaryDiffEqRosenbrock package's compat. 