### PR TITLE
Update CIMOptimizer repo URL

### DIFF
--- a/C/CIMOptimizer/Package.toml
+++ b/C/CIMOptimizer/Package.toml
@@ -1,3 +1,3 @@
 name = "CIMOptimizer"
 uuid = "f763a312-2f8b-4ea4-ad8b-371148ce3a7b"
-repo = "https://github.com/pedromxavier/CIMOptimizer.jl.git"
+repo = "https://github.com/JuliaQUBO/CIMOptimizer.jl.git"


### PR DESCRIPTION
Update the registered repository URL for CIMOptimizer.jl after the package moved to JuliaQUBO.

This is needed before registering CIMOptimizer v0.2.0 from https://github.com/JuliaQUBO/CIMOptimizer.jl, because Registrator currently rejects the registration with:

`Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry.`
