### PR TITLE
Update NQCCalculators repo URL to NQCDynamics monorepo

### DIFF
--- a/N/NQCCalculators/Package.toml
+++ b/N/NQCCalculators/Package.toml
@@ -1,3 +1,4 @@
 name = "NQCCalculators"
 uuid = "ddd1f41d-9621-41e2-91a4-6b87cc8989f3"
-repo = "https://github.com/NQCD/NQCCalculators.jl.git"
+repo = "https://github.com/NQCD/NQCDynamics.jl.git"
+subdir = "NQCCalculators.jl"

--- a/N/NQCCalculators/Versions.toml
+++ b/N/NQCCalculators/Versions.toml
@@ -1,3 +1,27 @@
+["1.0.0"]
+git-tree-sha1 = "52c3f2094f89773df087627184e55beb40cd0c8d"
+
+["1.0.1"]
+git-tree-sha1 = "bb9594797ef41805ca9df0db8b0a44d95eb4bd7e"
+
+["1.0.2"]
+git-tree-sha1 = "189faf8d6dfa5e38e1c46ee4d98f0a7333e14b4e"
+
+["1.0.3"]
+git-tree-sha1 = "dd9afc5eeb5ea2fb36c2492ae0a47282a858fe27"
+
+["1.0.4"]
+git-tree-sha1 = "1ef977b0d276284e729dbbc9521a2425bdf9cf55"
+
+["1.0.5"]
+git-tree-sha1 = "0eda4138dab574b1411ffe535b20dfc4214a3857"
+
+["1.0.6"]
+git-tree-sha1 = "b896212658f1ffa58681c5e2a5b52ac657d06686"
+
+["1.0.7"]
+git-tree-sha1 = "eb4eb701683d134f0c63ac52756249ae5994ac7b"
+
 ["1.0.8"]
 git-tree-sha1 = "7eff7f420b0f8b0b375131a15deed9e812c2c67b"
 


### PR DESCRIPTION
NQCCalculators is being moved into the [NQCDynamics](github.com/nqcd/nqcdynamics.jl.git) repo. This PR updates the repo location and includes legacy versions which were released before registration on the general registry. 

NQCCalculators git history has been integrated into the NQCDynamics repo. 