### PR TITLE
Retroactively cap SymbolicUtils at 4.45 for ModelingToolkitBase 1.0.0-1.68.0

### DIFF
--- a/M/ModelingToolkitBase/Compat.toml
+++ b/M/ModelingToolkitBase/Compat.toml
@@ -40,7 +40,7 @@ DocStringExtensions = "0.7 - 0.9"
 Moshi = "0.3"
 PrecompileTools = "1"
 RuntimeGeneratedFunctions = "0.5.9 - 0.5"
-SymbolicUtils = "4.6.0 - 4"
+SymbolicUtils = "4.6.0 - 4.45"
 
 ["1 - 1.30"]
 RecursiveArrayTools = "3.26.0 - 3"
@@ -91,16 +91,16 @@ SciMLStructures = "1.7.0 - 1"
 PreallocationTools = "0.4.27 - 0.4"
 
 ["1.10 - 1.11"]
-SymbolicUtils = "4.15.1 - 4"
+SymbolicUtils = "4.15.1 - 4.45"
 
 ["1.12 - 1.12.1"]
-SymbolicUtils = "4.17.0 - 4"
+SymbolicUtils = "4.17.0 - 4.45"
 
 ["1.12 - 1.29"]
 Symbolics = "7.12.0 - 7"
 
 ["1.12.2 - 1.22"]
-SymbolicUtils = "4.18.0 - 4"
+SymbolicUtils = "4.18.0 - 4.45"
 
 ["1.16 - 1"]
 EnzymeCore = "0.8"
@@ -118,7 +118,7 @@ JumpProcesses = "9.23.0 - 9"
 SciMLBase = "2.149.0 - 2"
 
 ["1.23 - 1.29"]
-SymbolicUtils = "4.20.1 - 4"
+SymbolicUtils = "4.20.1 - 4.45"
 
 ["1.23 - 1.45.0"]
 SCCNonlinearSolve = "1.8.1 - 1"
@@ -130,7 +130,7 @@ BandedMatrices = "1.11.0 - 1"
 FunctionWrappersWrappers = ["0.1", "1"]
 
 ["1.30 - 1.34"]
-SymbolicUtils = "4.23.1 - 4"
+SymbolicUtils = "4.23.1 - 4.45"
 
 ["1.30 - 1.36.1"]
 Symbolics = "7.18.1 - 7"
@@ -151,7 +151,7 @@ ImplicitDiscreteSolve = ["0.1.2 - 0.1", "1 - 2"]
 DiffEqBase = ["6.210.0 - 6", "7.2.0 - 7"]
 
 ["1.35 - 1.42"]
-SymbolicUtils = "4.27.0 - 4"
+SymbolicUtils = "4.27.0 - 4.45"
 
 ["1.36.2 - 1.51"]
 Symbolics = "7.24.0 - 7"
@@ -165,7 +165,7 @@ RuntimeGeneratedFunctions = "0.5.12 - 0.5"
 Moshi = "0.3.6 - 0.3"
 
 ["1.4 - 1.6.2"]
-SymbolicUtils = "4.7.1 - 4"
+SymbolicUtils = "4.7.1 - 4.45"
 
 ["1.4 - 1.65"]
 DocStringExtensions = "0.8 - 0.9"
@@ -174,7 +174,7 @@ DocStringExtensions = "0.8 - 0.9"
 DomainSets = "0.6 - 0.8"
 
 ["1.43"]
-SymbolicUtils = "4.34.1 - 4"
+SymbolicUtils = "4.34.1 - 4.45"
 
 ["1.43 - 1"]
 TaskLocalValues = "0.1.3 - 0.1"
@@ -183,7 +183,7 @@ TaskLocalValues = "0.1.3 - 0.1"
 SciMLBase = "3.18.0 - 3"
 
 ["1.44 - 1.51"]
-SymbolicUtils = "4.35.2 - 4"
+SymbolicUtils = "4.35.2 - 4.45"
 
 ["1.45.1 - 1"]
 SCCNonlinearSolve = "1.13.0 - 1"
@@ -213,11 +213,13 @@ DiffEqBase = "7.4.2 - 7"
 ["1.52 - 1"]
 JumpProcesses = "9.28.0 - 9"
 OffsetArrays = "1.11.0 - 1"
-SymbolicUtils = "4.35.3 - 4"
 julia = "1.10.0 - 1"
 
 ["1.52 - 1.54.0"]
 Symbolics = "7.31.0 - 7"
