### PR TITLE
HiddenMarkovModels.jl: Transfer HiddenMarkovModels from gdalle to JuliaStats

### DIFF
--- a/H/HiddenMarkovModels/Package.toml
+++ b/H/HiddenMarkovModels/Package.toml
@@ -1,3 +1,3 @@
 name = "HiddenMarkovModels"
 uuid = "84ca31d5-effc-45e0-bfda-5a68cd981f47"
-repo = "https://github.com/gdalle/HiddenMarkovModels.jl.git"
+repo = "https://github.com/JuliaStats/HiddenMarkovModels.jl.git"


### PR DESCRIPTION
I just transferred my package to the JuliaStats organization for secure long-term maintenance 