### PR TITLE
Update repository URL in Package.toml

### DIFF
--- a/Q/QuicoptClient/Package.toml
+++ b/Q/QuicoptClient/Package.toml
@@ -1,3 +1,3 @@
 name = "QuicoptClient"
 uuid = "e3379caf-a7d1-49bc-bad0-a3c1736f44f4"
-repo = "https://github.com/timbode/QuicoptClient.jl.git"
+repo = "https://github.com/Quicopt/QuicoptClient.jl.git"


### PR DESCRIPTION
The repo has moved from the authors personal space (timbode) to the organisation Quicopt.