### PR TITLE
Change repo URL of Numav.jl.

### DIFF
--- a/N/Numav/Package.toml
+++ b/N/Numav/Package.toml
@@ -1,4 +1,3 @@
 name = "Numav"
 uuid = "8e910097-05db-4d5e-bf44-3d692aba33cf"
 repo = "https://github.com/mmfiuza/Numav.jl.git"
-subdir = "julia-bindings/Numav.jl"

--- a/N/Numav/Package.toml
+++ b/N/Numav/Package.toml
@@ -1,4 +1,4 @@
 name = "Numav"
 uuid = "8e910097-05db-4d5e-bf44-3d692aba33cf"
-repo = "https://github.com/mmfiuza/numav.git"
+repo = "https://github.com/mmfiuza/Numav.jl.git"
 subdir = "julia-bindings/Numav.jl"


### PR DESCRIPTION
The URL changed because Numav is no longer primarily a C++ library with Julia bindings. It is now primarily a Julia library, with C++ implementations. The change was to follow the naming convention of Julia package repos.