### PR TITLE
change ARFFFiles repo

### DIFF
--- a/A/ARFFFiles/Package.toml
+++ b/A/ARFFFiles/Package.toml
@@ -1,3 +1,3 @@
 name = "ARFFFiles"
 uuid = "da404889-ca92-49ff-9e8b-0aa6b4d38dc8"
-repo = "https://github.com/cjdoris/ARFFFiles.jl.git"
+repo = "https://github.com/JuliaData/ARFFFiles.jl.git"


### PR DESCRIPTION
ARFFFiles has moved to https://github.com/JuliaData/ARFFFiles.jl from my personal repo https://github.com/cjdoris/ARFFFiles.jl.

Related issue: https://github.com/JuliaData/ARFFFiles.jl/issues/31.