### PR TITLE
Moving repos of QuantumDynamics.jl and QuantumDynamicsCLI.jl

### DIFF
--- a/Q/QuantumDynamics/Package.toml
+++ b/Q/QuantumDynamics/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumDynamics"
 uuid = "5a40c529-53c2-4483-a223-e00c1cee8134"
-repo = "https://github.com/amartyabose/QuantumDynamics.jl.git"
+repo = "https://github.com/Bose-Research-Group/QuantumDynamics.jl.git"

--- a/Q/QuantumDynamicsCLI/Package.toml
+++ b/Q/QuantumDynamicsCLI/Package.toml
@@ -1,3 +1,3 @@
 name = "QuantumDynamicsCLI"
 uuid = "7b5053f5-1407-4cb9-9ce0-e1149904b77e"
-repo = "https://github.com/amartyabose/QuantumDynamicsCLI.jl.git"
+repo = "https://github.com/Bose-Research-Group/QuantumDynamicsCLI.jl.git"


### PR DESCRIPTION
I have transferred the two packages to my research group's GitHub organization.  This pull request makes the change consistent for future versions of the packages.