### PR TITLE
PlutoStaticHTML.jl: Update repository URL

### DIFF
--- a/P/PlutoStaticHTML/Package.toml
+++ b/P/PlutoStaticHTML/Package.toml
@@ -1,3 +1,3 @@
 name = "PlutoStaticHTML"
 uuid = "359b1769-a58e-495b-9770-312e911026ad"
-repo = "https://github.com/rikhuijzer/PlutoStaticHTML.jl.git"
+repo = "https://github.com/JuliaPluto/PlutoStaticHTML.jl.git"


### PR DESCRIPTION
`PlutoStaticHTML.jl` has moved from https://github.com/rikhuijzer/PlutoStaticHTML.jl to https://github.com/JuliaPluto/PlutoStaticHTML.jl as discussed in https://github.com/JuliaPluto/PlutoStaticHTML.jl/issues/222.