### PR TITLE
Point the five Khepri packages at the aptmcl/Khepri monorepo

### DIFF
--- a/K/Khepri/Package.toml
+++ b/K/Khepri/Package.toml
@@ -1,3 +1,4 @@
 name = "Khepri"
 uuid = "59ceddad-2dad-55ad-af66-072f48a109d0"
-repo = "https://github.com/aptmcl/Khepri.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/Khepri"

--- a/K/KhepriAutoCAD/Package.toml
+++ b/K/KhepriAutoCAD/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriAutoCAD"
 uuid = "84eb9a3b-232b-4081-b917-cfea549d0d83"
-repo = "https://github.com/aptmcl/KhepriAutoCAD.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriAutoCAD"

--- a/K/KhepriBase/Package.toml
+++ b/K/KhepriBase/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriBase"
 uuid = "4cc0fe96-1163-46f3-ba32-de1e65d9548f"
-repo = "https://github.com/aptmcl/KhepriBase.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriBase"

--- a/K/KhepriIllustrator/Package.toml
+++ b/K/KhepriIllustrator/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriIllustrator"
 uuid = "7159cd1a-befd-4126-8a94-9819cf26f52f"
-repo = "https://github.com/aptmcl/KhepriIllustrator.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriIllustrator"

--- a/K/KhepriTikZ/Package.toml
+++ b/K/KhepriTikZ/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriTikZ"
 uuid = "d7448f13-5788-4f2e-89b7-cfef8ec02b84"
-repo = "https://github.com/aptmcl/KhepriTikZ.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriTikZ"


### PR DESCRIPTION
The packages moved from individual repositories into a monorepo. Each entry now names that repository and the subdirectory the package occupies.

Versions.toml, Deps.toml and Compat.toml are deliberately untouched: the git-tree-sha1 recorded for every already-registered version refers to a tree in the original per-package repository, and those repositories are archived read-only rather than deleted, so existing versions continue to resolve.