### PR TITLE
Mark SassC_jll as deprecated

### DIFF
--- a/jll/S/SassC_jll/Package.toml
+++ b/jll/S/SassC_jll/Package.toml
@@ -1,3 +1,6 @@
 name = "SassC_jll"
 uuid = "e813748c-f071-5ac4-9ddd-9e9e72545407"
 repo = "https://github.com/JuliaBinaryWrappers/SassC_jll.jl.git"
+
+[metadata.deprecated]
+reason = "Upstream LibSass has reached its end of life. It will no longer receive updates of any kind."


### PR DESCRIPTION
cf. https://github.com/sass/sassc?tab=readme-ov-file.