### PR TITLE
BlockTensorKit repository transfer

### DIFF
--- a/B/BlockTensorKit/Package.toml
+++ b/B/BlockTensorKit/Package.toml
@@ -1,3 +1,3 @@
 name = "BlockTensorKit"
 uuid = "5f87ffc2-9cf1-4a46-8172-465d160bd8cd"
-repo = "https://github.com/lkdvos/BlockTensorKit.jl.git"
+repo = "https://github.com/QuantumKitHub/BlockTensorKit.jl.git"


### PR DESCRIPTION
Moved the BlockTensorKit.jl repository to the QuantumKitHub organization, updated the link:

From [lkdvos](https://github.com/lkdvos/BlockTensorKit.jl.git) to [QuantumKitHub](https://github.com/QuantumKitHub/BlockTensorKit.jl.git). (although github of course auto-forwards the former to the latter)