### PR TITLE
New version: SuperLU_DIST_jll v9.2.1+1

### DIFF
--- a/jll/S/SuperLU_DIST_jll/Compat.toml
+++ b/jll/S/SuperLU_DIST_jll/Compat.toml
@@ -48,7 +48,7 @@ TOML = ["0.0.0", "1"]
 ["8.2.3-9"]
 MPICH_jll = "5.0.1-5"
 MPItrampoline_jll = "5.5.6-5"
-OpenBLAS32_jll = "0.3.33-0.3"
+OpenBLAS32_jll = "0.3.32-0.3"
 OpenMPI_jll = ["4.1.9-4", "5.0.11-5"]
 
 [9]

--- a/jll/S/SuperLU_DIST_jll/Versions.toml
+++ b/jll/S/SuperLU_DIST_jll/Versions.toml
@@ -21,3 +21,6 @@ git-tree-sha1 = "d87e967f1c184edacfd5037a237ad7277a1bdc4e"
 
 ["9.2.1+0"]
 git-tree-sha1 = "eaa2ff81aac161cfb5adf7ce3a013698bc6dc938"
+
+["9.2.1+1"]
+git-tree-sha1 = "6e0e6b348c28219369fa1bcbf49441fa5921718e"


### PR DESCRIPTION
Registers `SuperLU_DIST_jll` v9.2.1+1 (the per-integer-width header copies build from JuliaPackaging/Yggdrasil#13947) and, in the same change, broadens the 9.2.1 `OpenBLAS32_jll` compat floor from `0.3.33-0.3` to `0.3.32-0.3`.

The Yggdrasil recipe had to lower the OpenBLAS32_jll bound to 0.3.32 (the in-sysimage libblastrampoline_jll 5.4.0 only supports OpenBLAS32 0.3.9–0.3.32). The Registrator PR #158181 put that bound in the `[9]` section while 9.2.1+0 kept `0.3.33-0.3` in `["8.2.3-9"]`; since build metadata (+0/+1) is not distinguishable by version ranges, both ranges covered 9.2.1 and tripped the registry consistency check (`Overlapping ranges for OpenBLAS32_jll ... for version 9.2.1+0`).

Unifying both builds onto a single `OpenBLAS32_jll = "0.3.32-0.3"` entry (a compat broadening; 0.3.32↔0.3.33 are ABI-compatible) removes the overlap.

Supersedes #158181.