### PR TITLE
Update NQCBase repo URL to NQCDynamics monorepo

### DIFF
--- a/N/NQCBase/Package.toml
+++ b/N/NQCBase/Package.toml
@@ -1,3 +1,4 @@
 name = "NQCBase"
 uuid = "78c76ebc-5665-4934-b512-82d81b5cbfb7"
-repo = "https://github.com/NQCD/NQCBase.jl.git"
+repo = "https://github.com/NQCD/NQCDynamics.jl.git"
+subdir = "NQCBase.jl"

--- a/N/NQCBase/Versions.toml
+++ b/N/NQCBase/Versions.toml
@@ -1,3 +1,33 @@
+["0.1.3"]
+git-tree-sha1 = "1604d15605357b1d27e2ad2c55081a204562a0e5"
+
+["0.1.4"]
+git-tree-sha1 = "cf747f810c7192d5d436a5d54c1a76f48caf2efd"
+
+["0.1.5"]
+git-tree-sha1 = "27e95e6140ad96fd4c541a4d98ad2e3a02684669"
+
+["0.2.0"]
+git-tree-sha1 = "f74964c3e4620468c84035b379d3165d3b7f7f59"
+
+["0.2.1"]
+git-tree-sha1 = "95bbdf278198517daf1b5d3cf7354a013065bc09"
+
+["0.2.9"]
+git-tree-sha1 = "19a268fb45556d310a7a2da721547f34742ac741"
+
+["0.2.10"]
+git-tree-sha1 = "1346b7aed7551fa849f552b477f5e61bd4bb24f4"
+
+["0.2.11"]
+git-tree-sha1 = "e143378ba7fd3ffcdd6a1c78f438d33cdaaf0378"
+
+["0.3.0"]
+git-tree-sha1 = "faa27850ab166c5f72c42ef2c400194c03411b9f"
+
+["0.5.0"]
+git-tree-sha1 = "d759ed76322e8ee9d24142a072b8926103d5403e"
+
 ["1.0.0"]
 git-tree-sha1 = "c08f25056151c29157a1d223b1baf52c63938864"
 


### PR DESCRIPTION
NQCBase is being moved into the [NQCDynamics](github.com/nqcd/nqcdynamics.jl.git) repo. This PR updates the repo location and includes legacy versions which were released before registration on the general registry. 

NQCBase git history has been integrated into the NQCDynamics repo. 