### PR TITLE
Update repository URL for RegionTrees after moving to JuliaGeometry org

### DIFF
--- a/R/RegionTrees/Package.toml
+++ b/R/RegionTrees/Package.toml
@@ -1,3 +1,3 @@
 name = "RegionTrees"
 uuid = "dee08c22-ab7f-5625-9660-a9af2021b33f"
-repo = "https://github.com/rdeits/RegionTrees.jl.git"
+repo = "https://github.com/JuliaGeometry/RegionTrees.jl.git"


### PR DESCRIPTION
The repo was moved in 2024 (details in https://github.com/JuliaGeometry/RegionTrees.jl/issues/44), but no release have been made since. I am making this PR ahead of new releases of the package.