### PR TITLE
[Breeze] Fix syntax of compat bounds

### DIFF
--- a/B/Breeze/WeakCompat.toml
+++ b/B/Breeze/WeakCompat.toml
@@ -24,7 +24,7 @@ CloudMicrophysics = "0.31.4 - 0.32"
 CloudMicrophysics = "0.31.4 - 0.35"
 
 ["0.7 - 0.8"]
-Reactant = "0.2.268 - 0.2.274, 0.2.278 - 0.2"
+Reactant = ["0.2.268 - 0.2.274", "0.2.278 - 0.2"]
 
 ["0.7.4 - 0.7"]
 CloudMicrophysics = "0.37.0 - 0.37.1"


### PR DESCRIPTION
CI didn't catch syntax error in #163449, which caused
```
ERROR: ArgumentError: invalid version range: "0.2.268 - 0.2.274, 0.2.278 - 0.2"
Stacktrace:
  [1] Pkg.Versions.VersionRange(s::String)
    @ Pkg.Versions /usr/local/julia/share/julia/stdlib/v1.11/Pkg/src/Versions.jl:144
  [2] VersionSpec
    @ /usr/local/julia/share/julia/stdlib/v1.11/Pkg/src/Versions.jl:229 [inlined]
  [3] (::Pkg.Registry.var"#12#17")(::Pair{String, Any})
    @ Pkg.Registry ./none:0
  [4] iterate
    @ ./generator.jl:48 [inlined]
  [5] Dict{String, Pkg.Versions.VersionSpec}(kv::Base.Generator{Dict{String, Any}, Pkg.Registry.var"#12#17"})
    @ Base ./dict.jl:93
  [6] init_package_info!(pkg::Pkg.Registry.PkgEntry)
    @ Pkg.Registry /usr/local/julia/share/julia/stdlib/v1.11/Pkg/src/Registry/registry_instance.jl:234
```