+
+["1.52 - 1.68.0"]
+SymbolicUtils = "4.35.3 - 4.45"
 
 ["1.54.1 - 1"]
 Symbolics = "7.32.1 - 7"
@@ -248,7 +250,7 @@ Moshi = "0.3.7 - 0.3"
 Symbolics = "7.8.0 - 7"
 
 ["1.6.3 - 1.9"]
-SymbolicUtils = "4.12.0 - 4"
+SymbolicUtils = "4.12.0 - 4.45"
 
 ["1.60 - 1"]
 Printf = "1"


### PR DESCRIPTION
Retroactive compat cap. **Not a registration** — no new version is being registered here.

## Why

Every registered `ModelingToolkitBase` version (1.0.0 – 1.68.0, 106 of them) calls the untyped three-argument constructor in `shift2term`:

```julia
metadata = Base.ImmutableDict(metadata, VariableUnshifted, unshifted)
```

Base defines no such method. The three-argument `(parent, key, value)` form is an **inner** constructor, so it exists only on the parameterized type; every outer constructor takes `Pair`s:

```julia
struct ImmutableDict{K,V} <: AbstractDict{K,V}
    ImmutableDict{K,V}(parent::ImmutableDict, key, value) where {K,V} = new(parent, key, value)   # typed only
end
ImmutableDict(t::ImmutableDict{K,V}, KV::Pair) where {K,V} = ...
```

That call only ever resolved because SymbolicUtils carried a pirated `Base.ImmutableDict(d::ImmutableDict{K,V}, x, y)` method. [SymbolicUtils 4.46.0 removed it](https://github.com/JuliaSymbolics/SymbolicUtils.jl/commit/3aeef075d36be1ef13bffaffbfa5b646594a2b7a) as an Aqua piracy cleanup. Because every `ModelingToolkitBase` compat entry allowed `- 4`, the resolver pairs any of those versions with 4.46.0 and produces an environment where `mtkcompile` throws on any discrete system with shifted array variables:

```
MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{DataType, Any},
             ::Type{ModelingToolkitBase.VariableUnshifted}, ::…BasicSymbolicImpl…)
Stacktrace:
  [1] shift2term      @ ModelingToolkitBase/src/variables.jl:303
  [2] default_toterm  @ ModelingToolkitBase/src/variables.jl:271
  [3] __mtkcompile    @ ModelingToolkitBase/src/systems/systems.jl:390
```

SymbolicUtils 4.45.0 is the last release carrying the pirated method, so `- 4.45` is the correct boundary. The source fix is [SciML/ModelingToolkit.jl#5035](https://github.com/SciML/ModelingToolkit.jl/pull/5035); this cap covers the releases that are already out.

## What changed

12 `SymbolicUtils` entries, upper bound `4` → `4.45`.

The `["1.52 - 1"]` entry is open-ended, so capping it in place would also cap the forthcoming fixed release. Its `SymbolicUtils` line is moved into a bounded `["1.52 - 1.68.0"]` block instead; the other keys in that block (`JumpProcesses`, `OffsetArrays`, `julia`) are left open-ended and untouched.

## Verification

Parsed the file before and after and resolved the effective `SymbolicUtils` bound for all 106 registered versions:

```
--- BEFORE: 106 registered versions
    versions with !=1 SymbolicUtils entry: 0
    12 distinct ranges, all ending "- 4"      allows 4.46? True   (all 106)
--- AFTER: 106 registered versions
    versions with !=1 SymbolicUtils entry: 0
    12 distinct ranges, all ending "- 4.45"   allows 4.46? False  (all 106)
```

No version gains a second or conflicting `SymbolicUtils` entry, and lower bounds are unchanged. Future versions are deliberately left unconstrained here so registration writes their own entry:

```
  1.68.0   -> [('"1.52 - 1.68.0"', '4.35.3 - 4.45')]
  1.68.1   -> no SymbolicUtils entry (written on release)
  1.69.0   -> no SymbolicUtils entry (written on release)
```

## Not verified

I have not run the registry's own consistency tooling locally — the checks above are my own parse of the range semantics. Please flag if the split-block approach for the open-ended range is not how you prefer these handled; I'm happy to restructure it.

`Symbolics` ≤ 7.36 and `SymbolicIntegration` ≤ 3.7.0 have the same problem from their own call sites. I've left them out of this PR to keep it reviewable — happy to follow up separately if you'd like them capped too.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73qSfpoV1bHGbknXLX9Q2
