### PR TITLE
Add subdir for StrictMode

### DIFF
--- a/S/StrictMode/Package.toml
+++ b/S/StrictMode/Package.toml
@@ -1,3 +1,4 @@
 name = "StrictMode"
 uuid = "0e98b4f4-d0e6-42ac-af0a-707c24852f32"
 repo = "https://github.com/el-oso/StrictMode.jl.git"
+subdir = "StrictMode"


### PR DESCRIPTION
StrictMode has moved from the repository root into a `StrictMode/` subfolder, so that it
sits beside `StrictModeTest`, a second package in the same repository. The files were moved
with `git mv`, leaving the revision history intact, and a copy of the license file is in the
package subdirectory.

This is the manual `subdir` pull request described in the General README's "How do I move a
package into a subdirectory of a repository?".

Registration of v0.4.0 is open at #166641 and will be re-invoked once this merges, so that
it only touches the files AutoMerge allows.
