### PR TITLE
Update repository URL in Package.toml for ChemistryLab.jl

### DIFF
--- a/C/ChemistryLab/Package.toml
+++ b/C/ChemistryLab/Package.toml
@@ -1,3 +1,3 @@
 name = "ChemistryLab"
 uuid = "f346e401-14f9-407c-a0e2-c4f64a3e574a"
-repo = "https://github.com/jfbarthelemy/ChemistryLab.jl.git"
+repo = "https://github.com/MicroPoroChemoMechanics/ChemistryLab.jl.git"


### PR DESCRIPTION
ChemistryLab (UUID f346e401-14f9-407c-a0e2-c4f64a3e574a) has moved from `jfbarthelemy/ChemistryLab.jl` to the organization `MicroPoroChemoMechanics/ChemistryLab.jl`. I own both locations (I am the org owner). This PR only updates the `repo` field so that JuliaRegistrator accepts the next version registration. Thanks!