### PR TITLE
Yank SciMLBase 3.32.0

### DIFF
--- a/S/SciMLBase/Versions.toml
+++ b/S/SciMLBase/Versions.toml
@@ -1610,3 +1610,4 @@ git-tree-sha1 = "a4a3caa5612dcd4ff0925a98b3820654c663cd9c"
 
 ["3.32.0"]
 git-tree-sha1 = "199471538ab02e0c279758b1395c62aef9443f50"
+yanked = true


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Mark SciMLBase v3.32.0 as yanked in the General registry.
- Leave all other SciMLBase versions unchanged.

## Reason
SciMLBase v3.32.0 is the bad release identified from the FunctionProperties extension regression, and a replacement release is now available outside this yanked version.

## Verification
- `git diff --check`
- `/home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no -e 'using TOML; TOML.parsefile("S/SciMLBase/Versions.toml"); println("S/SciMLBase/Versions.toml parsed")'`\n