### PR TITLE
Update repository URL to MicroPoroChemoMechanics

### DIFF
--- a/C/ChemistryLab/Package.toml
+++ b/C/ChemistryLab/Package.toml
@@ -1,3 +1,3 @@
 name = "ChemistryLab"
 uuid = "f346e401-14f9-407c-a0e2-c4f64a3e574a"
-repo = "https://github.com/jfbarthelemy/ChemistryLab.jl.git"
+repo = "https://github.com/MicroPoroChemoMechanics/ChemistryLab.jl.git"

--- a/O/OptimaSolver/Package.toml
+++ b/O/OptimaSolver/Package.toml
@@ -1,3 +1,3 @@
 name = "OptimaSolver"
 uuid = "24efeca9-a785-406e-adb3-83609348bee7"
-repo = "https://github.com/ChemistryTools/OptimaSolver.jl.git"
+repo = "https://github.com/MicroPoroChemoMechanics/OptimaSolver.jl.git"

--- a/T/TensND/Package.toml
+++ b/T/TensND/Package.toml
@@ -1,3 +1,3 @@
 name = "TensND"
 uuid = "474b5345-2588-4284-8a58-2430a1a40cb0"
-repo = "https://github.com/jfbarthelemy/TensND.jl.git"
+repo = "https://github.com/MicroPoroChemoMechanics/TensND.jl.git"


### PR DESCRIPTION
The 3 packages ChemistryLab.jl, OptimaSolver.jl and TensND.jl, which were either on my personal account or on organization that I own, have been transfered to the new organization MicroPoroChemoMechanics which I also own. Thanks for the URL move.