### PR TITLE
Cap DiffEqBase 7.10-7.14 compat on SciMLBase <= 3.46

### DIFF
--- a/D/DiffEqBase/Compat.toml
+++ b/D/DiffEqBase/Compat.toml
@@ -627,13 +627,13 @@ RecursiveArrayTools = "4"
 SciMLBase = "3.0 - 3.39"
 
 ["7.10"]
-SciMLBase = "3.40.0 - 3"
+SciMLBase = "3.40.0 - 3.46"
 
 ["7.11 - 7.13"]
-SciMLBase = "3.39.0 - 3"
+SciMLBase = "3.39.0 - 3.46"
 
-["7.14 - 7"]
-SciMLBase = "3.46.0 - 3"
+["7.14"]
+SciMLBase = "3.46.0 - 3.46"
 
 ["7.5 - 7"]
 SciMLLogging = "1.10.1 - 2"


### PR DESCRIPTION
SciMLBase 3.47.0 moves the DEIntegrator methods of check_error/check_error! into DiffEqBase and removes SciMLBase.report_integrator_failure. DiffEqBase <= 7.14 defines `function SciMLBase.report_integrator_failure(...)`, so those versions fail to precompile against SciMLBase 3.47.0 with an UndefVarError. DiffEqBase 7.15.0 requires SciMLBase 3.47.

3.47.0 is not yet registered, so this removes no currently-resolvable combination.

Supports https://github.com/SciML/OrdinaryDiffEq.jl/pull/4153 and https://github.com/SciML/SciMLBase.jl/pull/1504