### PR TITLE
Update repository URL for BlochSimulators

### DIFF
--- a/B/BlochSimulators/Package.toml
+++ b/B/BlochSimulators/Package.toml
@@ -1,3 +1,3 @@
 name = "BlochSimulators"
 uuid = "2c9a3a5d-4a8d-4ca7-a6c9-04a38836deab"
-repo = "https://github.com/oscarvanderheide/BlochSimulators.jl.git"
+repo = "https://github.com/MagneticResonanceImaging/BlochSimulators.jl.git"


### PR DESCRIPTION
Moved the repository to the MagneticResonanceImaging organisation