### PR TITLE
Retroactively cap SymbolicUtils for Symbolics through 7.36

### DIFF
--- a/S/Symbolics/Compat.toml
+++ b/S/Symbolics/Compat.toml
@@ -388,34 +388,34 @@ MutableArithmetics = "1.6.5 - 1"
 Preferences = "1.5.0 - 1"
 
 ["7.0.0"]
-SymbolicUtils = "4.3.0 - 4"
+SymbolicUtils = "4.3.0 - 4.45"
 
 ["7.0.1 - 7.2"]
-SymbolicUtils = "4.4.0 - 4"
+SymbolicUtils = "4.4.0 - 4.45"
 
 ["7.12 - 7.16"]
-SymbolicUtils = "4.17.0 - 4"
+SymbolicUtils = "4.17.0 - 4.45"
 
 ["7.17 - 7.21"]
-SymbolicUtils = "4.21.0 - 4"
+SymbolicUtils = "4.21.0 - 4.45"
 
 ["7.18.1 - 7"]
 DomainSets = "0.6 - 0.8"
 
 ["7.22 - 7.26"]
-SymbolicUtils = "4.27.0 - 4"
+SymbolicUtils = "4.27.0 - 4.45"
 
 ["7.25 - 7"]
 LogExpFunctions = ["0.3", "1"]
 
 ["7.27 - 7.29"]
-SymbolicUtils = "4.35.0 - 4"
+SymbolicUtils = "4.35.0 - 4.45"
 
 ["7.3 - 7.11"]
-SymbolicUtils = "4.10.0 - 4"
+SymbolicUtils = "4.10.0 - 4.45"
 
-["7.30 - 7"]
-SymbolicUtils = "4.37.0 - 4"
+["7.30 - 7.36"]
+SymbolicUtils = "4.37.0 - 4.45"
 
 ["7.31.1 - 7"]
 IntervalSets = "0.7.4 - 0.7"
@@ -427,6 +427,7 @@ PrecompileTools = "1.2.1 - 1"
 SciMLPublic = "1.2.0 - 1"
 StaticArraysCore = "1.4.3 - 1"
 SymbolicLimits = "1.1.0 - 1"
+SymbolicUtils = "4.37.0 - 4"
 
 ["7.38 - 7"]
 Libdl = "1"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Retroactively cap SymbolicUtils at 4.45 for Symbolics 7.0.0 through 7.36. SymbolicUtils 4.46 removed an untyped three-argument `Base.ImmutableDict` method, but those Symbolics releases still call it from `renamed_metadata`, so the previously legal dependency pair fails at runtime.

Symbolics 7.37 fixed the constructor call in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1960, so its existing open-ended SymbolicUtils compatibility is preserved.

## Verification

Before this registry change, the following clean environment resolved Symbolics 7.36.0 with SymbolicUtils 4.46.0 and reproduced the failure:

```text
pkgversion(Symbolics) = v"7.36.0"
pkgversion(SymbolicUtils) = v"4.46.0"
ERROR: MethodError: no method matching Base.ImmutableDict(
    ::Base.ImmutableDict{DataType, Any},
    ::Type{Symbolics.VariableSource},
    ::Tuple{Symbol, Symbol})
Stacktrace:
 [1] renamed_metadata(...)
   @ Symbolics .../src/variable.jl:589
```

With this registry change, the same exact pair is rejected:

```text
ERROR: Unsatisfiable requirements detected for package SymbolicUtils [d1185830]:
 ├─restricted to versions 4.46.0 by an explicit requirement
 └─restricted by compatibility requirements with Symbolics [0c5d862f]
   to versions: 4.37.0-4.45.0 — no versions left
```

The first fixed release remains compatible with SymbolicUtils 4.46.0:

```text
pkgversion(Symbolics) = v"7.37.0"
pkgversion(SymbolicUtils) = v"4.46.0"
renamed[Symbolics.VariableSource] = (:variables, :y)
```

Registry consistency:

```text
Test Summary:                                |   Pass   Total   Time
(Registry|Package|Versions|Deps|Compat).toml | 931662  931662  39.2s
```

Also run:

```text
git diff --check
typos S/Symbolics/Compat.toml
```

Both exited successfully with no output.

## Not verified

GitHub CI has not run yet. No package source or newer Symbolics compatibility was changed.

## Reviewer attention

This is a retroactive compatibility restriction across all Symbolics 7 releases before the typed-constructor fix. The bounds retain each release range's existing lower floor and only replace the upper `4` bound with `4.45`.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a0501c-815c-7cf1-93c4-ddb4fab68924).
