### PR TITLE
Change repo URL for RheologyCalculator

### DIFF
--- a/R/RheologyCalculator/Package.toml
+++ b/R/RheologyCalculator/Package.toml
@@ -1,3 +1,3 @@
 name = "RheologyCalculator"
 uuid = "62cdc9a2-0e94-40de-8fb5-c079398d65d0"
-repo = "https://github.com/albert-de-montserrat/RheologyCalculator.jl.git"
+repo = "https://github.com/JuliaGeodynamics/RheologyCalculator.jl.git"


### PR DESCRIPTION
The RheologyCalculator.jl repository has been transferred from
albert-de-montserrat/RheologyCalculator.jl to
JuliaGeodynamics/RheologyCalculator.jl. The old URL redirects to the new one.

I am the package author and a member of JuliaGeodynamics.