### PR TITLE
Update XML.jl repo URL → JuliaData (org transfer)

### DIFF
--- a/X/XML/Package.toml
+++ b/X/XML/Package.toml
@@ -1,3 +1,3 @@
 name = "XML"
 uuid = "72c71f33-b9b6-44de-8c94-c961784809e2"
-repo = "https://github.com/JuliaComputing/XML.jl.git"
+repo = "https://github.com/JuliaData/XML.jl.git"


### PR DESCRIPTION
XML.jl moved from JuliaComputing to JuliaData (the old URL redirects to the new, confirming it's the same package). This updates the registered `repo` so new versions can register — v0.3.9 is currently blocked. cc @quinnj @ViralBShah to confirm the transfer.