### PR TITLE
Fix compat entries that name non-dependencies (Python_jll, Exodus_jll)

### DIFF
--- a/jll/E/Exodus_jll/Compat.toml
+++ b/jll/E/Exodus_jll/Compat.toml
@@ -1,5 +1,4 @@
 [0]
-Fmt_jll = "9"
 HDF5_jll = "1.12"
 JLLWrappers = "1.2.0-1"
 julia = "1.6.0-1"

--- a/jll/P/Python_jll/Compat.toml
+++ b/jll/P/Python_jll/Compat.toml
@@ -1,6 +1,3 @@
-["3-3.10"]
-LibMPDec_jll = "2"
-
 ["3-3.10.14"]
 JLLWrappers = "1.2.0-1"
 
@@ -12,6 +9,9 @@ Bzip2_jll = "1.0.6"
 Expat_jll = "2.2.7-2"
 Libffi_jll = "3.2.1-3.2"
 julia = "1"
+
+["3.10-3.10"]
+LibMPDec_jll = "2"
 
 ["3.10.13-3.10.14"]
 Artifacts = "1"


### PR DESCRIPTION
Two packages in General carry a compat bound over a version range that reaches back before the bound's package became a dependency, so some of their versions bound a package they do not depend on. These are the only two instances in the whole registry.

## The fix

### Python_jll

`LibMPDec_jll` is a dependency from 3.10 on:

```toml
# Deps.toml
["3.10-3"]
LibMPDec_jll = "7106de7a-f406-5ef1-84f7-3345f7341bd2"
```

but the compat bound covers `3 - 3.10`, which includes all nine 3.8.x builds (3.8.1+0 … 3.8.8+3):

```toml
# Compat.toml
["3-3.10"]
LibMPDec_jll = "2"
```

Narrowed to `["3.10-3.10"]`. The 3.11+ series already has its own entry (`["3.11-3"] LibMPDec_jll = "2.5.1-2"`), so no version loses a bound.

### Exodus_jll

`Fmt_jll` is a dependency from 8 on (`Deps.toml [8-9]`), but `Compat.toml` also lists it under `[0]`, where 0.1.0+0 and 0.1.1+0 do not depend on it. Removed from `[0]`; the `[8]` entry carrying the real bound is untouched.

## Why this is safe

Pkg ignores a compat entry for a package that a version does not depend on, so both edits are inert. I checked that mechanically: for each of the 21 versions across the two packages I computed the *effective* compat map — the bounds on packages the version actually depends on, strong and weak, which is what Pkg reads — before and after the patch. They are identical. Nothing that resolves today resolves differently.

## How these got introduced

Both arose the same way, and the mechanism is worth spelling out because it will keep producing new instances.

**Step 1 — a manual compat PR uses a range that starts at the bottom of the series rather than at the version where the dependency was added.**

- Python_jll: #125574 (2025-02-21, "Python_jll: Declare LibMPDec_jll compat bounds") appended

  ```toml
  ["3"]
  LibMPDec_jll = "2"
  ```

  `["3"]` covers every 3.x, but `LibMPDec_jll` had been a dependency only from 3.10.

- Exodus_jll: #111403 (2024-07-20, "[Exodus_jll] Update Compat.toml") appended

  ```toml
  ["0-8"]
  Fmt_jll = "9"
  ```

  `["0-8"]` covers 0.1.x too, but `Fmt_jll` had been a dependency only from 8.

Both PRs were merged within about an hour and a half. That is not a review failure so much as a structural one: the bound is written in the *dependent's* version space, the dependency's introduction point lives in a different file, and nothing checks the two against each other.

**Step 2 — a routine automated registration rewrites `Compat.toml` and carries the too-wide range forward.**

Registrator recompresses the whole file when a new version lands, so the malformed range gets redistributed into a fresh section layout, which obscures its origin:

- Python_jll v3.11.12+0 (2025-05-16) split `["3"]` into `["3-3.10"]` + `["3.11-3"]`. The 3.11 half is correct; the `3-3.10` half is the surviving error.
- Exodus_jll v9.4.0+0 (2025-05-11) split `["0-8"]` into `[0]` + `[8]`. The `[8]` half is correct; the `[0]` half is the surviving error.

So in both cases the registry now shows a tidy, plausible-looking section that no human ever wrote, three months to a year after the mistake was made.

## Why it is worth fixing at all

The entries misstate what the packages require, and consumers that read the registry more literally than Pkg does can trip over them. In my case, resolving each compat name through the version's deps map raised a `KeyError` on `LibMPDec_jll` and killed a whole-registry traversal ([Resolver.jl#54](https://github.com/StefanKarpinski/Resolver.jl/issues/54)). I have made that code tolerant, since the registry is allowed to look like this — but the registrations are still wrong.

## The check

I found these with a small lint written while debugging the traversal failure. The rule is:

> For each package entry, for each `(range, compat_map)`, for each registered version `v` in `range`: collect the union of dependency names from every `(range′, deps_map)` with `v ∈ range′`, strong and weak. Flag `(package, v, name)` if `name` is absent — excluding `julia`, which every version may bound.

That is roughly 161k version×entry checks over General and runs in a few seconds against a parsed registry. Output on General today:

```
## compat-non-dep: 2 finding(s)

  Exodus_jll [General] — Fmt_jll
    versions: 0.1.0+0, 0.1.1+0
    depends on Fmt_jll: 8.19.0+0, 8.19.1+0, 9.4.0+0
  Python_jll [General] — LibMPDec_jll
    versions: 3.8.1+0, 3.8.1+1 … 3.8.8+3 (9 versions)
    depends on LibMPDec_jll: 3.10.7+0, 3.10.8+0, 3.10.8+1, 3.10.13+0, 3.10.14+0, 3.10.16+0, 3.11.12+0
```

Reporting *which versions do have the dependency* is the useful part: it is exactly the range the bound should have been written over, so the fix reads straight off the report.

The same pass reports three neighbouring classes, which for the record currently stand at: 23 Deps/Compat ranges that cover no registered version, no dependencies on unregistered UUIDs, and one package whose every registered version is yanked. None of those are touched here.

## Suggestion: make this a RegistryCI check

Given the two-step mechanism above, a one-time cleanup does not prevent recurrence — the next manual compat PR that guesses at a range will reintroduce it, and a later registration will launder it into something that looks deliberate. I would suggest RegistryCI grow this as a check:

- **As an AutoMerge guideline on registration PRs**, scoped to the package being registered: cheap (the data is already parsed) and it catches the Step-2 case where a rewrite propagates an existing error into new sections.
- **As a check on manual PRs to General**, scoped to the files the PR touches: this is where the errors are actually *introduced*, and where the fix is a one-character edit to the range instead of an archaeology exercise.
- Optionally as a whole-registry consistency test, since at 2 findings the registry is currently clean enough to enforce at zero.

The check has no false-positive story I can find: a bound on a package a version does not depend on is inert by Pkg's own semantics, so there is never a reason to write one deliberately. I have a working implementation and am happy to open an issue on RegistryCI.jl and port it over, if that would be welcome.

---

Co-author: patch and analysis prepared interactively with [Claude Code](https://claude.com/claude-code).