### PR TITLE
NonlinearSolveQuasiNewton: cap NonlinearSolveBase to 2.33 for v1.13.x (maybe_pinv!! removed in 2.34)

### DIFF
--- a/N/NonlinearSolveQuasiNewton/Compat.toml
+++ b/N/NonlinearSolveQuasiNewton/Compat.toml
@@ -35,7 +35,7 @@ NonlinearSolveBase = "2.1.0 - 2"
 NonlinearSolveBase = "2.2.0 - 2"
 
 ["1.13"]
-NonlinearSolveBase = "2.20.0 - 2"
+NonlinearSolveBase = "2.20.0 - 2.33"
 
 ["1.13.0"]
 SciMLBase = "2.153.0 - 2"


### PR DESCRIPTION
Retroactive compat fix for `NonlinearSolveQuasiNewton` v1.13.x.

### Problem
`NonlinearSolveBase` v2.34.0 removed the internal helper `Utils.maybe_pinv!!` (renamed to `Utils.linsolve_identity!!`). Released `NonlinearSolveQuasiNewton` versions **≤ 1.13.3** still call `Utils.maybe_pinv!!` (`src/initialization.jl:215`), but their registered compat is `NonlinearSolveBase = "2.20.0 - 2"`, which admits the incompatible 2.34.0. The resulting resolution fails to precompile:

```
UndefVarError: `maybe_pinv!!` not defined in `NonlinearSolveBase.Utils`
  @ NonlinearSolveQuasiNewton/src/initialization.jl:215
```

The fixed `NonlinearSolveQuasiNewton` v1.14.0 (uses `linsolve_identity!!`, floors `NonlinearSolveBase` at 2.34) is already registered and resolves fine, but the broken `1.13.x + 2.34.0` combination remains selectable for any resolution that excludes 1.14.0.

### Fix
Cap `NonlinearSolveBase` to `2.20.0 - 2.33` for the `["1.13"]` range (releases 1.13.0–1.13.3), i.e. the last `NonlinearSolveBase` that still provides `maybe_pinv!!`. Via the registry's intersection semantics this only tightens the ceiling.

- v1.14.0+ is unaffected (its own entry floors `NonlinearSolveBase` at 2.34.0).
- v1.12 and earlier already cannot co-resolve with base 2.34.0 (their `SciMLBase` compat caps at 2.x, while base 2.34.0 requires `SciMLBase` 3.19), so no cap is needed there.

### Verification
With this cap applied to a local registry copy:
- Normal resolution is unchanged — still selects `NonlinearSolveQuasiNewton 1.14.0` + `NonlinearSolveBase 2.34.0`.
- Forcing `NonlinearSolveQuasiNewton 1.13.3` now resolves `NonlinearSolveBase 2.33.0` (instead of the broken 2.34.0) and precompiles cleanly.

Surfaced by SciML/NBodySimulator.jl#128.