### PR TITLE
New version: DependencyAtlas v1.0.0

### DIFF
--- a/D/DependencyAtlas/Compat.toml
+++ b/D/DependencyAtlas/Compat.toml
@@ -1,6 +1,14 @@
 [0]
-HTTP = "1"
 JET = "0.11"
-JSON = "1"
 StaticLint = "9"
 julia = "1.12.0-1"
+
+[0-1]
+HTTP = "1"
+JSON = "1"
+
+[1]
+JET = ["0.9", "0.11"]
+JuliaSyntax = "1.0.2-1"
+PrecompileTools = "1.2.0-1"
+julia = "1.10.0-1"

--- a/D/DependencyAtlas/Deps.toml
+++ b/D/DependencyAtlas/Deps.toml
@@ -1,11 +1,17 @@
 [0]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+StaticLint = "b3cc710f-9c33-5bdb-a03d-a94903873e97"
+
+[0-1]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-StaticLint = "b3cc710f-9c33-5bdb-a03d-a94903873e97"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[1]
+JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"

--- a/D/DependencyAtlas/Versions.toml
+++ b/D/DependencyAtlas/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.0"]
 git-tree-sha1 = "fad9939e24c9cd7be3570b4551e457992adb8434"
+
+["1.0.0"]
+git-tree-sha1 = "ed6e488d30ca8287d37d368dcd4dede5afb9542d"


### PR DESCRIPTION
Release notes:

DependencyAtlas v1.0.0 is a major release.

Breaking / major changes:
- The default analysis path is now DepAtlasSource-only.
- The source parser was migrated from the previous in-project parser to JuliaSyntax.
- JET moved from automatic whole-project enrichment to on-demand method-level views.
- StaticLint was removed from the active analysis pipeline.

Changelog:
https://codeberg.org/karei/DependencyAtlas.jl/src/branch/master/changelog.md
