### PR TITLE
[Reactant] Fix compat with ReactantCore

### DIFF
--- a/R/Reactant/Compat.toml
+++ b/R/Reactant/Compat.toml
@@ -562,7 +562,6 @@ Preferences = "1.4.3 - 1"
 PrettyTables = "3.1.2 - 3"
 ProtoBuf = "1.3.0 - 1"
 Random = "1.10.0 - 1"
-ReactantCore = "0.1.18 - 0.1"
 ScopedValues = "1.3.0 - 1"
 Scratch = "1.3.0 - 1"
 Serialization = "1.10.0 - 1"
@@ -583,6 +582,7 @@ HTTP = "1.10.15 - 1"
 ["0.2.255 - 0.2.264"]
 Enzyme = "0.13.104 - 0.13"
 OrderedCollections = "1.1.0 - 1"
+ReactantCore = "0.1.18 - 0.1"
 
 ["0.2.256 - 0.2.259"]
 Reactant_jll = "0.0.376"
@@ -612,6 +612,7 @@ GPUCompiler = "1.8.1 - 1"
 Enzyme = "0.13.115 - 0.13"
 GPUCompiler = "1.17.0 - 1"
 OrderedCollections = "1.1.0 - 2"
+ReactantCore = "0.1.20 - 0.1"
 Reactant_jll = "0.0.385"
 
 ["0.2.27 - 0"]


### PR DESCRIPTION
[Reactant@0.2.265 effectively requires ReactantCore@0.1.20](https://github.com/EnzymeAD/Reactant.jl/pull/2972), but when that was released ReactantCore@0.1.20 was actually not released yet and the compat bound wasn't updated accordingly. [ReactantCore@0.1.20 is now out](https://github.com/JuliaRegistries/General/pull/157838) and this change is reflecting the real compat bound.

CC @pangoraw @wsmoses for your information.