### PR TITLE
Update repo URL for TruncatedDistributions.jl (transferred to Distribution-Matching org)

### DIFF
--- a/T/TruncatedDistributions/Package.toml
+++ b/T/TruncatedDistributions/Package.toml
@@ -1,3 +1,3 @@
 name = "TruncatedDistributions"
 uuid = "77af390e-3af4-4cd8-bbfa-7ab7569c172d"
-repo = "https://github.com/yoninazarathy/TruncatedDistributions.jl.git"
+repo = "https://github.com/Distribution-Matching/TruncatedDistributions.jl.git"


### PR DESCRIPTION
This updates the `repo` URL in `T/TruncatedDistributions/Package.toml`.

The package `TruncatedDistributions` (UUID `77af390e-3af4-4cd8-bbfa-7ab7569c172d`) has been transferred from the original author's personal account to the **Distribution-Matching** organization:

- old: `https://github.com/yoninazarathy/TruncatedDistributions.jl.git`
- new: `https://github.com/Distribution-Matching/TruncatedDistributions.jl.git`

Both the original account (`yoninazarathy`, package author) and the `Distribution-Matching` organization are controlled by the same owner. This PR is opened from the `yoninazarathy` account.

Registration of the next release (v0.3.0) is currently blocked: JuliaRegistrator returns *"Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry and retry."* This PR is that URL change; once merged we'll re-run the registrator.

Only the `repo =` line changes; `name` and `uuid` are unchanged.