### PR TITLE
SOFA.jl: Update repo URL (after repo move to JuliaAstro org)

### DIFF
--- a/S/SOFA/Package.toml
+++ b/S/SOFA/Package.toml
@@ -1,3 +1,3 @@
 name = "SOFA"
 uuid = "ad3d3fd0-b5f2-51ee-b274-8cdbe62317e2"
-repo = "https://github.com/sisl/SOFA.jl.git"
+repo = "https://github.com/JuliaAstro/SOFA.jl.git"


### PR DESCRIPTION
SOFA.jl now lives under the JuliaAstro umbrella. Thanks!