### PR TITLE
Naming guidelines: add example for a name with identical scope to an existing package

### DIFF
--- a/NAMING_GUIDELINES.md
+++ b/NAMING_GUIDELINES.md
@@ -40,6 +40,7 @@ Since the `General` registry belongs to the entire community, people may have op
 
 7. <a id="rule-avoid-close-names" href="#rule-avoid-close-names">§</a> Avoid giving a package a name that is too close to an existing package's name.
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather, use a new name such as `ConcurrentWebsockets` that is descriptive of what distinguishes the package.
+     * `QuasiMC` indicates an identical scope to `QuasiMonteCarlo`. Choose a name that is descriptive of what distinguishes the new package, or use a ["less systematic name"](#rule-less-systematic). Or, contribute to the existing package.
 
 8. <a id="rule-avoid-unrelated-project-names" href="#rule-avoid-unrelated-project-names">§</a> Avoid using a distinctive name that is already in use in a well-known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc., for a package that is unrelated to the popular `tkinter` Python package, even if it provides bindings to Tcl/Tk. A package name of `Tkinter.jl` would only be appropriate if the package used Python's library to accomplish its work or was spearheaded by the same community of developers.


### PR DESCRIPTION
Stacked on top of #165754 (base branch `mg-naming-guidelines`); merge that one first.  Splitting this out from #165754 since it deserves its own discussion.

This adds one more example to rule 7 ("avoid close names"), for a case where the new name implies the same scope as an existing package rather than a typo-level similarity:

> * `QuasiMC` indicates an identical scope to `QuasiMonteCarlo`. Choose a name that is descriptive of what distinguishes the new package, or use a ["less systematic name"](#rule-less-systematic). Or, contribute to the existing package.

There is a more narrow version of this: package names that differ from existing registered packages only by writing out or abbreviating some part of the name.

But I would endorse the more broader implications for the general governance of the registry: systematically named packages have a moral obligation to be maintained within the scope that their name implies, so that an equivalently named package can reasonably be denied with "please contribute to the existing package". Julia's strength is a coherent ecosystem grown out of our descriptive naming tradition, and it would be a shame if the registry ended up littered with equivalent variations of the same name.
