### PR TITLE
Mark Libz as deprecated

### DIFF
--- a/L/Libz/Package.toml
+++ b/L/Libz/Package.toml
@@ -1,3 +1,7 @@
 name = "Libz"
 uuid = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
 repo = "https://github.com/BioJulia/Libz.jl.git"
+
+[metadata.deprecated]
+reason = "This package is unmaintained"
+alternative = "CodecZlib"


### PR DESCRIPTION
This package was [deprecated by the original author 9 years ago](https://github.com/BioJulia/Libz.jl/commit/a1ef6bd0d4e0cdb1c5c5c1004af0da6abfa6b769):

> NOTE: If you are starting a new project on Julia 0.6 or later, it is recommended to use the [CodecZlib.jl](https://github.com/bicycle1885/CodecZlib.jl) package instead. CodecZlib.jl and [other packages](https://github.com/bicycle1885/TranscodingStreams.jl) offer more unified interfaces for a wide range of file formats.

CC @jakobnissen https://github.com/BioJulia/Libz.jl/issues/69

