### PR TITLE
Point the five registered Khepri packages at the aptmcl/Khepri monorepo (subdir)

### DIFF
--- a/K/Khepri/Package.toml
+++ b/K/Khepri/Package.toml
@@ -1,3 +1,4 @@
 name = "Khepri"
 uuid = "59ceddad-2dad-55ad-af66-072f48a109d0"
-repo = "https://github.com/aptmcl/Khepri.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/Khepri"

--- a/K/KhepriAutoCAD/Package.toml
+++ b/K/KhepriAutoCAD/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriAutoCAD"
 uuid = "84eb9a3b-232b-4081-b917-cfea549d0d83"
-repo = "https://github.com/aptmcl/KhepriAutoCAD.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriAutoCAD"

--- a/K/KhepriBase/Package.toml
+++ b/K/KhepriBase/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriBase"
 uuid = "4cc0fe96-1163-46f3-ba32-de1e65d9548f"
-repo = "https://github.com/aptmcl/KhepriBase.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriBase"

--- a/K/KhepriIllustrator/Package.toml
+++ b/K/KhepriIllustrator/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriIllustrator"
 uuid = "7159cd1a-befd-4126-8a94-9819cf26f52f"
-repo = "https://github.com/aptmcl/KhepriIllustrator.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriIllustrator"

--- a/K/KhepriTikZ/Package.toml
+++ b/K/KhepriTikZ/Package.toml
@@ -1,3 +1,4 @@
 name = "KhepriTikZ"
 uuid = "d7448f13-5788-4f2e-89b7-cfef8ec02b84"
-repo = "https://github.com/aptmcl/KhepriTikZ.jl.git"
+repo = "https://github.com/aptmcl/Khepri.git"
+subdir = "Julia/KhepriTikZ"


### PR DESCRIPTION
The Khepri packages were consolidated from 23 separate repositories into one
monorepo, `aptmcl/Khepri`, with each package now living under `Julia/<Pkg>`.
The five packages already in General still point at their pre-consolidation
repositories, so Registrator refuses new versions with:

> Error while trying to register: Changing package repo URL not allowed,
> please submit a pull request with the URL change to the target registry
> and retry.

This PR makes that URL change for exactly those five, adding the `subdir`
each package now needs:

| Package | old repo | new |
|---|---|---|
| KhepriBase | `aptmcl/KhepriBase.jl` | `aptmcl/Khepri`, subdir `Julia/KhepriBase` |
| Khepri | `aptmcl/Khepri.jl` | `aptmcl/Khepri`, subdir `Julia/Khepri` |
| KhepriAutoCAD | `aptmcl/KhepriAutoCAD.jl` | `aptmcl/Khepri`, subdir `Julia/KhepriAutoCAD` |
| KhepriIllustrator | `aptmcl/KhepriIllustrator.jl` | `aptmcl/Khepri`, subdir `Julia/KhepriIllustrator` |
| KhepriTikZ | `aptmcl/KhepriTikZ.jl` | `aptmcl/Khepri`, subdir `Julia/KhepriTikZ` |

Notes:

- **UUIDs are unchanged** — these remain the same packages, only the source
  location moves. No `Versions.toml`, `Deps.toml`, or `Compat.toml` entries
  are touched, so all previously registered versions keep resolving from the
  git tree they were tagged from.
- The monorepo is public, the same owner (`aptmcl`) controls both the old and
  new repositories, and each package sits at the stated subdirectory with its
  own `Project.toml`.
- The old per-package repositories are still in place and will not be archived
  until after this lands.

Once merged, new versions will be registered from the monorepo with
`@JuliaRegistrator register subdir=Julia/<Pkg>`.