### PR TITLE
Update url of VectorInterface.jl

### DIFF
--- a/V/VectorInterface/Package.toml
+++ b/V/VectorInterface/Package.toml
@@ -1,3 +1,3 @@
 name = "VectorInterface"
 uuid = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
-repo = "https://github.com/Jutho/VectorInterface.jl.git"
+repo = "https://github.com/QuantumKitHub/VectorInterface.jl.git"


### PR DESCRIPTION
This has moved to https://github.com/QuantumKitHub/VectorInterface.jl