### PR TITLE
Update repository URLs for EnergyIntegration and EnergyIntegrationWebApp

### DIFF
--- a/E/EnergyIntegration/Package.toml
+++ b/E/EnergyIntegration/Package.toml
@@ -1,3 +1,3 @@
 name = "EnergyIntegration"
 uuid = "603f9d78-3227-40ee-8768-7855343f6fcd"
-repo = "https://github.com/EnergyIntegration/EnergyIntegration.jl.git"
+repo = "https://codeberg.org/EnergyIntegration/EnergyIntegration.jl.git"

--- a/E/EnergyIntegrationWebApp/Package.toml
+++ b/E/EnergyIntegrationWebApp/Package.toml
@@ -1,3 +1,3 @@
 name = "EnergyIntegrationWebApp"
 uuid = "a6bc986e-675b-4287-8dea-8a93b3f9a836"
-repo = "https://github.com/EnergyIntegration/EnergyIntegrationWebApp.jl.git"
+repo = "https://codeberg.org/EnergyIntegration/EnergyIntegrationWebApp.jl.git"


### PR DESCRIPTION
This updates the General registry entries for EnergyIntegration and EnergyIntegrationWebApp after moving both repositories from GitHub to Codeberg.

The old URLs do not redirect because this is a cross-forge migration. Both packages were originally registered by @abcdvvvv in #146941 and #147219.

Repository changes:

- EnergyIntegration:
  https://github.com/EnergyIntegration/EnergyIntegration.jl.git
  → https://codeberg.org/EnergyIntegration/EnergyIntegration.jl.git
- EnergyIntegrationWebApp:
  https://github.com/EnergyIntegration/EnergyIntegrationWebApp.jl.git
  → https://codeberg.org/EnergyIntegration/EnergyIntegrationWebApp.jl.git

Fresh-clone tree checks against the Codeberg repositories find every registered version:

```text
EnergyIntegration v0.0.1: found 160cd402f57eeef756d71421584496ff65c3f9bd
EnergyIntegrationWebApp v0.1.2: found b1f83ea5481f9365e6371eb83a7b2ea803ad56fa
```