### PR TITLE
Retroactive weak compat: cap TaylorIntegration 0.18.4-0.18.15 at OrdinaryDiffEqCore <= 4.13

### DIFF
--- a/T/TaylorIntegration/WeakCompat.toml
+++ b/T/TaylorIntegration/WeakCompat.toml
@@ -6,4 +6,6 @@ IntervalArithmetic = ["0.23", "1"]
 
 ["0.18.4 - 0"]
 DiffEqBase = "6.210.0 - 7"
-OrdinaryDiffEqCore = "3.17.0 - 4"
+
+["0.18.4 - 0.18.15"]
+OrdinaryDiffEqCore = "3.17.0 - 4.13"


### PR DESCRIPTION
Retroactive compat-only change (no new version registered). This constrains a package I do not maintain — **maintainers of https://github.com/PerezHz/TaylorIntegration.jl are welcome to adjust or reject it**, and the evidence below is meant to be checkable independently.

## What

Cap `TaylorIntegration` **0.18.4 – 0.18.15** at `OrdinaryDiffEqCore ≤ 4.13`, in `WeakCompat.toml` (`OrdinaryDiffEqCore` is a weak dependency backing `TaylorIntegrationDiffEqExt`):

```diff
 ["0.18.4 - 0"]
 DiffEqBase = "6.210.0 - 7"
-OrdinaryDiffEqCore = "3.17.0 - 4"
+
+["0.18.4 - 0.18.15"]
+OrdinaryDiffEqCore = "3.17.0 - 4.13"
```

This narrows an existing declared bound (`"3.17, 4"` in the package's `Project.toml`); it does not invent a constraint where the package declared none.

## Why

`OrdinaryDiffEqCore` master (4.14.0, **not yet registered**) removes the blanket `@reexport using SciMLBase` (SciML/OrdinaryDiffEq.jl#4119) in a minor bump. `names(OrdinaryDiffEqCore)` drops from 374 exported names at 4.13.0 to 227 at master, and 111 names that resolved as `OrdinaryDiffEqCore.x` at 4.13.0 stop resolving.

`TaylorIntegrationDiffEqExt` opens with:

```julia
using OrdinaryDiffEqCore:
    ODEFunction,
    ODEProblem,
    DynamicalODEProblem,
    @cache
```

`ODEFunction` and `DynamicalODEProblem` are owned by SciMLBase and were reachable through `OrdinaryDiffEqCore` only via the re-export. Under 4.14.0 they are gone, and the extension fails to precompile.

## The failure

Julia 1.12.6, each version installed from this registry, `OrdinaryDiffEqCore` path-`dev`'d at monorepo master (4.14.0), loading `TaylorIntegration` + `OrdinaryDiffEqCore` + `DiffEqBase` so the extension triggers:

```
  [bbf590c4] OrdinaryDiffEqCore v4.14.0
  [92b13dbe] TaylorIntegration v0.18.15

WARNING: Imported binding OrdinaryDiffEqCore.ODEFunction was undeclared at import time during import to TaylorIntegrationDiffEqExt.
WARNING: Imported binding OrdinaryDiffEqCore.DynamicalODEProblem was undeclared at import time during import to TaylorIntegrationDiffEqExt.
ERROR: LoadError: UndefVarError: `ODEFunction` not defined in `TaylorIntegrationDiffEqExt`
  @ ~/.julia/packages/TaylorIntegration/.../ext/TaylorIntegrationDiffEqExt.jl:381
```

This is how the failure was originally noticed downstream, through `ProbNumDiffEq`.

## Why the whole 0.18.4–0.18.15 range and not just 0.18.15

Two reasons, and this is the judgement call in this PR:

1. **They all fail.** I reproduced the error above on **0.18.4, 0.18.14 and 0.18.15**, and checked the extension source of every registered 0.18.x from 0.18.4 through 0.18.15 — the four-name `using OrdinaryDiffEqCore: ...` block is identical in all twelve. Every version in the existing `["0.18.4 - 0"]` weak-compat block declares `OrdinaryDiffEqCore = "3.17.0 - 4"` and therefore admits 4.14.0.
2. **Capping only 0.18.15 would make things worse, not better.** The resolver would satisfy a user who wants `OrdinaryDiffEqCore` 4.14.0 by silently downgrading `TaylorIntegration` to 0.18.14 — which is broken in exactly the same way, but now with an older package and a more confusing error.

## That a `WeakCompat.toml` cap actually constrains resolution

Worth stating because it is less commonly exercised than `Compat.toml`. `Pkg.Operations` merges weak compat into the resolver graph (`add_compat!(all_compat_u, Registry.weak_compat_info(info))`). I also checked it empirically: in an isolated depot with a copy of this registry, capping `TaylorIntegration`'s weak `OrdinaryDiffEqCore` bound at `3.17.0 - 4.10` and resolving `["TaylorIntegration", "OrdinaryDiffEqCore"]` moved the selection from

```
  [bbf590c4] OrdinaryDiffEqCore v4.13.0     ->     [bbf590c4] OrdinaryDiffEqCore v4.10.0
  [92b13dbe] TaylorIntegration v0.18.15            [92b13dbe] TaylorIntegration v0.18.15
```

so the bound is honoured. (4.10 was used only as a probe, since 4.14.0 is not registered and 4.13.0 is currently the maximum.)

## Preventive, not remedial

`OrdinaryDiffEqCore` 4.14.0 is **not registered yet**. Landing the cap first means the broken pair is never resolvable.

There is no successor `TaylorIntegration` release. The source-side fix is to import `ODEFunction` / `ODEProblem` / `DynamicalODEProblem` from `SciMLBase` (which owns and exports them) rather than from `OrdinaryDiffEqCore`; a release carrying that would keep an uncapped `OrdinaryDiffEqCore = "..., 4"` and be unaffected by this cap.

## Range splitting

The existing `["0.18.4 - 0"]` block is open-ended, so capping it in place would also cap unreleased 0.18.16+. `OrdinaryDiffEqCore` is moved into a closed `["0.18.4 - 0.18.15"]` block; `DiffEqBase` keeps the open range. Verified through `Pkg.Registry.uncompress` before and after:

```
  0.18.4:  before=3.17.0 - 4  after=3.17.0 - 4.13  | admits4.13=true admits4.14=false
  0.18.10: before=3.17.0 - 4  after=3.17.0 - 4.13  | admits4.13=true admits4.14=false
  0.18.14: before=3.17.0 - 4  after=3.17.0 - 4.13  | admits4.13=true admits4.14=false
  0.18.15: before=3.17.0 - 4  after=3.17.0 - 4.13  | admits4.13=true admits4.14=false
  FUTURE 0.18.16: after=nothing  (uncapped)
```

`DiffEqBase` is unchanged for every version.

## Not verified

The `TaylorIntegration` test suite was not run, and 0.18.5–0.18.13 were covered by source inspection rather than by a load test. `OrdinaryDiffEqCore` 4.14.0 was tested as a path-`dev` of the monorepo master, not a registered tarball, since it is not registered.

## Context

Full analysis and the audit of all 64 registered packages admitting 4.14.0: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4175

Same-shape precedents in this registry: https://github.com/JuliaRegistries/General/pull/159026 · https://github.com/JuliaRegistries/General/pull/160741 · https://github.com/JuliaRegistries/General/pull/162878

🤖 Generated with [Claude Code](https://claude.com/claude-code)