### PR TITLE
Change  location of TensorCategories.jl

### DIFF
--- a/T/TensorCategories/Package.toml
+++ b/T/TensorCategories/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorCategories"
 uuid = "258c694e-7338-4d4d-b524-4851272a75cf"
-repo = "https://github.com/TensorCategories/TensorCategories.jl"
+repo = "https://github.com/TensorCategories/TensorCategories.jl.git"

--- a/T/TensorCategories/Package.toml
+++ b/T/TensorCategories/Package.toml
@@ -1,3 +1,3 @@
 name = "TensorCategories"
 uuid = "258c694e-7338-4d4d-b524-4851272a75cf"
-repo = "https://github.com/FabianMaeurer/TensorCategories.jl.git"
+repo = "https://github.com/TensorCategories/TensorCategories.jl"


### PR DESCRIPTION
The repository for TensorCatgegories.jl was moved to an organization and hence the repo address should be updated