### PR TITLE
Restore SciMLBase 3.40 compat for NonlinearSolveBase 2.38

### DIFF
--- a/N/NonlinearSolveBase/Compat.toml
+++ b/N/NonlinearSolveBase/Compat.toml
@@ -178,11 +178,7 @@ SciMLBase = "3.33.0 - 3.39"
 ["2.37.1 - 2.37"]
 SciMLBase = "3.33.0 - 3"
 
-["2.38 - 2.38.0"]
-RespecializeParams = "1"
-SciMLBase = "3.37.0 - 3.39"
-
-["2.38.1 - 2"]
+["2.38 - 2"]
 RespecializeParams = "1"
 SciMLBase = "3.37.0 - 3"
 


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Restore SciMLBase 3.40 compatibility for registered NonlinearSolveBase 2.38.0.

General #162635 capped this release at SciMLBase 3.39 on the assumption that it
still consumed a removed SciMLBase reexport. The registered release already uses
the owning SciMLOperators API, so that cap is not needed.

This combines the two 2.38 ranges without changing any dependency except the
SciMLBase upper bound for 2.38.0.

## Root cause and source boundary

- Registered NonlinearSolveBase 2.38.0 has tree
  `b94033b1ed73030ea66dc51ecc38f3b8dcea9cc2`.
- NonlinearSolve master `cb25573a1d034f10f3e68cace5713e6464d42163`
  has that exact subtree at `lib/NonlinearSolveBase`.
- `update_coefficients!` has been imported directly from its public owner,
  SciMLOperators, since NonlinearSolve commit
  `6f0f6891011b087355f682764e9e807de8bdafec` (#1047, July 12).
- A full source/extension scan found no use of the SciMLOperators or
  ConstructionBase names removed from SciMLBase's export surface.

The bad registry edge was introduced by General commit
`4f9d6e883858315c416a3abeb37daecec61bd59a` (#162635). SciMLBase 3.40.0 was
registered by `7968f275ad4c916fb472be47d812e2f4b8e4e3d0`.

## Local verification

Julia 1.12.6:

- Installed the **registered** NonlinearSolveBase 2.38.0 and SciMLBase 3.40.0
  through this patched registry, then loaded every weak-dependency extension:
  **11/11 loaded** (BandedMatrices, ChainRulesCore, Enzyme, ForwardDiff,
  LineSearch, LinearSolve, Mooncake, ReverseDiff, SparseArrays,
  SparseMatrixColorings, and Tracker).
- Ran the package's official `GROUP=Core` suite on the byte-identical source
  tree with SciMLBase 3.40.0: **155/155 passed**.
- Ran `RegistryCI.test()` after rebasing: **601207/601207 passed**.
- Compared effective compat for every registered NonlinearSolveBase version.
  Exactly one version changes:
  `2.38.0: SciMLBase 3.37-3.39 -> 3.37-3`; every other dependency and version
  remains byte-for-byte equivalent after range evaluation.

The official NonlinearSolveBase QA group reported 19 passes and one independent
clean-master error: the ForwardDiff extension imports the private
`wrapfun_iip_opaque`. That error is being investigated separately and is neither
allow-listed nor changed here.

## Downstream resolver result

Before this change, developing current SciMLSensitivity master fails at the
NonlinearSolveBase 2.38.0 cap. With this registry correction applied, that
conflict disappears and resolution advances to the separate registered
OrdinaryDiffEqCore 4.11 / SciMLBase 3.40 incompatibility. Thus this is one
focused correction in the release chain; it does not claim to resolve that
independent OrdinaryDiffEqCore release blocker.
