### PR TITLE
UnicodePlots: widen Unitful compat on 2.9 - 3.8.0

### DIFF
--- a/U/UnicodePlots/Compat.toml
+++ b/U/UnicodePlots/Compat.toml
@@ -50,7 +50,7 @@ NaNMath = "0.3"
 NaNMath = ["0.3", "1"]
 
 ["2.9 - 3.3"]
-Unitful = "1.6"
+Unitful = "1.6.0 - 1"
 
 [3]
 StaticArrays = "1"

--- a/U/UnicodePlots/WeakCompat.toml
+++ b/U/UnicodePlots/WeakCompat.toml
@@ -4,7 +4,7 @@ FreeType = "4"
 ImageInTerminal = "0.5"
 
 ["3.4 - 3.8.0"]
-Unitful = "1.6"
+Unitful = "1.6.0 - 1"
 
 ["3.6.1 - 3"]
 IntervalSets = "0.7"


### PR DESCRIPTION
UnicodePlots 2.9 - 3.8.0 uses `Unitful.RealOrRealQuantity`, added in
Unitful 1.6 (JuliaPhysics/Unitful.jl#421), so its Unitful compat needs a
floor of 1.6. That floor was added in #150490 as `Unitful = "1.6"`
(context in JuliaPlots/UnicodePlots.jl#430 and JuliaPlots/UnicodePlots.jl#431).

As a registry version range, `"1.6"` covers only the 1.6.x series, which
caps Unitful below 1.7 and leaves these versions unresolvable against
current Unitful releases. Set `Unitful = "1.6.0 - 1"` for the intended
[1.6.0, 2.0.0) range. Applies to both the strong compat (2.9 - 3.3) and
the weak/extension compat (3.4 - 3.8.0).

---

Authored by Claude.
