### PR TITLE
Update GIVPOptimizer repository URL

### DIFF
--- a/G/GIVPOptimizer/Package.toml
+++ b/G/GIVPOptimizer/Package.toml
@@ -1,4 +1,4 @@
 name = "GIVPOptimizer"
 uuid = "52b765d9-9955-43cf-8457-2e847d316e43"
-repo = "https://github.com/Arnime/grasp_ils_vnd_pr.git"
+repo = "https://github.com/Arnime/givp.git"
 subdir = "julia"


### PR DESCRIPTION
Updates the registered repository URL for GIVPOptimizer from
`https://github.com/Arnime/grasp_ils_vnd_pr.git` to
`https://github.com/Arnime/givp.git`.

The package remains in the `julia` subdirectory and its registered release
history is preserved. This change is required after the repository rename/migration
so Registrator can register future releases.