### PR TITLE
CUDA_Runtime_jll/CUDA_Compiler_jll: pin CUDA_Driver_jll to 13.3.1

### DIFF
--- a/jll/C/CUDA_Compiler_jll/Compat.toml
+++ b/jll/C/CUDA_Compiler_jll/Compat.toml
@@ -9,8 +9,8 @@ julia = "1.6.0-1"
 ["0-0.1"]
 CUDA_Driver_jll = "12"
 
-["0.2-0.5.0"]
+["0.2-0.4"]
 CUDA_Driver_jll = "13"
 
-["0.5.1-0"]
-CUDA_Driver_jll = "13.3.1-13"
+["0.5.0-0.6.0"]
+CUDA_Driver_jll = "13.3.1"

--- a/jll/C/CUDA_Runtime_jll/Compat.toml
+++ b/jll/C/CUDA_Runtime_jll/Compat.toml
@@ -51,8 +51,8 @@ CUDA_Driver_jll = "0.1-0.2"
 ["0.2.1-0.2"]
 CUDA_Driver_jll = "0.2"
 
-["0.22-0"]
-CUDA_Driver_jll = "13.3.1-13"
+["0.22-0.24.2"]
+CUDA_Driver_jll = "13.3.1"
 
 ["0.24-0.24.1"]
 CUDA_Compiler_jll = "0.5"


### PR DESCRIPTION
CUDA_Runtime_jll 0.22–0.24.2 and CUDA_Compiler_jll 0.5.0–0.6.0 ship platform
augmentation hooks that call into CUDA_Driver_jll: 0.22–0.24.0 / 0.5.0 call
`inspect_driver` (which needs the helper binary the Driver ships in
helper-only artifacts on Windows and non-L4T Tegra), 0.24.1–0.24.2 /
0.5.1–0.6.0 call `select_cuda_toolkit`. The upcoming CUDA_Driver_jll 13.3.4
removes that selection API and the helper-only artifacts: toolkit selection
moves into the Runtime/Compiler hook itself (CUDA_Runtime_jll 0.24.3 /
CUDA_Compiler_jll 0.6.1 will declare `CUDA_Driver_jll = "13.3.4 - 13"`).

Rather than keeping compatibility code in the Driver, cap the old hook
generations retroactively to the last Driver they were validated against:

- CUDA_Runtime_jll `["0.22-0.24.2"]`: `13.3.1-13` → `13.3.1`
- CUDA_Compiler_jll `["0.5.0-0.6.0"]`: `13` / `13.3.1-13` → `13.3.1`
  (split off `["0.2-0.4"]`, which keeps `13`: those hooks are driver-independent)

CUDA_Runtime_jll 0.19–0.21 keep `13` (they only read `CUDA_Driver_jll.libcuda`,
which stays). 13.3.2/13.3.3 were the initial Tegra releases; nothing in the
stack is meant to depend on them, so the pin is exactly 13.3.1.

Assisted by: Fable 5.1
