### PR TITLE
Update RingPolymerArrays repo URL for NQCDynamics monorepo

### DIFF
--- a/R/RingPolymerArrays/Package.toml
+++ b/R/RingPolymerArrays/Package.toml
@@ -1,3 +1,4 @@
 name = "RingPolymerArrays"
 uuid = "81cd853e-d334-476c-b156-f95acc8a32dc"
-repo = "https://github.com/NQCD/RingPolymerArrays.jl.git"
+repo = "https://github.com/NQCD/NQCDynamics.jl.git"
+subdir = "RingPolymerArrays.jl"

--- a/R/RingPolymerArrays/Versions.toml
+++ b/R/RingPolymerArrays/Versions.toml
@@ -1,2 +1,14 @@
+["0.1.0"]
+git-tree-sha1 = "019662faa29d0b473b53e142d83ff49598c356d7"
+
+["0.1.1"]
+git-tree-sha1 = "e0f2cbd692a371c730463fa15bd98f1a4eadbf88"
+
+["0.1.2"]
+git-tree-sha1 = "7484189250998fc736f7526751d188a8b86d5b9e"
+
+["0.1.3"]
+git-tree-sha1 = "ea19bf100b5ca4bd717151d82950e52824976d82"
+
 ["1.0.0"]
 git-tree-sha1 = "dbcdc77350589c6a507026a346bd946f7f729748"


### PR DESCRIPTION
RingPolymerArrays is being moved into the [NQCDynamics](github.com/nqcd/nqcdynamics.jl.git) repo. This PR updates the repo location and includes legacy versions which were released before registration on the general registry. 

RingPolymerArrays git history has been integrated into the NQCDynamics repo. 