### PR TITLE
[JLArrays] Remove KernelAbstractions 0.10 compat

### DIFF
--- a/J/JLArrays/Compat.toml
+++ b/J/JLArrays/Compat.toml
@@ -32,7 +32,7 @@ KernelAbstractions = "0.9"
 ["0.3 - 0"]
 Adapt = "2 - 4"
 GPUArrays = "11.1.0 - 11"
-KernelAbstractions = "0.9 - 0.10"
+KernelAbstractions = "0.9"
 
 ["0.3 - 0.3.1"]
 julia = "1.8.0 - 1"


### PR DESCRIPTION
KA 0.10 compat was added prematurely so these versions won't actually support KA 0.10 once it releases