### PR TITLE
Retro-compat: OrdinaryDiffEq{NonlinearSolve,Rosenbrock,BDF} require OrdinaryDiffEqCore >=4.6 (find_algebraic_vars_eqs)

### DIFF
--- a/O/OrdinaryDiffEqBDF/Compat.toml
+++ b/O/OrdinaryDiffEqBDF/Compat.toml
@@ -170,10 +170,11 @@ Reexport = "1.2.2 - 1"
 ["2.2.1 - 2.2"]
 SciMLBase = "3.10.0 - 3"
 
-["2.2.2 - 2.3.0"]
+["2.2.2 - 2.2"]
 OrdinaryDiffEqCore = "4.4.0 - 4"
 
 ["2.3.0"]
+OrdinaryDiffEqCore = "4.6.0 - 4"
 SciMLBase = "3.30.0 - 3"
 
 ["2.3.1 - 2"]

--- a/O/OrdinaryDiffEqNonlinearSolve/Compat.toml
+++ b/O/OrdinaryDiffEqNonlinearSolve/Compat.toml
@@ -184,7 +184,7 @@ ForwardDiff = ["0.10.36-0.10", "1"]
 DiffEqBase = "7"
 OrdinaryDiffEqDifferentiation = "3"
 
-["2 - 2.1"]
+["2 - 2.0"]
 OrdinaryDiffEqCore = "4"
 
 ["2.0"]
@@ -225,6 +225,7 @@ NonlinearSolve = "4.17.1 - 4"
 LinearSolve = "3.75.0 - 4"
 
 ["2.1"]
+OrdinaryDiffEqCore = "4.6.0 - 4"
 SciMLBase = "3.30.0 - 3"
 
 ["2.1 - 2"]

--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -171,7 +171,7 @@ OrdinaryDiffEqDifferentiation = "3 - 3.2.2"
 RecursiveArrayTools = "4"
 SciMLBase = "3"
 
-["2 - 2.4.0"]
+["2 - 2.3"]
 OrdinaryDiffEqCore = "4"
 
 ["2.3 - 2"]
@@ -201,6 +201,7 @@ LinearSolve = "3.75.0 - 4"
 OrdinaryDiffEqDifferentiation = "3.2.1 - 3"
 
 ["2.4.0"]
+OrdinaryDiffEqCore = "4.6.0 - 4"
 SciMLBase = "3.30.0 - 3"
 
 ["2.4.1 - 2"]


### PR DESCRIPTION
Retroactive `[compat]` fix: raise the `OrdinaryDiffEqCore` **lower** bound to `4.6` for the three registered sublibrary versions that import `find_algebraic_vars_eqs` from `OrdinaryDiffEqCore`.

### Why

`find_algebraic_vars_eqs` was moved from `OrdinaryDiffEqNonlinearSolve` into `OrdinaryDiffEqCore` (SciML/OrdinaryDiffEq.jl#3073), first released in **OrdinaryDiffEqCore v4.6.0** — it does not exist in Core ≤ 4.5.0. Three sublibrary versions now import it from Core but declared a Core floor below 4.6, so the resolver could pair them with Core 4.4/4.5 and precompilation fails on Julia 1.10:

```
WARNING: could not import OrdinaryDiffEqCore.find_algebraic_vars_eqs into OrdinaryDiffEqBDF
ERROR: UndefVarError: `find_algebraic_vars_eqs` not defined
```

Reported downstream: SciML/DeepEquilibriumNetworks.jl#224. Fixed going forward in SciML/OrdinaryDiffEq.jl (Core floor raised to `4.6`); this retro-compat unblocks the already-registered versions.

### Changes (only the post-move version of each package)

| package | version | `OrdinaryDiffEqCore` before | after |
|---|---|---|---|
| OrdinaryDiffEqNonlinearSolve | 2.1.0 | `"4"` | `"4.6"` |
| OrdinaryDiffEqRosenbrock | 2.4.0 | `"4"` | `"4.6"` |
| OrdinaryDiffEqBDF | 2.3.0 | `"4.4.0 - 4"` | `"4.6.0 - 4"` |

The existing broad compat blocks were split into disjoint ranges so **only** the post-move version is bumped; earlier (pre-move) 2.x versions of each package — which import `find_algebraic_vars_eqs` from `OrdinaryDiffEqNonlinearSolve`, not Core — keep their original floor.

### Verification (local)

- Read each edited `Compat.toml` through Pkg's registry `uncompress`: no overlapping-range errors, and:
  - post-move (2.1.0 / 2.4.0 / 2.3.0): Core 4.5.0 **excluded**, 4.6.0 **allowed**.
  - pre-move (2.0.2 / 2.3.2 / 2.2.2): Core 4.5.0 **still allowed** (no collateral restriction).
- `OrdinaryDiffEqBDF@2.3.0` + `OrdinaryDiffEqCore@4.5.0` reproduces the precompile failure on Julia 1.10; with Core 4.6.0 it loads. `find_algebraic_vars_eqs` is absent from the Core 4.5.0 tag, present at 4.6.0.
- Core 4.6.0 is satisfiable in a modern environment (it requires SciMLBase ≥ 3.30, which resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)