### PR TITLE
Mark YASM_jll as deprecated

### DIFF
--- a/jll/Y/YASM_jll/Package.toml
+++ b/jll/Y/YASM_jll/Package.toml
@@ -1,3 +1,6 @@
 name = "YASM_jll"
 uuid = "997772c2-56d0-5ccd-9329-3f55f14e5768"
 repo = "https://github.com/JuliaBinaryWrappers/YASM_jll.jl.git"
+
+[metadata.deprecated]
+reason = "Upstream source has not released a new version since 2014"


### PR DESCRIPTION
The upstream source has not released a new version since 2014.

See https://github.com/yasm/yasm. There've been a handful of medium-severity CVEs reported against the project: https://julialang.github.io/SecurityAdvisories.jl/packages/YASM_jll/