### PR TITLE
Change NamedDims repo URL (org transfer: invenia → JuliaArrays)

### DIFF
--- a/N/NamedDims/Package.toml
+++ b/N/NamedDims/Package.toml
@@ -1,3 +1,3 @@
 name = "NamedDims"
 uuid = "356022a1-0364-5f58-8944-0da4b18d706f"
-repo = "https://github.com/invenia/NamedDims.jl.git"
+repo = "https://github.com/JuliaArrays/NamedDims.jl.git"


### PR DESCRIPTION
NamedDims.jl has moved from the `invenia` org to `JuliaArrays`. This updates the registry repo URL accordingly.

- Old: https://github.com/invenia/NamedDims.jl.git
- New: https://github.com/JuliaArrays/NamedDims.jl.git