### PR TITLE
Retrocap OrdinaryDiffEqRosenbrock/Extrapolation vs OrdinaryDiffEqDifferentiation ≥ 3.2.3

### DIFF
--- a/O/OrdinaryDiffEqExtrapolation/Compat.toml
+++ b/O/OrdinaryDiffEqExtrapolation/Compat.toml
@@ -104,6 +104,11 @@ OrdinaryDiffEqCore = "1.29.0 - 1"
 
 [2]
 DiffEqBase = "7"
+
+["2 - 2.2.2"]
+OrdinaryDiffEqDifferentiation = "3 - 3.2.2"
+
+["2.3 - 2"]
 OrdinaryDiffEqDifferentiation = "3"
 
 ["2 - 2.1"]

--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -168,7 +168,7 @@ OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqRosenbrockTableaus = "2"
 
 ["2 - 2.3.0"]
-OrdinaryDiffEqDifferentiation = "3"
+OrdinaryDiffEqDifferentiation = "3 - 3.2.2"
 RecursiveArrayTools = "4"
 SciMLBase = "3"
 
@@ -183,12 +183,17 @@ ADTypes = "1.22.0 - 1"
 DifferentiationInterface = "0.7.18 - 0.7"
 ForwardDiff = "1.3.3 - 1"
 MuladdMacro = "0.2.1 - 0.2"
-OrdinaryDiffEqDifferentiation = "3.2.1 - 3"
 PrecompileTools = "1.2.1 - 1"
 Preferences = "1.5.0 - 1"
 RecursiveArrayTools = "4.2.0 - 4"
 Reexport = "1.2.2 - 1"
 SciMLBase = "3.10.0 - 3"
+
+["2.3.1 - 2.3.2"]
+OrdinaryDiffEqDifferentiation = "3.2.1 - 3.2.2"
+
+["2.4 - 2"]
+OrdinaryDiffEqDifferentiation = "3.2.1 - 3"
 
 ["2.3.2 - 2"]
 LinearSolve = "3.75.0 - 4"


### PR DESCRIPTION
> [!NOTE]
> Please do not merge until reviewed by @ChrisRackauckas. Opened as draft.

## Summary

Cap `OrdinaryDiffEqDifferentiation` at `3.2.2` (i.e. `< 3.2.3`) for the **broken** registered solver versions, while leaving the **fixed** TagBot releases free to take 3.2.3+:

| Package | Broken (capped) | Fixed (not capped) |
|---------|-----------------|--------------------|
| `OrdinaryDiffEqRosenbrock` | `2.0.0` – `2.3.2` | `2.4.0` (#160462) |
| `OrdinaryDiffEqExtrapolation` | `2.0.0` – `2.2.2` | `2.3.0` (#160478) |

## Why

`OrdinaryDiffEqDifferentiation` v3.2.3 (and v3.3.0 in #160474) shipped from the QA / ExplicitImports cleanup in SciML/OrdinaryDiffEq.jl#3777. That release stopped re-exporting SciMLBase-owned wrappers `TimeDerivativeWrapper` and `TimeGradientWrapper`.

Registered solvers still import those names from OrdinaryDiffEqDifferentiation → `UndefVarError: TimeDerivativeWrapper not defined` with ODEDiff ≥ 3.2.3.

User reports: SciML/OrdinaryDiffEq.jl#3841, SciML/SciMLBase.jl#1427.

## TagBot wave (2026-07-09)

~40 OrdinaryDiffEq sublibrary registrations are open from the minor bump in SciML/OrdinaryDiffEq.jl#3842. Scan of each package pre-TagBot latest tree for imports of `TimeDerivativeWrapper` from ODEDiff against names in ODEDiff 3.2.3: **only Rosenbrock and Extrapolation** need this retrocap.

```toml
# Rosenbrock
["2 - 2.3.0"]
OrdinaryDiffEqDifferentiation = "3 - 3.2.2"

["2.3.1 - 2.3.2"]
OrdinaryDiffEqDifferentiation = "3.2.1 - 3.2.2"

["2.4 - 2"]
OrdinaryDiffEqDifferentiation = "3.2.1 - 3"

# Extrapolation
["2 - 2.2.2"]
OrdinaryDiffEqDifferentiation = "3 - 3.2.2"

["2.3 - 2"]
OrdinaryDiffEqDifferentiation = "3"
```

Merge note: fine to land after or before TagBot #160462 / #160478; the `["2.4 - 2"]` / `["2.3 - 2"]` entries keep fixed releases compatible with ODEDiff ≥ 3.2.3.