### PR TITLE
Update OAuth.jl repository URL

### DIFF
--- a/O/OAuth/Package.toml
+++ b/O/OAuth/Package.toml
@@ -1,3 +1,3 @@
 name = "OAuth"
 uuid = "22d8b318-f366-56fb-a292-a93f7d76c017"
-repo = "https://github.com/randyzwitch/OAuth.jl.git"
+repo = "https://github.com/JuliaServices/OAuth.jl.git"


### PR DESCRIPTION
OAuth.jl was transferred to JuliaServices. Registrator cannot register OAuth v2.0.0 until the registry package repo URL points at the current repository.

This updates only the package repo URL; UUID and package name are unchanged.