### PR TITLE
[Breeze] Fix compat bounds with Reactant

### DIFF
--- a/B/Breeze/WeakCompat.toml
+++ b/B/Breeze/WeakCompat.toml
@@ -12,7 +12,7 @@ SpecialFunctions = "2"
 CloudMicrophysics = "0.29 - 0.30"
 
 ["0.3.2 - 0.6"]
-Reactant = "0.2.203 - 0.2"
+Reactant = "0.2.203 - 0.2.274"
 
 ["0.4 - 0.4.1"]
 CloudMicrophysics = "0.31.4 - 0.31"
@@ -23,12 +23,11 @@ CloudMicrophysics = "0.31.4 - 0.32"
 ["0.5 - 0.7.3"]
 CloudMicrophysics = "0.31.4 - 0.35"
 
-["0.7"]
-Reactant = "0.2.268 - 0.2"
+["0.7 - 0.8"]
+Reactant = "0.2.268 - 0.2.274, 0.2.278 - 0.2"
 
 ["0.7.4 - 0.7"]
 CloudMicrophysics = "0.37.0 - 0.37.1"
 
 ["0.8 - 0"]
 CloudMicrophysics = "0.37.0 - 0.37.1"
-Reactant = "0.2.278 - 0.2"


### PR DESCRIPTION
Compat bound with Reactant in Breeze@0.8.0 was unnecessarily strict, the main point was to skip versions v0.2.275-0.2.277 which are known to cause numerical issues.  Reflect changes in https://github.com/NumericalEarth/Breeze.jl/pull/895.

CC @dkytezab.