### PR TITLE
Change DuckDB URL to its own repository

### DIFF
--- a/D/DuckDB/Package.toml
+++ b/D/DuckDB/Package.toml
@@ -1,4 +1,3 @@
 name = "DuckDB"
 uuid = "d2f5444f-75bc-4fdf-ac35-56f514c445e1"
-repo = "https://github.com/duckdb/duckdb.git"
-subdir = "tools/juliapkg"
+repo = "https://github.com/duckdb/DuckDB.jl.git"


### PR DESCRIPTION
DuckDB.jl has been moved out of the `duckdb/duckdb` monorepo (`tools/juliapkg`) into its own repository: https://github.com/duckdb/DuckDB.jl
   
History and all released tags are preserved, so every registered git-tree-sha1 still resolves in the new repo. No new version is being registered, only the URL.

There's some extra context here when we first moved DuckDB from its original author to the DuckDB repo (https://github.com/JuliaRegistries/General/pull/58361). Now we have been moving client integrations out into their own repositories, so we would like to also move the Julia client out of the main DuckDB repository.

All versions with the same hashes should be there, as detailed in the linked pull request when we did the first move:

```
   check_package_versions("DuckDB", "https://github.com/duckdb/DuckDB.jl.git"):
   35/35 found, none missing
   (0.2.3, 0.2.4, 0.2.5, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.6.0, 0.7.0, 0.7.1, 0.8.0, 0.8.1, 0.9.0, 0.9.1, 0.10.0, 0.10.1, 0.10.2, 0.10.3, 1.0.0, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.3.0, 1.3.1, 1.3.2, 1.4.1, 1.4.4, 1.5.0, 1.5.1, 1.5.2)
```