### PR TITLE
Move Bibliography-related packages to JuliaBibliographies

### DIFF
--- a/B/BibInternal/Package.toml
+++ b/B/BibInternal/Package.toml
@@ -1,3 +1,3 @@
 name = "BibInternal"
 uuid = "2027ae74-3657-4b95-ae00-e2f7d55c3e64"
-repo = "https://github.com/Humans-of-Julia/BibInternal.jl.git"
+repo = "https://github.com/JuliaBibliographies/BibInternal.jl.git"

--- a/B/BibParser/Package.toml
+++ b/B/BibParser/Package.toml
@@ -1,3 +1,3 @@
 name = "BibParser"
 uuid = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"
-repo = "https://github.com/Humans-of-Julia/BibParser.jl.git"
+repo = "https://github.com/JuliaBibliographies/BibParser.jl.git"

--- a/B/Bibliography/Package.toml
+++ b/B/Bibliography/Package.toml
@@ -1,3 +1,3 @@
 name = "Bibliography"
 uuid = "f1be7e48-bf82-45af-a471-ae754a193061"
-repo = "https://github.com/Humans-of-Julia/Bibliography.jl.git"
+repo = "https://github.com/JuliaBibliographies/Bibliography.jl.git"


### PR DESCRIPTION
`Bibliography.jl` and the related packages `BibInternal.jl` and `BibParser.jl` have been moved (by the original package maintainer @Azzaare) from their previous home at https://github.com/Humans-of-Julia/ to https://github.com/JuliaBibliographies/

This is a reflection on the old organization having become inactive and these packages being important dependencies of the Documentation ecosystem (via
[`DocumenterCitations.jl`](https://github.com/JuliaDocs/DocumenterCitations.jl)) that should be well-maintained, in an organization with multiple active owners.