### PR TITLE
[Breeze] Cap compatibility with Oceananigans

### DIFF
--- a/B/Breeze/Compat.toml
+++ b/B/Breeze/Compat.toml
@@ -53,13 +53,13 @@ Oceananigans = "0.107.4 - 0.108.0"
 Oceananigans = "0.109.1 - 0.109"
 
 ["0.5.3 - 0.6"]
-Oceananigans = "0.110"
+Oceananigans = "0.110 - 0.110.19"
 
 ["0.7 - 0.7.1"]
-Oceananigans = "0.110.2 - 0.110"
+Oceananigans = "0.110.2 - 0.110.19"
 
 ["0.7.2 - 0.7"]
-Oceananigans = "0.110.8 - 0.110"
+Oceananigans = "0.110.8 - 0.110.19"
 
 ["0.8 - 0"]
-Oceananigans = "0.110.14 - 0.110"
+Oceananigans = "0.110.14 - 0.110.19"


### PR DESCRIPTION
Oceananigans v0.110.20 moved a function used by Breeze to a different module.  Ref: https://github.com/NumericalEarth/Breeze.jl/pull/933.