### PR TITLE
NestedSamplers: Update repository URL in Package.toml

### DIFF
--- a/N/NestedSamplers/Package.toml
+++ b/N/NestedSamplers/Package.toml
@@ -1,3 +1,3 @@
 name = "NestedSamplers"
 uuid = "41ceaf6f-1696-4a54-9b49-2e7a9ec3782e"
-repo = "https://github.com/TuringLang/NestedSamplers.jl.git"
+repo = "https://github.com/chalk-lab/NestedSamplers.jl.git"


### PR DESCRIPTION
1. [x] I have confirmed that the old URL automatically redirects to the new URL in the web browser.
2. [x] The PR preserves the trailing `.git` at the end of the URL.
3. [x] The Treecheck CI job ran on this PR and is green.

Verification of availablility of all versions (ref: https://github.com/JuliaRegistries/General/blob/master/CONTRIBUTING.md#appendix-checking-if-a-repository-contains-all-registered-versions-of-a-package):

```julia
julia> check_package_versions("NestedSamplers", "https://github.com/chalk-lab/NestedSamplers.jl.git");
Cloning into '/tmp/jl_4SranC'...
remote: Enumerating objects: 3262, done.
remote: Counting objects: 100% (579/579), done.
remote: Compressing objects: 100% (145/145), done.
remote: Total 3262 (delta 517), reused 434 (delta 434), pack-reused 2683 (from 1)
Receiving objects: 100% (3262/3262), 9.83 MiB | 4.57 MiB/s, done.
Resolving deltas: 100% (1870/1870), done.
NestedSamplers: v0.1.0 found
NestedSamplers: v0.2.0 found
NestedSamplers: v0.3.0 found
NestedSamplers: v0.4.0 found
NestedSamplers: v0.4.1 found
NestedSamplers: v0.5.0 found
NestedSamplers: v0.5.1 found
NestedSamplers: v0.6.0 found
NestedSamplers: v0.6.1 found
NestedSamplers: v0.6.2 found
NestedSamplers: v0.6.3 found
NestedSamplers: v0.6.4 found
NestedSamplers: v0.6.5 found
NestedSamplers: v0.6.6 found
NestedSamplers: v0.7.0 found
NestedSamplers: v0.7.1 found
NestedSamplers: v0.8.0 found
NestedSamplers: v0.8.1 found
NestedSamplers: v0.8.2 found
NestedSamplers: v0.8.3 found

julia> 

```