### PR TITLE
Fix OrdinaryDiffEqCore compat floor for five OrdinaryDiffEq sublibrary versions

### DIFF
--- a/O/OrdinaryDiffEqDefault/Compat.toml
+++ b/O/OrdinaryDiffEqDefault/Compat.toml
@@ -124,7 +124,7 @@ SciMLBase = "3.35.1 - 3"
 LinearSolve = "5.1.0 - 5"
 
 ["2.4.1"]
-OrdinaryDiffEqCore = "4.8.0 - 4"
+OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.4.1 - 2"]
 SciMLBase = "3.39.0 - 3"

--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -216,7 +216,7 @@ LinearSolve = "5.1.0 - 5"
 MuladdMacro = "0.2.4 - 0.2"
 
 ["2.6.1"]
-OrdinaryDiffEqCore = "4.10.0 - 4"
+OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.6.1 - 2"]
 ArrayInterface = "7.28.0 - 7"

--- a/O/OrdinaryDiffEqSSPRK/Compat.toml
+++ b/O/OrdinaryDiffEqSSPRK/Compat.toml
@@ -97,7 +97,7 @@ MuladdMacro = "0.2.1 - 0.2"
 SciMLBase = "3.35.1 - 3"
 
 ["2.2.1"]
-OrdinaryDiffEqCore = "4.10.0 - 4"
+OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.2.1 - 2"]
 MuladdMacro = "0.2.4 - 0.2"

--- a/O/OrdinaryDiffEqTsit5/Compat.toml
+++ b/O/OrdinaryDiffEqTsit5/Compat.toml
@@ -107,7 +107,7 @@ CommonSolve = "0.2.6 - 0.2"
 SciMLBase = "3.35.1 - 3"
 
 ["2.1.1"]
-OrdinaryDiffEqCore = "4.10.0 - 4"
+OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.1.1 - 2"]
 MuladdMacro = "0.2.4 - 0.2"

--- a/O/OrdinaryDiffEqVerner/Compat.toml
+++ b/O/OrdinaryDiffEqVerner/Compat.toml
@@ -110,7 +110,7 @@ MuladdMacro = "0.2.1 - 0.2"
 SciMLBase = "3.35.1 - 3"
 
 ["2.2.1"]
-OrdinaryDiffEqCore = "4.10.0 - 4"
+OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.2.1 - 2"]
 MuladdMacro = "0.2.4 - 0.2"


### PR DESCRIPTION
## What this fixes

Five registered OrdinaryDiffEq sublibrary versions declare an `OrdinaryDiffEqCore` lower bound that predates a symbol they reference, so they cannot precompile against part of the range they allow:

| package | version | current bound | references |
|---|---|---|---|
| OrdinaryDiffEqTsit5 | 2.1.1 | `4.10.0 - 4` | `OrdinaryDiffEqCore.lorenz_pref`, `lorenz_pref_params` |
| OrdinaryDiffEqVerner | 2.2.1 | `4.10.0 - 4` | same |
| OrdinaryDiffEqSSPRK | 2.2.1 | `4.10.0 - 4` | same |
| OrdinaryDiffEqRosenbrock | 2.6.1 | `4.10.0 - 4` | same |
| OrdinaryDiffEqDefault | 2.4.1 | `4.8.0 - 4` | same |

`lorenz_pref` / `lorenz_pref_params` were added to OrdinaryDiffEqCore in a `@compile_workload`, and the first *registered* OrdinaryDiffEqCore containing them is **4.11.0** (an intermediate 4.10.1 was version-bumped upstream but never registered — General goes `4.10.0 -> 4.11.0`). Resolving any of the five against OrdinaryDiffEqCore 4.10.0 gives:

```
ERROR: LoadError: UndefVarError: `lorenz_pref` not defined in `OrdinaryDiffEqCore`
```

Reported downstream as SciML/OrdinaryDiffEq.jl#4079, hit on Google Colab's Julia runtime where preinstalled packages hold OrdinaryDiffEqCore at 4.10.0.

## Why the upstream fix isn't sufficient

The floor was corrected upstream in SciML/OrdinaryDiffEq.jl#4080, and the successor releases — Tsit5 2.1.2, Verner 2.2.2, SSPRK 2.2.2, Rosenbrock 2.6.2, Default 2.4.2 — are already registered with `OrdinaryDiffEqCore = "4.11.0 - 4"`.

That fixes new installs but not the reported situation. With OrdinaryDiffEqCore already installed at 4.10.0, `Pkg.add("OrdinaryDiffEqTsit5")` prefers to keep the installed version and selects Tsit5 **2.1.1**, reproducing the failure. I confirmed this against the live registry after those releases merged. Correcting the historical bound is what actually closes it.

## The change

`OrdinaryDiffEqCore = "4.11.0 - 4"` for exactly those five versions. Each already has its own single-version key in `Compat.toml`, so it is one line per package and no other version's bounds move.

## Verification

Built a local copy of this registry carrying the patch and resolved against it in an isolated depot:

- **Environment holding OrdinaryDiffEqCore 4.10.0** — before: selects Tsit5 2.1.1, precompile fails. After: selects Tsit5 2.1.0 (predates the workload), precompiles, `solve` returns `1.3728004409033048`.
- **Unconstrained environment** — unchanged: Tsit5 2.1.2 with OrdinaryDiffEqCore 4.11.0, same result.

I also round-tripped `O/OrdinaryDiffEqTsit5/Compat.toml` through `RegistryTools.Compress` and diffed the decompressed mappings: zero semantic differences from the canonical recompression apart from the intended bound. I kept the surgical one-line edits rather than the recompressed output, since a full round-trip rewrites these files wholesale (~700 lines changed) for no semantic gain.

## Not included

`OrdinaryDiffEqBDF` 2.4.0, `OrdinaryDiffEqSDIRK` 2.8.1 and `OrdinaryDiffEqLowStorageRK` 3.2.1 do **not** contain the workload — I checked each registered tree — so their bounds are correct and are left alone.
