### PR TITLE
Correct OrdinaryDiffEqDefault 2.4.1 Core floor

### DIFF
--- a/O/OrdinaryDiffEqDefault/Compat.toml
+++ b/O/OrdinaryDiffEqDefault/Compat.toml
@@ -123,6 +123,8 @@ SciMLBase = "3.35.1 - 3"
 ["2.4 - 2"]
 LinearSolve = "5.1.0 - 5"
 
+["2.4.1"]
+OrdinaryDiffEqCore = "4.11.0 - 4"
+
 ["2.4.1 - 2"]
-OrdinaryDiffEqCore = "4.8.0 - 4"
 SciMLBase = "3.39.0 - 3"

--- a/O/OrdinaryDiffEqDefault/Compat.toml
+++ b/O/OrdinaryDiffEqDefault/Compat.toml
@@ -123,8 +123,6 @@ SciMLBase = "3.35.1 - 3"
 ["2.4 - 2"]
 LinearSolve = "5.1.0 - 5"
 
-["2.4.1"]
-OrdinaryDiffEqCore = "4.11.0 - 4"
-
 ["2.4.1 - 2"]
+OrdinaryDiffEqCore = "4.11.0 - 4"
 SciMLBase = "3.39.0 - 3"


### PR DESCRIPTION
## Summary

- require OrdinaryDiffEqCore 4.11 or later for OrdinaryDiffEqDefault 2.4.1 and later, by bumping the existing `["2.4.1 - 2"]` entry

## Why

OrdinaryDiffEqDefault 2.4.1 uses `AutoDePSpecialize` and the `lorenz_pref` precompile workload helpers. OrdinaryDiffEqCore 4.11.0 is the first registered Core release containing all of those names.

Without this correction, the registry can resolve 2.4.1 with Core 4.10.0 and fail while precompiling with `UndefVarError: lorenz_pref not defined in OrdinaryDiffEqCore`.

## Local verification

- reproduced the precompile failure with unmodified registry metadata and Core 4.10.0
- applied this metadata change and resolved the exact OrdinaryDiffEqDefault 2.4.1 release with Core 4.11.0
- loaded the corrected environment and passed all 5 targeted compatibility checks

Please ignore this draft until it has been reviewed by @ChrisRackauckas.
