### PR TITLE
Change QAtlas repo URL (org transfer: sotashimozono → QAtlasHub)

### DIFF
--- a/Q/QAtlas/Package.toml
+++ b/Q/QAtlas/Package.toml
@@ -1,3 +1,3 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-repo = "https://github.com/sotashimozono/QAtlas.jl.git"
+repo = "https://github.com/QAtlasHub/QAtlas.jl.git"


### PR DESCRIPTION
The QAtlas.jl repository was transferred to the **QAtlasHub** organization. Updating the recorded `repo` URL for package `QAtlas` (uuid `2bd488d2-d3e6-46ee-afb3-5515643db0c7`) from `https://github.com/sotashimozono/QAtlas.jl.git` to `https://github.com/QAtlasHub/QAtlas.jl.git`.

Same package/UUID; GitHub redirects the old URL to the new one. JuliaRegistrator blocks the URL change on registration and requests this PR ("Changing package repo URL not allowed, please submit a pull request with the URL change to the target registry"). After this merges, registration of new versions from the new org location will proceed.

And its related project will be also changed package url.