### PR TITLE
Mark WinRPM as deprecated

### DIFF
--- a/W/WinRPM/Package.toml
+++ b/W/WinRPM/Package.toml
@@ -1,3 +1,6 @@
 name = "WinRPM"
 uuid = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
 repo = "https://github.com/JuliaPackaging/WinRPM.jl.git"
+
+[metadata.deprecated]
+reason = "This package is unmaintained. Use _jll packages instead"


### PR DESCRIPTION
https://github.com/JuliaPackaging/WinRPM.jl.git was archived on Jun 3, 2025