### PR TITLE
Move JuliaFormatter.jl to JuliaEditorSupport org

### DIFF
--- a/J/JuliaFormatter/Package.toml
+++ b/J/JuliaFormatter/Package.toml
@@ -1,3 +1,3 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-repo = "https://github.com/domluna/JuliaFormatter.jl.git"
+repo = "https://github.com/JuliaEditorSupport/JuliaFormatter.jl.git"


### PR DESCRIPTION
As title, see https://github.com/JuliaEditorSupport/JuliaFormatter.jl.