### PR TITLE
Retroactive compat: cap OrdinaryDiffEqBDF 2.1.0-2.2.0 to OrdinaryDiffEqCore < 4.4

### DIFF
--- a/O/OrdinaryDiffEqBDF/Compat.toml
+++ b/O/OrdinaryDiffEqBDF/Compat.toml
@@ -147,8 +147,8 @@ SciMLBase = "3"
 ["2.0"]
 OrdinaryDiffEqCore = "4"
 
-["2.1 - 2"]
-OrdinaryDiffEqCore = "4.1.0 - 4"
+["2.1 - 2.2.0"]
+OrdinaryDiffEqCore = "4.1.0 - 4.3"
 
 ["2.1.1 - 2.1"]
 OrdinaryDiffEqSDIRK = "2"
@@ -159,6 +159,7 @@ OrdinaryDiffEqSDIRK = "2.5.0 - 2"
 ["2.2.1 - 2"]
 ADTypes = "1.22.0 - 1"
 MuladdMacro = "0.2.1 - 0.2"
+OrdinaryDiffEqCore = "4.1.0 - 4"
 PrecompileTools = "1.2.1 - 1"
 Preferences = "1.5.0 - 1"
 RecursiveArrayTools = "4.2.0 - 4"


### PR DESCRIPTION
Retroactive compat-only change (no new version registered).

### What

Cap `OrdinaryDiffEqBDF` **2.1.0, 2.1.1, 2.2.0** to `OrdinaryDiffEqCore = "4.1.0 - 4.3"` (i.e. exclude `OrdinaryDiffEqCore 4.4`). `OrdinaryDiffEqBDF 2.2.1` keeps `OrdinaryDiffEqCore = "4.1.0 - 4"` because it is compatible with 4.4.

```diff
-["2.1 - 2"]
-OrdinaryDiffEqCore = "4.1.0 - 4"
+["2.1 - 2.2.0"]
+OrdinaryDiffEqCore = "4.1.0 - 4.3"
```
```diff
 ["2.2.1 - 2"]
 ADTypes = "1.22.0 - 1"
 MuladdMacro = "0.2.1 - 0.2"
+OrdinaryDiffEqCore = "4.1.0 - 4"
 ...
```

### Why

`OrdinaryDiffEqCore 4.4.0` changed the `setup_controller_cache` extension interface: its `solve` now calls the 5-argument form (`setup_controller_cache(alg, cache, controller, EEstT, disco_probs)`). `OrdinaryDiffEqBDF` 2.1.0/2.1.1/2.2.0 only define the 4-argument method:

```julia
function setup_controller_cache(alg::Union{QNDF, FBDF, DFBDF}, cache, controller::BDFController, ::Type{E}) where {E}
```

Because those BDF versions carry `OrdinaryDiffEqCore = "4.1.0 - 4"`, the resolver may pair them with `OrdinaryDiffEqCore 4.4.0`, which then fails to precompile:

```
MethodError: no method matching setup_controller_cache(::OrdinaryDiffEqBDF.FBDF{…},
    ::OrdinaryDiffEqBDF.FBDFCache{…}, ::OrdinaryDiffEqBDF.BDFController{…},
    ::Type{Float64}, ::Vector{SciMLBase.IntervalNonlinearProblem})
```

This bricks `using OrdinaryDiffEq`. Upstream report: SciML/OrdinaryDiffEq.jl#3775.

The matching `OrdinaryDiffEqBDF 2.2.1` (which adds the 5-arg method) was registered ~1 h after `OrdinaryDiffEqCore 4.4.0`, so a Manifest resolved in that window — or one pinned to BDF ≤ 2.2.0 — hits the broken combination. This compat cap makes the resolver avoid it permanently.

### Verification

Reproduced locally on Julia 1.11:
- `OrdinaryDiffEqBDF 2.2.0` + `OrdinaryDiffEqCore 4.4.0` → precompile fails with the exact `MethodError` above.
- `OrdinaryDiffEqBDF 2.2.1` + `OrdinaryDiffEqCore 4.4.0` → precompiles and loads cleanly.
- 2.1.0/2.1.1 carry the identical 4-arg `setup_controller_cache` signature as 2.2.0.

Source-side floor bumps for the go-forward direction are already merged in SciML/OrdinaryDiffEq.jl#3774 (BDF → 2.2.2 with `OrdinaryDiffEqCore = "4.4"`). This PR closes the reverse direction for the already-registered versions.