### PR TITLE
TruncatedDistributions: update repo URL to Distribution-Matching org

### DIFF
--- a/T/TruncatedDistributions/Package.toml
+++ b/T/TruncatedDistributions/Package.toml
@@ -1,3 +1,3 @@
 name = "TruncatedDistributions"
 uuid = "77af390e-3af4-4cd8-bbfa-7ab7569c172d"
-repo = "https://github.com/yoninazarathy/TruncatedDistributions.jl.git"
+repo = "https://github.com/Distribution-Matching/TruncatedDistributions.jl.git"


### PR DESCRIPTION
The TruncatedDistributions.jl repo has been transferred from
`yoninazarathy/TruncatedDistributions.jl` to
`Distribution-Matching/TruncatedDistributions.jl`. Updating the
registered `repo` field so JuliaRegistrator can pick up subsequent
versions from the new location.

* UUID unchanged: `77af390e-3af4-4cd8-bbfa-7ab7569c172d`
* Existing tag `v0.1.0` is reachable at the new URL via GitHub's
  transfer redirect (GitHub also preserves all SHAs).
* I'll trigger JuliaRegistrator for `v0.2.0` from the new location once
  this lands.