### PR TITLE
Retroactive compat: cap OrdinaryDiffEqSDIRK at <2.4 in OrdinaryDiffEqBDF v2.0.0/v2.1.0

### DIFF
--- a/O/OrdinaryDiffEqBDF/Compat.toml
+++ b/O/OrdinaryDiffEqBDF/Compat.toml
@@ -141,5 +141,8 @@ SciMLBase = "3"
 ["2.0"]
 OrdinaryDiffEqCore = "4"
 
+["2.0 - 2.1.0"]
+OrdinaryDiffEqSDIRK = "2.0 - 2.3"
+
 ["2.1 - 2"]
 OrdinaryDiffEqCore = "4.1.0 - 4"


### PR DESCRIPTION
## Summary

Retroactively caps `OrdinaryDiffEqSDIRK` to `2.0 - 2.3` for the previously-registered `OrdinaryDiffEqBDF` versions `v2.0.0` and `v2.1.0`.

`OrdinaryDiffEqSDIRK v2.4.0` (CFNLIRK3 migrated to IMEX tableau form, unified error estimation, `@generated perform_step!`) introduced changes that break the `ImplicitEulerCache` cross-package contract relied on by the older BDF v2 caches. `OrdinaryDiffEqBDF v2.1.1` was bumped together with SDIRK v2.4.0 in the same release commit (SciML/OrdinaryDiffEq.jl@1e8760a2) and is known to work, so it keeps the open `"2"` compat.

Diff:
```toml
+["2.0 - 2.1.0"]
+OrdinaryDiffEqSDIRK = "2.0 - 2.3"
```

The existing `[2]` block still carries `OrdinaryDiffEqSDIRK = "2"`; Pkg intersects the two, so BDF `2.0.0`/`2.1.0` resolve to `[2.0.0, 2.4.0)` while `2.1.1` stays at `[2.0.0, 3.0.0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)