### PR TITLE
Retroactive compat: OrdinaryDiffEqFIRK 2.x -> OrdinaryDiffEqNonlinearSolve <2.1.0

### DIFF
--- a/O/OrdinaryDiffEqFIRK/Compat.toml
+++ b/O/OrdinaryDiffEqFIRK/Compat.toml
@@ -146,7 +146,7 @@ OrdinaryDiffEqCore = "1.19.0-1"
 [2]
 DiffEqBase = "7"
 OrdinaryDiffEqDifferentiation = "3"
-OrdinaryDiffEqNonlinearSolve = "2"
+OrdinaryDiffEqNonlinearSolve = "2.0.0 - 2.0"
 
 ["2 - 2.2"]
 OrdinaryDiffEqCore = "4"


### PR DESCRIPTION
Retroactive `[compat]` narrowing for `OrdinaryDiffEqFIRK` `[2.0.0, 2.3.2]` (the `[2]` block), changing `OrdinaryDiffEqNonlinearSolve` from `"2"` to `"2.0.0 - 2.0"` (i.e. `< 2.1.0`).

### Why

`OrdinaryDiffEqNonlinearSolve` v2.1.0 stopped bringing the nonlinear-solver status enums `FastConvergence`, `SlowConvergence`, and `VerySlowConvergence` into its namespace (they are defined in `OrdinaryDiffEqCore`). Registered `OrdinaryDiffEqFIRK` `2.0.0`–`2.3.2` do `using OrdinaryDiffEqNonlinearSolve: ..., FastConvergence, ..., VerySlowConvergence, ...`, so with `OrdinaryDiffEqNonlinearSolve` v2.1.0 they fail to precompile on **Julia 1.10**:

```
ERROR: LoadError: UndefVarError: `FastConvergence` not defined
Failed to precompile OrdinaryDiffEqFIRK ... src/OrdinaryDiffEqFIRK.jl:1
```

(On Julia 1.11+ the transitive `using ...: name` resolves, so the failure is Julia-1.10-specific — but 1.10 is the current LTS.) FIRK `2.x` declares `OrdinaryDiffEqNonlinearSolve = "2"`, so the resolver freely pairs it with the incompatible v2.1.0.

### Verification (local, Julia 1.10)

- `OrdinaryDiffEqFIRK@2.3.2` + `OrdinaryDiffEqNonlinearSolve@2.1.0` → precompile **fails** (`FastConvergence not defined`).
- `OrdinaryDiffEqFIRK@2.3.2` + `OrdinaryDiffEqNonlinearSolve@2.0.2` → **loads OK**.
- `OrdinaryDiffEqNonlinearSolve@2.0.2` allows `OrdinaryDiffEqCore = "4"` and `SciMLBase = "3.10"`, so this cap is satisfiable with current `OrdinaryDiffEqCore` 4.x / `SciMLBase` 3.x.
- `Pkg.Types.semver_spec("2.0.0 - 2.0")` includes 2.0.0/2.0.2 and excludes 2.1.0.

### Scope

Only `OrdinaryDiffEqFIRK` is affected — an audit of all sibling sublibraries found no other registered package that imports these three enums from `OrdinaryDiffEqNonlinearSolve` (e.g. `DelayDiffEq` imports them from `OrdinaryDiffEqCore`). The fixed code is already on `OrdinaryDiffEqFIRK` master (v2.4.0 imports the enums from `OrdinaryDiffEqCore`); this retroactive compat only covers the already-registered `<= 2.3.2` versions until 2.4.0 is released and for anyone pinned to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)