### PR TITLE
[DocumenterVitepress] Cap compat with DocumenterCitations

### DIFF
--- a/D/DocumenterVitepress/WeakCompat.toml
+++ b/D/DocumenterVitepress/WeakCompat.toml
@@ -1,2 +1,2 @@
 ["0.0.21 - 0"]
-DocumenterCitations = "1"
+DocumenterCitations = "1 - 1.4"


### PR DESCRIPTION
`DocumenterCitations@1.5.0` broke integration with `DocumenterVitepress`.  Ref: https://github.com/LuxDL/DocumenterVitepress.jl/issues/391