### PR TITLE
GPUCompiler: require PrecompileTools 1.0.2

### DIFF
--- a/G/GPUCompiler/Compat.toml
+++ b/G/GPUCompiler/Compat.toml
@@ -97,7 +97,7 @@ TOML = "1"
 julia = "1.10.0-1.11"
 
 ["0.27 - 2"]
-PrecompileTools = "1"
+PrecompileTools = "1.0.2 - 1"
 
 ["0.27.1"]
 LLVM = "8-9"


### PR DESCRIPTION
GPUCompiler >= 0.27 imports the workload macros (using PrecompileTools: @setup_workload, @compile_workload). PrecompileTools 1.0.0/1.0.1 expanded @setup_workload to an unqualified PrecompileTools.@load_preference reference, which is undefined in that setup and fails precompilation; fixed in 1.0.2 (JuliaLang/PrecompileTools.jl#13).