### PR TITLE
Require SciMLBase 3.46 for OrdinaryDiffEqBDF/OrdinaryDiffEqNonlinearSolve versions using AutoDespecialize

### DIFF
--- a/O/OrdinaryDiffEqBDF/Compat.toml
+++ b/O/OrdinaryDiffEqBDF/Compat.toml
@@ -194,10 +194,15 @@ MuladdMacro = "0.2.4 - 0.2"
 ["2.4.1 - 2"]
 ArrayInterface = "7.28.0 - 7"
 OrdinaryDiffEqDifferentiation = "3.3.0 - 3"
+
+["2.4.1 - 2.4.2"]
 SciMLBase = "3.39.0 - 3"
 
 ["2.4.1 - 2.4.4"]
 OrdinaryDiffEqCore = "4.12.0 - 4"
+
+["2.4.3 - 2"]
+SciMLBase = "3.46.0 - 3"
 
 ["2.4.5 - 2"]
 OrdinaryDiffEqCore = "4.15.1 - 4"

--- a/O/OrdinaryDiffEqNonlinearSolve/Compat.toml
+++ b/O/OrdinaryDiffEqNonlinearSolve/Compat.toml
@@ -283,15 +283,16 @@ CommonSolve = "0.2.6 - 0.2"
 
 ["2.8"]
 NonlinearSolveBase = "2.41.0 - 2"
+SciMLBase = "3.43.0 - 3"
 
 ["2.8 - 2"]
 NonlinearSolve = "4.25.0 - 4"
-SciMLBase = "3.43.0 - 3"
 SciMLPublic = "1.1.0 - 1"
 
 ["2.9 - 2"]
 NonlinearSolveBase = "2.45.0 - 2"
 OrdinaryDiffEqCore = "4.13.0 - 4"
+SciMLBase = "3.46.0 - 3"
 
 ["2.9 - 2.9.1"]
 OrdinaryDiffEqDifferentiation = "3.9.0 - 3"


### PR DESCRIPTION
## What changed and why

Six already-registered versions reference `SciMLBase.AutoDespecialize` but declare a `SciMLBase` lower bound below the version that introduced it. Pkg can therefore resolve them against a `SciMLBase` that lacks the symbol, and the resulting environment fails at precompile time.

`AutoDespecialize` was added in **SciMLBase v3.46.0**:

```console
$ for v in v3.45.0 v3.46.0; do
    printf "%s : " $v
    curl -sL "https://raw.githubusercontent.com/SciML/SciMLBase.jl/$v/src/scimlfunctions.jl" \
      | grep -c "^struct AutoDespecialize"
  done
v3.45.0 : 0
v3.46.0 : 1
```

There are no SciMLBase releases between 3.45.0 and 3.46.0, so `3.46.0` is the exact boundary.

The affected versions, and the first version of each package to reference the symbol:

| Package | Versions referencing `AutoDespecialize` | Declared `SciMLBase` | Required |
|---|---|---|---|
| `OrdinaryDiffEqBDF` | 2.4.3, 2.4.4, 2.4.5 | `3.39.0 - 3` | `3.46.0 - 3` |
| `OrdinaryDiffEqNonlinearSolve` | 2.9.0, 2.9.1, 2.9.2 | `3.43.0 - 3` | `3.46.0 - 3` |

The reference is not behind a runtime branch — it is evaluated during precompilation, in the module-level precompile workload:

```julia
# OrdinaryDiffEqBDF/src/OrdinaryDiffEqBDF.jl:151
if Preferences.@load_preference("PrecompileAutoDespecialize", true)
    dae_f = DAEFunction{true, SciMLBase.AutoDespecialize}(precompile_dae)
```

so any resolution that pairs these versions with SciMLBase < 3.46.0 fails to load at all.

This follows the retroactive-compat path described in the README under *When is yanking a release appropriate?* — the bounds were set too wide, and a patch release cannot fix it because Pkg would still resolve the existing versions.

## Failing before

Observed in the wild on `SciML/SciMLBenchmarks.jl`, whose weekly dependency refresh resolved `OrdinaryDiffEqBDF v2.4.4` alongside `SciMLBase v3.39.1` and then could not precompile:

```console
$ julia +1.12 --project=. -e 'using Pkg; Pkg.precompile(; strict=true)'
              ✗ OrdinaryDiffEqBDF
              ✗ OrdinaryDiffEqDefault
              ✗ OrdinaryDiffEq
ERROR: LoadError: UndefVarError: `AutoDespecialize` not defined in `SciMLBase`
exit=1
```

## Verification of this diff

Effective `SciMLBase` bound per registered version, computed with `Pkg.Versions.VersionRange` against the file before and after the change — only the affected versions move, everything else is byte-identical:

```
#### OrdinaryDiffEqBDF
  v2.4.0    same  before=["3.35.1 - 3"]  after=["3.35.1 - 3"]
  v2.4.1    same  before=["3.39.0 - 3"]  after=["3.39.0 - 3"]
  v2.4.2    same  before=["3.39.0 - 3"]  after=["3.39.0 - 3"]
  v2.4.3  CHANGED  before=["3.39.0 - 3"]  after=["3.46.0 - 3"]
  v2.4.4  CHANGED  before=["3.39.0 - 3"]  after=["3.46.0 - 3"]
  v2.4.5  CHANGED  before=["3.39.0 - 3"]  after=["3.46.0 - 3"]

#### OrdinaryDiffEqNonlinearSolve
  v2.7.0    same  before=["3.39.0 - 3"]  after=["3.39.0 - 3"]
  v2.8.0    same  before=["3.43.0 - 3"]  after=["3.43.0 - 3"]
  v2.9.0  CHANGED  before=["3.43.0 - 3"]  after=["3.46.0 - 3"]
  v2.9.1  CHANGED  before=["3.43.0 - 3"]  after=["3.46.0 - 3"]
  v2.9.2  CHANGED  before=["3.43.0 - 3"]  after=["3.46.0 - 3"]
```

Both files parse as valid TOML.

## What I did not verify

- I did not re-resolve every downstream environment in General that depends on these packages; the check above is confined to the effective bounds of the two edited files.
- The scan for affected packages covered package versions present in a local depot plus the full registered version lists of these two packages. Other packages referencing `AutoDespecialize` with a too-low bound may exist and would need the same treatment.

## Note for maintainers

`master` of `SciML/OrdinaryDiffEq.jl` still carries the too-low bounds (`lib/OrdinaryDiffEqBDF/Project.toml` → `SciMLBase = "3.39"`, `lib/OrdinaryDiffEqNonlinearSolve/Project.toml` → `SciMLBase = "3.43"`), so the next release of either would reintroduce the problem. That needs a separate PR upstream; this one only repairs the already-registered versions.

🤖 Generated with Claude Code (model: claude-opus-5[1m])
https://claude.ai/code/session_016yBsJDGXDqPHqaJCVzpyr9
