### PR TITLE
Update CIMOptimizer.jl repository URL

### DIFF
--- a/C/CIMOptimizer/Package.toml
+++ b/C/CIMOptimizer/Package.toml
@@ -1,3 +1,3 @@
 name = "CIMOptimizer"
 uuid = "f763a312-2f8b-4ea4-ad8b-371148ce3a7b"
-repo = "https://github.com/pedromxavier/CIMOptimizer.jl.git"
+repo = "https://github.com/JuliaQUBO/CIMOptimizer.jl.git"


### PR DESCRIPTION
Updates CIMOptimizer's registered repository URL from the former personal repository to the current JuliaQUBO organization repository.

This is needed before registering CIMOptimizer.jl v0.2.0 because Registrator rejects releases when the package repo URL changes without an explicit registry PR.