### PR TITLE
JET: Apply rolling Julia compatibility policy

### DIFF
--- a/J/JET/Compat.toml
+++ b/J/JET/Compat.toml
@@ -44,7 +44,7 @@ CodeTracking = "1 - 3"
 
 ["0.10.15 - 0.10"]
 LoweredCodeUtils = "3.4 - 3.5"
-julia = "1.12.0 - 1"
+julia = "1.12"
 
 ["0.10.2 - 0.10.6"]
 JuliaSyntax = ["0.4.10-0.4", "1"]
@@ -103,8 +103,8 @@ Revise = "3.13.0 - 3"
 ["0.11.4"]
 LoweredCodeUtils = "3.4 - 3.5"
 
-["0.11.4 - 0"]
-julia = "1.12.0 - 1"
+["0.11.4 - 0.11.6"]
+julia = "1.12"
 
 ["0.11.5"]
 LoweredCodeUtils = "3.6.2 - 3"
@@ -120,6 +120,7 @@ LoweredCodeUtils = "3.7.2 - 3"
 CodeTracking = "3"
 JuliaInterpreter = "0.11.4 - 0.11"
 LoweredCodeUtils = "3.8.0 - 3"
+julia = "1.12.0 - 1"
 
 ["0.2"]
 LoweredCodeUtils = "2-2.3"


### PR DESCRIPTION
JET releases depend on Julia compiler internals, and older versions can load but fail on newer Julia releases. JuliaRegistries/General#145354 therefore capped all registered JET versions to their known Julia minor. However, that also left no JET version resolvable on the next Julia prerelease. Packages with JET in a test environment then failed during `Pkg.instantiate` before they could skip unsupported JET tests, as reported in aviatesk/JET.jl#796.

JET v0.12 introduces a rolling compatibility frontier. The latest JET series keeps an open Julia 1.x upper bound and loads empty stubs when full functionality is unavailable. Older JET series retain exact upper bounds so normal and lower-bound resolution cannot select versions that use incompatible compiler internals. The policy is documented at: https://github.com/aviatesk/JET.jl#julia-compatibility-and-versioning

Cap JET v0.10.15 and v0.11.4-v0.11.6 at Julia 1.12, and leave JET v0.12 compatible with Julia 1.12 and later 1.x versions. Julia 1.13 and nightly can now resolve v0.12, while Julia 1.12 can still resolve the older releases.

The registry parser accepts the updated TOML. The effective compat specs accept v0.10.15 and v0.11.6 only on Julia 1.12, while v0.12 accepts Julia 1.12, Julia 1.13, and Julia 1.14-DEV.