### PR TITLE
CI (Stalebot): Skip PRs that have the `stalebot-ignore` label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,3 +18,4 @@ jobs:
         days-before-pr-close: 7
         delete-branch: true
         operations-per-run: 100
+        stalebot-ignore: stalebot-ignore

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,4 @@ jobs:
         days-before-pr-close: 7
         delete-branch: true
         operations-per-run: 100
-        stalebot-ignore: stalebot-ignore
+        exempt-pr-labels: stalebot-ignore


### PR DESCRIPTION
I have a few PRs (authored by me, not Registrator) that I do plan on working on eventually. It's annoying to keep getting comments from the stalebot.

This PR configures the stalebot to skip PRs that have the [`stalebot-ignore` label](https://github.com/JuliaRegistries/General/issues?q=state%3Aopen%20label%3Astalebot-ignore).