### PR TITLE
Move FlexiChains to JuliaBayes organisation

### DIFF
--- a/F/FlexiChains/Package.toml
+++ b/F/FlexiChains/Package.toml
@@ -1,3 +1,3 @@
 name = "FlexiChains"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-repo = "https://github.com/penelopeysm/FlexiChains.jl.git"
+repo = "https://github.com/JuliaBayes/FlexiChains.jl.git"


### PR DESCRIPTION
I've moved my personal repo to an org: https://github.com/JuliaBayes/FlexiChains.jl