### PR TITLE
CUDA_Runtime_jll: require CUDA_Driver 13.0.1 for v0.22-0.24

### DIFF
--- a/jll/C/CUDA_Runtime_jll/Compat.toml
+++ b/jll/C/CUDA_Runtime_jll/Compat.toml
@@ -42,8 +42,11 @@ CUDA_Driver_jll = "0.13"
 ["0.18"]
 CUDA_Driver_jll = "12"
 
-["0.19-0.24.0"]
+["0.19-0.21"]
 CUDA_Driver_jll = "13"
+
+["0.22-0.24.0"]
+CUDA_Driver_jll = "13.0.1-13"
 
 ["0.2.0"]
 CUDA_Driver_jll = "0.1-0.2"


### PR DESCRIPTION
The platform augmentation of these versions calls CUDA_Driver_jll.inspect_driver, which was only introduced in CUDA_Driver_jll 13.0.0+3. With older driver JLLs the augmentation silently selects cuda=none, breaking artifact selection. Registry compat cannot express build numbers, so require 13.0.1 instead. CUDA_Runtime_jll 0.24.1 already carries a proper bound (13.3.1).