### PR TITLE
Retroactive compat: cap OrdinaryDiffEqLowOrderRK and OrdinaryDiffEqSIMDRK at OrdinaryDiffEqCore <= 4.13

### DIFF
--- a/O/OrdinaryDiffEqLowOrderRK/Compat.toml
+++ b/O/OrdinaryDiffEqLowOrderRK/Compat.toml
@@ -78,7 +78,7 @@ RecursiveArrayTools = "4"
 SciMLBase = "3"
 
 ["2 - 2.2.1"]
-OrdinaryDiffEqCore = "4"
+OrdinaryDiffEqCore = "4.0.0 - 4.13"
 
 ["2.1.1 - 2"]
 RecursiveArrayTools = "4.2.0 - 4"
@@ -96,7 +96,9 @@ SciMLBase = "3.30.0 - 3"
 ["2.2.1"]
 SciMLBase = "3.35.1 - 3"
 
+["2.2.2"]
+OrdinaryDiffEqCore = "4.10.0 - 4.13"
+
 ["2.2.2 - 2"]
 MuladdMacro = "0.2.4 - 0.2"
-OrdinaryDiffEqCore = "4.10.0 - 4"
 SciMLBase = "3.39.0 - 3"

--- a/O/OrdinaryDiffEqSIMDRK/Compat.toml
+++ b/O/OrdinaryDiffEqSIMDRK/Compat.toml
@@ -27,7 +27,9 @@ OrdinaryDiffEqCore = "3"
 
 [2]
 FastBroadcast = "1.3.0 - 1"
-OrdinaryDiffEqCore = "4"
+
+["2 - 2.1.1"]
+OrdinaryDiffEqCore = "4.0.0 - 4.13"
 
 ["2.0.2 - 2"]
 Reexport = "1.2.2 - 1"


### PR DESCRIPTION
Retroactive compat-only change (no new version registered).

## What

Cap every registered 2.x of two OrdinaryDiffEq sublibraries at `OrdinaryDiffEqCore ≤ 4.13`:

| package | versions | `OrdinaryDiffEqCore` before | after |
|---|---|---|---|
| `OrdinaryDiffEqLowOrderRK` | 2.0.0, 2.1.0, 2.1.1, 2.2.0, 2.2.1 | `4` | `4.0.0 - 4.13` |
| `OrdinaryDiffEqLowOrderRK` | 2.2.2 | `4.10.0 - 4` | `4.10.0 - 4.13` |
| `OrdinaryDiffEqSIMDRK` | 2.0.0, 2.0.1, 2.0.2, 2.1.0, 2.1.1 | `4` | `4.0.0 - 4.13` |

That is *all* registered 2.x of both packages. Both are SciML-owned.

## Why

`OrdinaryDiffEqCore` master (4.14.0, **not yet registered**) removed the blanket `@reexport using SciMLBase` in SciML/OrdinaryDiffEq.jl#4119 without a major bump. Measured by loading both and diffing, `names(OrdinaryDiffEqCore)` goes from 374 exported names at 4.13.0 to 227 at master — 152 removed, and 111 names that resolved as `OrdinaryDiffEqCore.x` at 4.13.0 no longer resolve.

Both packages reach through that re-export, so both fail to precompile against 4.14.0. Since their declared bound is `"4"`, the resolver would happily pair them with it.

## Verified failures

Julia 1.12.6, each registered version installed from this registry against a path-`dev`'d `OrdinaryDiffEqCore` at master (4.14.0). **All 6 `OrdinaryDiffEqLowOrderRK` versions and all 5 `OrdinaryDiffEqSIMDRK` versions fail**, so these are clean whole-range caps rather than per-version surgery.

`OrdinaryDiffEqLowOrderRK` (identical on 2.0.0 / 2.1.0 / 2.1.1 / 2.2.0 / 2.2.1 / 2.2.2) — `du_cache`/`u_cache` are owned and exported by SciMLBase:

