### PR TITLE
Retroactive compat: cap OrdinaryDiffEqSDIRK at <2.4 in OrdinaryDiffEqBDF v2.0.0/v2.1.0

### DIFF
--- a/O/OrdinaryDiffEqBDF/Compat.toml
+++ b/O/OrdinaryDiffEqBDF/Compat.toml
@@ -134,12 +134,17 @@ Reexport = "1.2.0 - 1"
 DiffEqBase = "7"
 OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqNonlinearSolve = "2"
-OrdinaryDiffEqSDIRK = "2"
 RecursiveArrayTools = "4"
 SciMLBase = "3"
 
 ["2.0"]
 OrdinaryDiffEqCore = "4"
 
+["2.0 - 2.1.0"]
+OrdinaryDiffEqSDIRK = "2.0 - 2.3"
+
 ["2.1 - 2"]
 OrdinaryDiffEqCore = "4.1.0 - 4"
+
+["2.1.1 - 2"]
+OrdinaryDiffEqSDIRK = "2"


### PR DESCRIPTION
## Summary

Retroactively caps `OrdinaryDiffEqSDIRK` to `2.0 - 2.3` for the previously-registered `OrdinaryDiffEqBDF` versions `v2.0.0` and `v2.1.0`.

`OrdinaryDiffEqSDIRK v2.4.0` (CFNLIRK3 migrated to IMEX tableau form, unified error estimation, `@generated perform_step!`) introduced changes that break the `ImplicitEulerCache` cross-package contract relied on by the older BDF v2 caches. `OrdinaryDiffEqBDF v2.1.1` was bumped together with SDIRK v2.4.0 in the same release commit (SciML/OrdinaryDiffEq.jl@1e8760a2) and is known to work, so it keeps the open compat to `"2"`.

Diff:
```toml
 [2]
 DiffEqBase = "7"
 OrdinaryDiffEqDifferentiation = "3"
 OrdinaryDiffEqNonlinearSolve = "2"
-OrdinaryDiffEqSDIRK = "2"
 RecursiveArrayTools = "4"
 SciMLBase = "3"

+["2.0 - 2.1.0"]
+OrdinaryDiffEqSDIRK = "2.0 - 2.3"
+
+["2.1.1 - 2"]
+OrdinaryDiffEqSDIRK = "2"
```

`OrdinaryDiffEqSDIRK` is pulled out of the `[2]` block and re-introduced as two disjoint per-version blocks, so RegistryCI's consistency check (which requires each `(dep, version)` to be covered by exactly one block) is satisfied. Net resolution: BDF `2.0.0`/`2.1.0` → SDIRK `[2.0.0, 2.4.0)`, BDF `2.1.1` → SDIRK `[2.0.0, 3.0.0)`.

Supersedes #155941 (same intent; that PR's overlapping-ranges form failed the consistency check).

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)