### PR TITLE
Tighten BoundaryValueDiffEqMIRK/FIRK 1.13 Compat to require Core >= 2.2

### DIFF
--- a/B/BoundaryValueDiffEqFIRK/Compat.toml
+++ b/B/BoundaryValueDiffEqFIRK/Compat.toml
@@ -71,13 +71,14 @@ BoundaryValueDiffEqCore = "1.12.0 - 1"
 ["1.11 - 1"]
 DifferentiationInterface = "0.7"
 
-["1.11 - 1.13"]
+["1.11 - 1.12"]
 BoundaryValueDiffEqCore = "2"
 
 ["1.12 - 1"]
 PreallocationTools = ["0.4", "1"]
 
 ["1.13"]
+BoundaryValueDiffEqCore = "2.2.0 - 2"
 SciMLBase = "2.152.1 - 2"
 
 ["1.14"]

--- a/B/BoundaryValueDiffEqMIRK/Compat.toml
+++ b/B/BoundaryValueDiffEqMIRK/Compat.toml
@@ -86,13 +86,14 @@ BoundaryValueDiffEqCore = "1.12.0 - 1"
 ["1.11 - 1"]
 DifferentiationInterface = "0.7"
 
-["1.11 - 1.13"]
+["1.11 - 1.12"]
 BoundaryValueDiffEqCore = "2"
 
 ["1.12 - 1"]
 PreallocationTools = ["0.4", "1"]
 
 ["1.13"]
+BoundaryValueDiffEqCore = "2.2.0 - 2"
 SciMLBase = "2.152.1 - 2"
 
 ["1.14"]


### PR DESCRIPTION
## Summary

Retroactive Compat.toml fix for `BoundaryValueDiffEqMIRK` 1.13.0 and `BoundaryValueDiffEqFIRK` 1.13.0: tightens their `BoundaryValueDiffEqCore` lower bound from `"2"` to `"2.2.0 - 2"`.

These two versions call

```julia
__initial_guess_on_mesh(prob.u0, mesh, prob.p; tune_parameters = tune_parameters)
```

(`lib/BoundaryValueDiffEqMIRK/src/mirk.jl` line 77 and `lib/BoundaryValueDiffEqFIRK/src/firk.jl` lines 154, 324 in their respective tags). The `tune_parameters` keyword was only added to `__initial_guess_on_mesh` in `BoundaryValueDiffEqCore` 2.2.0 — Core 2.0.x and 2.1.x define the function without that kwarg.

The registered compat for `["1.11 - 1.13"]` was just `BoundaryValueDiffEqCore = "2"`, so when the resolver downgrades (for example when `OptimizationOptimJL` or `SymbolicAnalysis` is added to an environment that already has `DifferentialEquations` 7.17.0), it picks Core 2.1.0 alongside MIRK/FIRK 1.13.0 and precompilation fails:

```
✗ BoundaryValueDiffEqFIRK
✗ BoundaryValueDiffEqMIRK
✗ BoundaryValueDiffEq
✗ DifferentialEquations
```

with a `MethodError` on the `tune_parameters` keyword inside the precompile workload.

JuliaManifolds/Manifolds.jl#887 was merged to work around this on the Manifolds side (by forcing the resolver to keep Core ≥ 2.2 when Manifolds is present), but bare `DifferentialEquations` 7 environments — and any other env that pulls in MIRK/FIRK transitively — still hit the same break. Refs: SciML/DifferentialEquations.jl#1134, SciML/DifferentialEquations.jl#1136.

MIRK 1.11/1.12 and FIRK 1.11/1.12 only pass `tune_parameters` to `__extract_problem_details`, which has accepted that kwarg since Core 2.0.0, so they remain compatible with Core 2.0/2.1 and their compat row is left as `"2"`.

## Diff

```diff
 ["1.11 - 1"]
 DifferentiationInterface = "0.7"

-["1.11 - 1.13"]
+["1.11 - 1.12"]
 BoundaryValueDiffEqCore = "2"

 ["1.13"]
+BoundaryValueDiffEqCore = "2.2.0 - 2"
 SciMLBase = "2.152.1 - 2"
```

(applied identically to both `B/BoundaryValueDiffEqMIRK/Compat.toml` and `B/BoundaryValueDiffEqFIRK/Compat.toml`).

## Verification

- Inspected MIRK/FIRK source at tags `BoundaryValueDiffEqMIRK-v1.{11,12,13}.0` and `BoundaryValueDiffEqFIRK-v1.{11,12,13}.0`. Only the 1.13.0 tags pass `tune_parameters` to `__initial_guess_on_mesh`.
- Inspected `BoundaryValueDiffEqCore` source at tags `BoundaryValueDiffEqCore-v2.{0,1,2}.0`. The `tune_parameters` kwarg appears on `__initial_guess_on_mesh` first in 2.2.0; in 2.0.x / 2.1.x it is a positional-only signature.
- Tree hashes are unchanged; only Compat.toml is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)