```
WARNING: Imported binding OrdinaryDiffEqCore.du_cache was undeclared at import time during import to OrdinaryDiffEqLowOrderRK.
WARNING: Imported binding OrdinaryDiffEqCore.u_cache was undeclared at import time during import to OrdinaryDiffEqLowOrderRK.
ERROR: LoadError: invalid method definition in OrdinaryDiffEqLowOrderRK: exported function OrdinaryDiffEqCore.u_cache does not exist
  @ ~/.julia/packages/OrdinaryDiffEqLowOrderRK/lrGen/src/low_order_rk_caches.jl:695
```

`OrdinaryDiffEqSIMDRK` (identical on 2.0.0 / 2.0.1 / 2.0.2 / 2.1.0 / 2.1.1) — it does `@reexport using OrdinaryDiffEqCore` and then uses `ODEFunction` unqualified:

```
ERROR: LoadError: UndefVarError: `ODEFunction` not defined in `OrdinaryDiffEqSIMDRK`
  @ ~/.julia/packages/OrdinaryDiffEqSIMDRK/h8e8q/src/perform_step.jl:45
```

This is not confined to the two packages: anything depending on `OrdinaryDiffEqLowOrderRK` inherits the failure. I observed that directly while testing `FlightCore` 0.2.0, whose load aborted on `OrdinaryDiffEqLowOrderRK` before reaching its own code. Per the registry's `Deps.toml`, `CollectiveSpins`, `HierarchicalEOM`, `InformationGeometry`, `OrdinaryDiffEqAdamsBashforthMoulton`, `OrdinaryDiffEqOperatorSplitting`, `QuantumOptics` and `QuantumToolbox` also depend on it; those seven I did not load-test myself — they are reported as failing in the linked issue's sweep.

## Preventive, not remedial

`OrdinaryDiffEqCore` 4.14.0 is **not registered yet**. Landing this cap first means the broken pair is never resolvable, rather than being repaired after users hit it.

## Successors

Fixed versions exist on master and are pending registration: `OrdinaryDiffEqLowOrderRK` 2.2.3 and `OrdinaryDiffEqSIMDRK` 2.1.2 (SciML/OrdinaryDiffEq.jl#4183). Both import the affected names from the packages that own them, so both will carry an uncapped `OrdinaryDiffEqCore = "4"`. Users on 4.14.0 move to those.

## Range splitting

`OrdinaryDiffEqLowOrderRK` 2.0.0–2.2.1 already sit in a closed `["2 - 2.2.1"]` block, so that one is a single value change. The other two edits split an open-ended block so the cap cannot leak onto unregistered successors:

- `["2.2.2 - 2"]` → `OrdinaryDiffEqCore` moved out into a new `["2.2.2"]` block; `MuladdMacro`/`SciMLBase` stay on the open range.
- `[2]` (SIMDRK) → `OrdinaryDiffEqCore` moved out into a new `["2 - 2.1.1"]` block; `FastBroadcast` stays on `[2]`.

Verified by running both files through `Pkg.Registry.uncompress` before and after:

```
=== OrdinaryDiffEqLowOrderRK ===
  2.0.0: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.1.0: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.1.1: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.2.0: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.2.1: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.2.2: before=4.10.0 - 4     after=4.10.0 - 4.13  | admits4.13=true admits4.14=false
  FUTURE 2.2.3: after=nothing  (uncapped)
=== OrdinaryDiffEqSIMDRK ===
  2.0.0: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.0.1: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.0.2: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.1.0: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  2.1.1: before=4              after=4.0.0 - 4.13   | admits4.13=true admits4.14=false
  FUTURE 2.1.2: after=nothing  (uncapped)
```

No dependency other than `OrdinaryDiffEqCore` changes for any version, and a hypothetical 2.2.3 / 2.1.2 is unconstrained by these files.

## Not verified

I did not run either package's test suite; the evidence here is resolve-and-precompile plus registry metadata. `OrdinaryDiffEqCore` 4.14.0 was tested as a path-`dev` of the monorepo master, not as a registered tarball, since it is not registered.

## Context

Full analysis, including the 64-package audit that identified these: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4175

Same-shape precedents on this package family: https://github.com/JuliaRegistries/General/pull/159026 · https://github.com/JuliaRegistries/General/pull/160741 · https://github.com/JuliaRegistries/General/pull/162878

🤖 Generated with [Claude Code](https://claude.com/claude-code)