### PR TITLE
Retroactive compat: cap PositiveIntegrators 0.2.18 at OrdinaryDiffEqCore <= 4.13

### DIFF
--- a/P/PositiveIntegrators/Compat.toml
+++ b/P/PositiveIntegrators/Compat.toml
@@ -65,10 +65,12 @@ OrdinaryDiffEqCore = "3.0.1 - 3"
 ["0.2.17"]
 FastBroadcast = ["0.3.5 - 0.3", "1"]
 
+["0.2.18"]
+OrdinaryDiffEqCore = "4.2.0 - 4.13"
+
 ["0.2.18 - 0"]
 FastBroadcast = "1.3.0 - 1"
 LinearSolve = "3.75.0 - 3"
-OrdinaryDiffEqCore = "4.2.0 - 4"
 SciMLBase = "3.7.0 - 3"
 
 ["0.2.7 - 0"]


### PR DESCRIPTION
Retroactive compat-only change (no new version registered). This constrains a package I do not maintain, so I have tried to make the evidence complete enough to check independently — **maintainers of https://github.com/NumericalMathematics/PositiveIntegrators.jl are of course welcome to adjust or reject it.**

## What

Cap `PositiveIntegrators` **0.2.18** at `OrdinaryDiffEqCore ≤ 4.13`:

```diff
+["0.2.18"]
+OrdinaryDiffEqCore = "4.2.0 - 4.13"
+
 ["0.2.18 - 0"]
 FastBroadcast = "1.3.0 - 1"
 LinearSolve = "3.75.0 - 3"
-OrdinaryDiffEqCore = "4.2.0 - 4"
 SciMLBase = "3.7.0 - 3"
```

Only 0.2.18 is affected. 0.2.15–0.2.17 carry `OrdinaryDiffEqCore = "3"` and are untouched.

## Why

`OrdinaryDiffEqCore` master (4.14.0, **not yet registered**) removes the blanket `@reexport using SciMLBase` (SciML/OrdinaryDiffEq.jl#4119) in a minor bump. `names(OrdinaryDiffEqCore)` drops from 374 exported names at 4.13.0 to 227 at master; 111 names that resolved as `OrdinaryDiffEqCore.x` at 4.13.0 stop resolving.

`ODESolution` is one of them. It is owned and exported by SciMLBase and was only visible through `OrdinaryDiffEqCore` because of that re-export. `PositiveIntegrators` 0.2.18 imports it from `OrdinaryDiffEqCore`, and its declared bound `"4.2.0 - 4"` admits 4.14.0 — so the resolver can pick a combination that does not precompile.

## The failure

Julia 1.12.6, `PositiveIntegrators` 0.2.18 installed from this registry, `OrdinaryDiffEqCore` path-`dev`'d at monorepo master (4.14.0):

```
  [bbf590c4] OrdinaryDiffEqCore v4.14.0
  [d1b20bf0] PositiveIntegrators v0.2.18

julia> using PositiveIntegrators
WARNING: Imported binding OrdinaryDiffEqCore.ODESolution was undeclared at import time during import to PositiveIntegrators.
ERROR: LoadError: UndefVarError: `ODESolution` not defined in `PositiveIntegrators`
```

This is a hard precompile failure — `using PositiveIntegrators` does not work at all in that combination.

## Why cap rather than wait

`OrdinaryDiffEqCore` 4.14.0 is **not registered yet**. If the cap lands first, the broken pair is simply never resolvable and no user ever sees the error above. If 4.14.0 registers first, every fresh `Pkg.add("PositiveIntegrators")` resolves to the broken pair until a new `PositiveIntegrators` release exists — and the cap would still be wanted afterwards, because 0.2.18 stays in the registry and stays reachable from an old manifest or a constrained resolve.

There is no successor release yet. The one-line source fix is to take `ODESolution` from `SciMLBase` (which owns and exports it) instead of from `OrdinaryDiffEqCore`; a release carrying that change would keep an uncapped `OrdinaryDiffEqCore = "4"` and this cap would not affect it.

## Range splitting

The existing `["0.2.18 - 0"]` block is open-ended, so capping it in place would also cap unreleased 0.2.19+. `OrdinaryDiffEqCore` is moved into a closed single-version `["0.2.18"]` block instead; `FastBroadcast`, `LinearSolve` and `SciMLBase` keep the open range. Verified through `Pkg.Registry.uncompress` before and after:

```
  0.2.15: before=3            after=3             | admits4.13=false admits4.14=false
  0.2.16: before=3.0.1 - 3    after=3.0.1 - 3     | admits4.13=false admits4.14=false
  0.2.17: before=3.0.1 - 3    after=3.0.1 - 3     | admits4.13=false admits4.14=false
  0.2.18: before=4.2.0 - 4    after=4.2.0 - 4.13  | admits4.13=true  admits4.14=false
  FUTURE 0.2.19: after=nothing  (uncapped)
```

No dependency other than `OrdinaryDiffEqCore` changes for any version.

## Not verified

I did not run the `PositiveIntegrators` test suite; the evidence is resolve-and-precompile plus registry metadata. `OrdinaryDiffEqCore` 4.14.0 was tested as a path-`dev` of the monorepo master, not as a registered tarball, since it is not registered.

## Context

Full analysis and the audit of all 64 registered packages admitting 4.14.0: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4175

Same-shape precedents in this registry: https://github.com/JuliaRegistries/General/pull/159026 · https://github.com/JuliaRegistries/General/pull/160741 · https://github.com/JuliaRegistries/General/pull/162878

🤖 Generated with [Claude Code](https://claude.com/claude-code)