### PR TITLE
Rename ThermoCycleGlides.jl to Carnot.jl

### DIFF
--- a/T/ThermoCycleGlides/Package.toml
+++ b/T/ThermoCycleGlides/Package.toml
@@ -1,3 +1,3 @@
 name = "ThermoCycleGlides"
 uuid = "58ad84e6-b92d-4139-8d7e-462257ec6cf0"
-repo = "https://github.com/ClapeyronThermo/ThermoCycleGlides.jl.git"
+repo = "https://github.com/ClapeyronThermo/Carnot.jl.git"


### PR DESCRIPTION
This is to rename the package ThermoCycleGlides.jl to Carnot.jl

cc: @longemen3000 