### PR TITLE
Fix cuTile v0.3 compat

### DIFF
--- a/C/cuTile/Compat.toml
+++ b/C/cuTile/Compat.toml
@@ -7,7 +7,7 @@ julia = "1.11.0 - 1"
 CompilerCaching = "0.1.2 - 0.1"
 IRStructurizer = "0.1"
 
-["0 - 0.3.0"]
+["0 - 0.2"]
 CUDA_Compiler_jll = "0.4"
 
 ["0.1.2 - 0.1"]
@@ -25,13 +25,11 @@ GPUArrays = "11"
 
 ["0.3 - 0"]
 Adapt = "4.4.0 - 4"
-CUDACore = "6.1.0 - 6"
+CUDACore = "6.1.0 - 6.2.0"
+CUDA_Compiler_jll = "0.4 - 0.4.3"
 CompilerCaching = "0.2.4 - 0.2"
 IRStructurizer = "0.6"
 LMDB_jll = "0.9"
 PrecompileTools = "1"
 REPL = "1"
 Scratch = "1.2.0 - 1"
-
-["0.3.1 - 0"]
-CUDA_Compiler_jll = "0.4 - 0.4.3"


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/cuTile.jl/issues/270 as well as ensuring v0.3.0 runs (and not just v0.3.1) by implementing Tim's suggestion (https://github.com/JuliaGPU/cuTile.jl/issues/243#issuecomment-4587246795) from the last time a similar thing happened.

CUDACore v6.2.1 removed `PerDevice` (JuliaGPU/CUDA.jl#3178), which cuTile ≤ v0.3.1 imports at load time, so both v0.3.x releases now fail to precompile on fresh resolves. This caps them at CUDACore v6.2.0, the last version with `PerDevice`. It also moves the existing `CUDA_Compiler_jll = "0.4 - 0.4.3"` cap from v0.3.1 down to cover v0.3.0, which fails with jll v0.4.4+ for the same reason v0.3.1 was released (JuliaGPU/cuTile.jl#243). Already fixed on cuTile master (JuliaGPU/cuTile.jl#268).