### PR TITLE
New version: PySA v0.3.6

### DIFF
--- a/P/PySA/Versions.toml
+++ b/P/PySA/Versions.toml
@@ -24,3 +24,6 @@ git-tree-sha1 = "061f1f0e4c07896e8554f1b6b9f14a7d9bed29b3"
 
 ["0.3.5"]
 git-tree-sha1 = "ffac09d4d65beb3db656460592485142ff7c992f"
+
+["0.3.6"]
+git-tree-sha1 = "f6b574e8cc0071862e32b380ff94d0e25bfd2d15"


### PR DESCRIPTION
Manual registration fallback because JuliaRegistrator did not respond to the source repository commit comments.

- Registering package: PySA
- Repository: https://github.com/JuliaQUBO/PySA.jl
- Version: v0.3.6
- Commit: 14f6c89d1112cac54205c000dc2a63873d0c5422
- Tree: f6b574e8cc0071862e32b380ff94d0e25bfd2d15
- Reference: https://github.com/JuliaQUBO/PySA.jl/commit/14f6c89d1112cac54205c000dc2a63873d0c5422#commitcomment-187572340

Release notes:

## PySA v0.3.6

- Add Dependabot maintenance configuration for Julia dependencies and GitHub Actions.
- Refresh GitHub Actions dependencies and run CI on `main` pushes.
- Add a README CI badge and upload the generated coverage report as a workflow artifact.
