### PR TITLE
Update NQCDistributions repo url for NQCDynamics monorepo

### DIFF
--- a/N/NQCDistributions/Package.toml
+++ b/N/NQCDistributions/Package.toml
@@ -1,3 +1,4 @@
 name = "NQCDistributions"
 uuid = "657014a1-bd25-4aa2-92cb-cbcede0310ad"
-repo = "https://github.com/NQCD/NQCDistributions.jl.git"
+repo = "https://github.com/NQCD/NQCDynamics.jl.git"
+subdir = "NQCDistributions.jl"

--- a/N/NQCDistributions/Versions.toml
+++ b/N/NQCDistributions/Versions.toml
@@ -1,2 +1,47 @@
+["0.1.0"]
+git-tree-sha1 = "b442da1cf9ed6ea7a07ae59787aca8ba07c788fc"
+
+["0.1.1"]
+git-tree-sha1 = "aa3b90e1bd9b7e3e18d38b85cede0d157f20b6f3"
+
+["0.1.2"]
+git-tree-sha1 = "cd89da54afb21ad15399e40fa766870bcc062b98"
+
+["0.1.3"]
+git-tree-sha1 = "3fc79102c7a271869a42cb4cae68f340371f5460"
+
+["0.1.4"]
+git-tree-sha1 = "08b50e2a65764ef63048c6cf828259d02804cb99"
+
+["0.1.5"]
+git-tree-sha1 = "bbeaec3050838cd75495a14e16fab4bef0cf8295"
+
+["0.1.6"]
+git-tree-sha1 = "77b332f99371672d384b7b9ee231684ee7fdf33f"
+
+["0.1.7"]
+git-tree-sha1 = "286463f505d6c836856e4714f6af55c8a4c0b797"
+
+["0.1.8"]
+git-tree-sha1 = "e0369f977fd46ff41af4ba1d9454adb0786cf46f"
+
+["0.1.9"]
+git-tree-sha1 = "dd92313642609b9954636efb2369fe3956caa3ff"
+
+["0.1.10"]
+git-tree-sha1 = "e6c49107bb9ea88c11eef469ef3c9a2ef53a9715"
+
+["0.1.11"]
+git-tree-sha1 = "c8421da0ec317175ac7d394057ffb186796e0fdc"
+
+["0.1.12"]
+git-tree-sha1 = "b9abad80383d073911c47fb35eeac5d60f94730f"
+
+["0.1.13"]
+git-tree-sha1 = "3dc6a74ba0f83e5f5e41b9618621e604c9663714"
+
+["0.1.14"]
+git-tree-sha1 = "c1ea54268bf8c2acfa1db59eeba93f66facf3f97"
+
 ["1.0.0"]
 git-tree-sha1 = "8d624e3336edc97e9ac38f3ebc16f02d561315f1"


### PR DESCRIPTION
NQCDistributions is being moved into the [NQCDynamics](github.com/nqcd/nqcdynamics.jl.git) repo. This PR updates the repo location and includes legacy versions which were released before registration on the general registry. 

NQCDistributions git history has been integrated into the NQCDynamics repo. 