### PR TITLE
Update HypercubeTransform deps

### DIFF
--- a/H/HypercubeTransform/Compat.toml
+++ b/H/HypercubeTransform/Compat.toml
@@ -65,6 +65,9 @@ TransformVariables = "0.8"
 ["0.4.14 - 0"]
 TransformVariables = "0.8.19 - 0.8"
 
+["0.4.16 - 0"]
+Distributions = "0.25.129 - 0.25"
+
 ["0.4.4 - 0"]
 ChainRulesCore = "1"
 ComponentArrays = "0.15"
@@ -73,9 +76,11 @@ ComponentArrays = "0.15"
 julia = "1.10.0-1"
 
 ["0.4.7 - 0"]
-Distributions = "0.24 - 0.25"
 DocStringExtensions = "0.7 - 0.9"
 julia = "1.10.0 - 1"
 
 ["0.4.7 - 0.4.14"]
 NamedTupleTools = "0.12 - 0.14"
+
+["0.4.7 - 0.4.15"]
+Distributions = "0.24 - 0.25"


### PR DESCRIPTION
This is needed because Distributions changed the type signature in 0.25.129 for an alias. HypercubeTransform patched this, but I forgot to update the dependency to only support versions 0.225.129 and above. 

Patch assisted with Claude code. 