### PR TITLE
Update SymbolicIntegrationMaxima source

### DIFF
--- a/S/SymbolicIntegrationMaxima/Package.toml
+++ b/S/SymbolicIntegrationMaxima/Package.toml
@@ -1,3 +1,4 @@
 name = "SymbolicIntegrationMaxima"
 uuid = "6f8f0c92-4498-4b29-a8cc-7d11f58db8c9"
-repo = "https://github.com/Amin-El-Sayed/SymbolicIntegrationMaxima.jl.git"
+repo = "https://github.com/JuliaSymbolics/SymbolicIntegration.jl.git"
+subdir = "lib/SymbolicIntegrationMaxima"

--- a/S/SymbolicIntegrationMaxima/Versions.toml
+++ b/S/SymbolicIntegrationMaxima/Versions.toml
@@ -1,2 +1,2 @@
 ["0.1.1"]
-git-tree-sha1 = "a371364d456c6240eda6e1f6b8f853c329e1f02f"
+git-tree-sha1 = "8e20df7e10f36285837af89f2cc9b56a4181ccde"


### PR DESCRIPTION
Updates the `SymbolicIntegrationMaxima` registry metadata after the package moved into `JuliaSymbolics/SymbolicIntegration.jl` as the `lib/SymbolicIntegrationMaxima` subpackage.

This changes:
- `repo` to `https://github.com/JuliaSymbolics/SymbolicIntegration.jl.git`
- adds `subdir = "lib/SymbolicIntegrationMaxima"`

The package UUID and registered versions are unchanged.