### PR TITLE
Cap GPUCompiler compat of Metal 1.5-1.9 at 1.15

### DIFF
--- a/M/Metal/Compat.toml
+++ b/M/Metal/Compat.toml
@@ -124,7 +124,7 @@ UUIDs = "1"
 
 ["1.5 - 1.6.1"]
 CodecBzip2 = "0.8.5-0.8"
-GPUCompiler = ["0.26-0.27", "1"]
+GPUCompiler = ["0.26-0.27", "1 - 1.15"]
 
 ["1.5.0"]
 GPUArrays = "11.1.0-11"
@@ -157,7 +157,7 @@ GPUToolbox = "0.1 - 0.2"
 KernelAbstractions = "0.9.1 - 0.9"
 
 ["1.6.2 - 1.8"]
-GPUCompiler = ["0.26 - 0.27", "1"]
+GPUCompiler = ["0.26 - 0.27", "1 - 1.15"]
 
 ["1.7 - 1"]
 KernelAbstractions = "0.9.38 - 0.9"
@@ -170,6 +170,6 @@ BFloat16s = "0.5 - 0.6"
 GPUToolbox = ["0.1 - 0.3", "1"]
 
 ["1.9 - 1"]
-GPUCompiler = "1.7.1 - 1"
+GPUCompiler = "1.7.1 - 1.15"
 Random123 = "1.7.1 - 1"
 RandomNumbers = "1.6.0 - 1"


### PR DESCRIPTION
GPUCompiler 1.16 (JuliaGPU/GPUCompiler.jl#821) started lowering llvm.ctlz/llvm.cttz to air.clz/air.ctz using the 2-operand form emitted by Apple's frontend (value + i1 is_zero_undef). Released Metal.jl versions still provide device overrides that ccall the same intrinsics in their 1-operand form, so kernels reaching both sources put two signatures behind one symbol, failing to compile or miscompiling (JuliaGPU/GPUCompiler.jl#832). The overrides were removed on Metal.jl master (JuliaGPU/Metal.jl#801), whose next release requires GPUCompiler 1.17; retro-cap released versions to 1.15.

Supersedes https://github.com/JuliaGPU/GPUCompiler.jl/pull/832