### PR TITLE
Update `BioChemicalTreatment` URL to post-rename repo

### DIFF
--- a/B/BioChemicalTreatment/Package.toml
+++ b/B/BioChemicalTreatment/Package.toml
@@ -1,3 +1,3 @@
 name = "BioChemicalTreatment"
 uuid = "c4b0d576-2c18-480d-8459-22152dbbf5e0"
-repo = "https://gitlab.com/datinfo/BioChemicalTreatment.jl.git"
+repo = "https://gitlab.com/datinfo/Thetis.jl.git"


### PR DESCRIPTION
The repo was renamed due to the scope of the package exceeding BioChemicalTreatment processes, which the name suggests.