### PR TITLE
Update repo URLs: MadNLP org renamed to madsuite-org

### DIFF
--- a/D/DynamicNLPModels/Package.toml
+++ b/D/DynamicNLPModels/Package.toml
@@ -1,3 +1,3 @@
 name = "DynamicNLPModels"
 uuid = "18c187db-a9a9-4c13-a1b2-7cf0a4f6591a"
-repo = "https://github.com/MadNLP/DynamicNLPModels.jl.git"
+repo = "https://github.com/madsuite-org/DynamicNLPModels.jl.git"

--- a/E/ExaModels/Package.toml
+++ b/E/ExaModels/Package.toml
@@ -1,3 +1,3 @@
 name = "ExaModels"
 uuid = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
-repo = "https://github.com/exanauts/ExaModels.jl.git"
+repo = "https://github.com/madsuite-org/ExaModels.jl.git"

--- a/E/ExaModelsPower/Package.toml
+++ b/E/ExaModelsPower/Package.toml
@@ -1,3 +1,3 @@
 name = "ExaModelsPower"
 uuid = "2fff4b78-0b6c-428d-bac8-85ccea8c4bdf"
-repo = "https://github.com/MadNLP/ExaModelsPower.jl.git"
+repo = "https://github.com/madsuite-org/ExaModelsPower.jl.git"

--- a/E/ExaPowerIO/Package.toml
+++ b/E/ExaPowerIO/Package.toml
@@ -1,3 +1,3 @@
 name = "ExaPowerIO"
 uuid = "14903efe-9500-4d7f-a589-7ab7e15da6de"
-repo = "https://github.com/MadNLP/ExaPowerIO.jl.git"
+repo = "https://github.com/madsuite-org/ExaPowerIO.jl.git"

--- a/M/MadIPM/Package.toml
+++ b/M/MadIPM/Package.toml
@@ -1,3 +1,3 @@
 name = "MadIPM"
 uuid = "4406d55e-1099-4ca6-ac6a-6cf051b10024"
-repo = "https://github.com/MadNLP/MadIPM.jl.git"
+repo = "https://github.com/madsuite-org/MadIPM.jl.git"

--- a/M/MadNCL/Package.toml
+++ b/M/MadNCL/Package.toml
@@ -1,3 +1,3 @@
 name = "MadNCL"
 uuid = "434a0bcb-5a7c-42b2-a9d3-9e3f760e7af0"
-repo = "https://github.com/MadNLP/MadNCL.jl.git"
+repo = "https://github.com/madsuite-org/MadNCL.jl.git"

--- a/M/MadNLP/Package.toml
+++ b/M/MadNLP/Package.toml
@@ -1,3 +1,3 @@
 name = "MadNLP"
 uuid = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"

--- a/M/MadNLPGPU/Package.toml
+++ b/M/MadNLPGPU/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPGPU"
 uuid = "d72a61cc-809d-412f-99be-fd81f4b8a598"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPGPU"

--- a/M/MadNLPGraph/Package.toml
+++ b/M/MadNLPGraph/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPGraph"
 uuid = "2f590f30-ea46-438a-a78d-e5bfe3109704"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPGraph"

--- a/M/MadNLPHSL/Package.toml
+++ b/M/MadNLPHSL/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPHSL"
 uuid = "7fb6135f-58fe-4112-84ca-653cf5be0c77"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPHSL"

--- a/M/MadNLPKrylov/Package.toml
+++ b/M/MadNLPKrylov/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPKrylov"
 uuid = "1888cb03-ce40-4a36-8d45-ae8231a0e17c"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPKrylov"

--- a/M/MadNLPMumps/Package.toml
+++ b/M/MadNLPMumps/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPMumps"
 uuid = "3b83494e-c0a4-4895-918b-9157a7a085a1"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPMumps"

--- a/M/MadNLPPardiso/Package.toml
+++ b/M/MadNLPPardiso/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPPardiso"
 uuid = "312ee924-cb12-49df-b284-7304c3902fc0"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPPardiso"

--- a/M/MadNLPTests/Package.toml
+++ b/M/MadNLPTests/Package.toml
@@ -1,4 +1,4 @@
 name = "MadNLPTests"
 uuid = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
-repo = "https://github.com/MadNLP/MadNLP.jl.git"
+repo = "https://github.com/madsuite-org/MadNLP.jl.git"
 subdir = "lib/MadNLPTests"


### PR DESCRIPTION
The MadNLP GitHub organization was renamed to madsuite-org, and exanauts/ExaModels.jl was transferred into it. GitHub redirects the old URLs (and the old organization name has been re-registered by its former owner to keep the redirects protected), but the registry should point at the canonical locations.

14 packages, `repo` lines only: MadNLP and its seven `lib/` subpackages (MadNLPGPU, MadNLPHSL, MadNLPMumps, MadNLPPardiso, MadNLPKrylov, MadNLPGraph, MadNLPTests), MadIPM, MadNCL, DynamicNLPModels, ExaModelsPower, ExaPowerIO, and ExaModels.