### PR TITLE
Update url for renamed SpaceLiDAR.jl package

### DIFF
--- a/S/SpaceLiDAR/Package.toml
+++ b/S/SpaceLiDAR/Package.toml
@@ -1,3 +1,3 @@
 name = "SpaceLiDAR"
 uuid = "29bf0bfc-420f-4fa5-b441-811fd9e6e11d"
-repo = "https://github.com/evetion/SpaceLiDAR.jl.git"
+repo = "https://github.com/evetion/SpaceAltimetry.jl.git"


### PR DESCRIPTION
Renamed to SpaceAltimetry.jl, with its registration PR at https://github.com/JuliaRegistries/General/pull/164288.