### PR TITLE
Update NQCModels repo URL for NQCDynamics monorepo

### DIFF
--- a/N/NQCModels/Package.toml
+++ b/N/NQCModels/Package.toml
@@ -1,3 +1,4 @@
 name = "NQCModels"
 uuid = "c814dc9f-a51f-4eaf-877f-82eda4edad48"
-repo = "https://github.com/NQCD/NQCModels.jl.git"
+repo = "https://github.com/NQCD/NQCDynamics.jl.git"
+subdir = "NQCModels.jl"

--- a/N/NQCModels/Versions.toml
+++ b/N/NQCModels/Versions.toml
@@ -1,3 +1,75 @@
+["0.8.0"]
+git-tree-sha1 = "fd27586b6d52b38f4758bf0ede83a7d41cd4086a"
+
+["0.8.1"]
+git-tree-sha1 = "bb2765e53d134225ae5d89d24a6e7e0a335e35de"
+
+["0.8.2"]
+git-tree-sha1 = "cb955593a2cbaf2d500d2f2b2408530aefcb3e55"
+
+["0.8.3"]
+git-tree-sha1 = "36d2b0dd3d345b27fcd6871f3c8de0f7fd45f6fe"
+
+["0.8.4"]
+git-tree-sha1 = "ee3e3d4513063a77dee2055332d39058c3b23f64"
+
+["0.8.5"]
+git-tree-sha1 = "407655a1d8e7097d9feab1a725758830753efe81"
+
+["0.8.6"]
+git-tree-sha1 = "09e1854b2b2f8886e1cff8c3aeb7d4a8d74db048"
+
+["0.8.7"]
+git-tree-sha1 = "2f8ba3b0505021a75c7de2aea4432613d61b8c30"
+
+["0.8.8"]
+git-tree-sha1 = "7c447556bee923b50d95d0709608e630dfb4ca00"
+
+["0.8.9"]
+git-tree-sha1 = "3b0502545a225c0b1c643018d742d0f3afcd5e4f"
+
+["0.8.10"]
+git-tree-sha1 = "57dbcb52098c99eb00a714b0f888cbc3d1c1e9cc"
+
+["0.8.11"]
+git-tree-sha1 = "2630d5488d79dfb639f796c6ca028eaede12b5df"
+
+["0.8.12"]
+git-tree-sha1 = "07973b9844d0aa642340e7b8ea0fc748380e6b33"
+
+["0.8.13"]
+git-tree-sha1 = "e1d6643c83144d5c9b3afb2a496b99922d770f2e"
+
+["0.8.14"]
+git-tree-sha1 = "b75b25bd097fa9710c58e688adb4dc11bd2cbd1c"
+
+["0.8.15"]
+git-tree-sha1 = "bad70c6d120c7a8edc3f9d36ecbd0ea00c737c6b"
+
+["0.8.16"]
+git-tree-sha1 = "9d7750b5b3c0247ef0a6d0d37998acdee9a8c2ac"
+
+["0.8.17"]
+git-tree-sha1 = "e22fdb737bd78ec315e02342f9b9e8eaa7dee2cf"
+
+["0.8.18"]
+git-tree-sha1 = "d8a32efe23567be9287dd8267b7564b7c88fbbc5"
+
+["0.8.19"]
+git-tree-sha1 = "4ca94e3f5051294985ea32eb345f7466261295b8"
+
+["0.8.20"]
+git-tree-sha1 = "02e1d3c2f3dee21a7ebfb630ecc939c6e9d1a18a"
+
+["0.9.0"]
+git-tree-sha1 = "c0fb506421f6b1d03a9c6f93ecbf8b314111cdb7"
+
+["0.9.1"]
+git-tree-sha1 = "5a1c4b90200f1b3a353c1a75469b2b62fb95c020"
+
+["0.10.0"]
+git-tree-sha1 = "5a6041c5dd25562894f303d318831c171bedf23b"
+
 ["1.0.0"]
 git-tree-sha1 = "ff419ed2e53d8ace7133dcc2725b8dc5252f243b"
 


### PR DESCRIPTION
NQCModels is being moved into the [NQCDynamics](github.com/nqcd/nqcdynamics.jl.git) repo. This PR updates the repo location and includes legacy versions which were released before registration on the general registry. 

NQCModels git history has been integrated into the NQCDynamics repo. 