### PR TITLE
fix: clean registry before update to avoid 'registry dirty' error

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -78,6 +78,9 @@ jobs:
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.rm("General"); Pkg.Registry.add("General")'
+        env:
+          JULIA_PKG_SERVER: ""
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'
       - run: .ci/instantiate.sh .ci/
       - run: julia --color=yes --project=.ci/ -e 'import Pkg; Pkg.precompile()'
@@ -163,6 +166,9 @@ jobs:
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.rm("General"); Pkg.Registry.add("General")'
+        env:
+          JULIA_PKG_SERVER: ""
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'
       - run: .ci/instantiate.sh .ci/
       - run: julia --color=yes --project=.ci/ -e 'import Pkg; Pkg.precompile()'
@@ -223,6 +229,9 @@ jobs:
       - run: chmod 400 .ci/Project.toml
       - run: chmod 400 .ci/Manifest.toml
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.add("General")'
+        env:
+          JULIA_PKG_SERVER: ""
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.rm("General"); Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'

--- a/.github/workflows/automerge_staging.yml
+++ b/.github/workflows/automerge_staging.yml
@@ -61,6 +61,9 @@ jobs:
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.rm("General"); Pkg.Registry.add("General")'
+        env:
+          JULIA_PKG_SERVER: ""
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'
       - run: .ci/instantiate.sh .ci/AutoMerge/
       - run: |
@@ -123,6 +126,9 @@ jobs:
       - name: Cache artifacts
         uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.add("General")'
+        env:
+          JULIA_PKG_SERVER: ""
+      - run: julia --color=yes -e 'import Pkg; Pkg.Registry.rm("General"); Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
       - run: julia --color=yes -e 'import Pkg; Pkg.Registry.update()'


### PR DESCRIPTION
## Problem

The AutoMerge and AutoMerge (staging) workflows are failing with:
```
Error: Some registries failed to update:
— /tmp/jl_*/registries/General — registry dirty
```

This affects all jobs that call `Pkg.Registry.update()` after installing the General registry via git.

## Fix

Insert a cleanup step `Pkg.Registry.rm(General); Pkg.Registry.add(General)` (with `JULIA_PKG_SERVER: ""`) before every `Pkg.Registry.update()` call. This removes the stale git-based registry and reinstalls it using the tarball format, as recommended by Julia.

## Files changed

- `.github/workflows/automerge.yml` — 3 jobs: `AutoMerge-regular`, `AutoMerge-label`, `AutoMerge-stopwatch`
- `.github/workflows/automerge_staging.yml` — 2 jobs: `AutoMerge_staging-regular`, `AutoMerge_staging-label`