### PR TITLE
Update NQCDynamics repo URL for monorepo

### DIFF
--- a/N/NQCDynamics/Package.toml
+++ b/N/NQCDynamics/Package.toml
@@ -1,3 +1,4 @@
 name = "NQCDynamics"
 uuid = "36248dfb-79eb-4f4d-ab9c-e29ea5f33e14"
 repo = "https://github.com/NQCD/NQCDynamics.jl.git"
+subdir = "NQCDynamics.jl"

--- a/N/NQCDynamics/Versions.toml
+++ b/N/NQCDynamics/Versions.toml
@@ -1,3 +1,69 @@
+["0.9.3"]
+git-tree-sha1 = "4753ef949ee2f8cdc178a5099e8ed672badcd75e"
+
+["0.9.4"]
+git-tree-sha1 = "653dc18ab1fd0be190317a4e4cf7f9b7030a5f62"
+
+["0.9.5"]
+git-tree-sha1 = "a7df764bff462e7cdf68631c9f3f52e3034fa792"
+
+["0.10.0"]
+git-tree-sha1 = "8e472539e28f67b65371a94e6eb64f062bf71537"
+
+["0.10.1"]
+git-tree-sha1 = "c5a544cd126de6208c4aab75ccfb1c588360a1b4"
+
+["0.10.2"]
+git-tree-sha1 = "02d589717105df82aa7e968483df0be7a569ce45"
+
+["0.10.3"]
+git-tree-sha1 = "dc72a4f7187670cdbaa49aefd09101e053baabd0"
+
+["0.10.4"]
+git-tree-sha1 = "8f57234578bf00c69a81bb633a1aa53d241e3037"
+
+["0.11.0"]
+git-tree-sha1 = "d16832b2fc2ed5f73442c3cc2811c713cf6ec0f9"
+
+["0.11.1"]
+git-tree-sha1 = "4ad9f956d7ac05c6aab696feccf5dc9d59c40947"
+
+["0.12.0"]
+git-tree-sha1 = "7f6e119605a638baf390bf57970acbb963541f2f"
+
+["0.12.1"]
+git-tree-sha1 = "2295a67841efe49e98dfa933814760443060c448"
+
+["0.13.0"]
+git-tree-sha1 = "164bad0a2e485a7fdb414aaa2d708f167ad2b0f6"
+
+["0.13.1"]
+git-tree-sha1 = "88e3948fa80057f4220e20d0c2915fafa8037922"
+
+["0.13.2"]
+git-tree-sha1 = "df0354a71868b49bad627f9c214988aae208e8e5"
+
+["0.13.3"]
+git-tree-sha1 = "dae8ae596545f03acff26823befcb99d2825c66a"
+
+["0.13.4"]
+git-tree-sha1 = "f273889cfdfe888f632666675a6ad4d133b28de7"
+
+["0.13.5"]
+git-tree-sha1 = "06cee1a1b0749ebb7453c30d38e4737e5a3d6779"
+
+["0.13.6"]
+git-tree-sha1 = "95516996ad70cf8260f4a1df30f28920ddd0150d"
+
+["0.14.0"]
+git-tree-sha1 = "a3bf22586b29d1cf1dc024a239cfddd737234ac2"
+
+["0.15.0"]
+git-tree-sha1 = "6e14467dffbe88b35109dcefacb919b79039a031"
+
+["0.15.1"]
+git-tree-sha1 = "919b8e289b57c22fd086d4b1c198ec48ba1dfb2e"
+
 ["1.0.1"]
 git-tree-sha1 = "55daab2c0b0d4f470becc778d21be1077c1b9d18"
 


### PR DESCRIPTION
NQCDynamics is being turned into a monorepo containing: 

- [NQCBase.jl](https://github.com/JuliaRegistries/General/pull/166812)
- [NQCCalculators.jl](https://github.com/JuliaRegistries/General/pull/166813)
- NQCDynamics.jl
- [NQCDistributions.jl](https://github.com/JuliaRegistries/General/pull/166814)
- [NQCModels.jl](https://github.com/JuliaRegistries/General/pull/166815)
- [RingPolymerArrays](https://github.com/JuliaRegistries/General/pull/166816)

This PR updates the repo location and includes legacy versions which were released before registration on the general registry. 

Git history is already integrated. 

