### PR TITLE
Yank Reseau 1.1.0–1.3.4 due to expired precompile certificate

### DIFF
--- a/R/Reseau/Versions.toml
+++ b/R/Reseau/Versions.toml
@@ -6,39 +6,51 @@ git-tree-sha1 = "4aaa1ae7034c2a37c25f672923a2620976062909"
 
 ["1.1.0"]
 git-tree-sha1 = "672ce58df8dc872d5654b5c413072f5498242c84"
+yanked = true
 
 ["1.1.1"]
 git-tree-sha1 = "0740046f33ee2c16b9ac407f4e6f7b4543325d02"
+yanked = true
 
 ["1.1.2"]
 git-tree-sha1 = "3b6e3aa3baee935b46df2f0e8250bb9060ee7dbb"
+yanked = true
 
 ["1.1.3"]
 git-tree-sha1 = "165e3acdfaa0c7ec087d7a3851c63da4cb9dd6fb"
+yanked = true
 
 ["1.1.4"]
 git-tree-sha1 = "678f858c26fdd8680d6dad7a2694273a05819485"
+yanked = true
 
 ["1.2.0"]
 git-tree-sha1 = "33f26576f637898b7745bae3963abb370add88f1"
+yanked = true
 
 ["1.2.1"]
 git-tree-sha1 = "4b5b5c2fc0629de34217b03b2729caa855414bc1"
+yanked = true
 
 ["1.3.0"]
 git-tree-sha1 = "318b3430e02b27b736f711fe03014116bd3ba100"
+yanked = true
 
 ["1.3.1"]
 git-tree-sha1 = "0eab6d95ed40c2ef3992255c1c71e4f9748932b5"
+yanked = true
 
 ["1.3.2"]
 git-tree-sha1 = "5ccb99ea21f18b328e5da04a36fd10b56cb8850a"
+yanked = true
 
 ["1.3.3"]
 git-tree-sha1 = "8648ea1f1e700e9abd617d7eb6843a73097f2aeb"
+yanked = true
 
 ["1.3.4"]
 git-tree-sha1 = "0bd997a5b763395a78575989ac02e622f42461e9"
+yanked = true
 
 ["1.3.5"]
 git-tree-sha1 = "6bb4e276780eaba7c5a61af85c6d537a245d8150"


### PR DESCRIPTION
Yank Reseau 1.1.0 through 1.3.4 (12 releases). Their default precompile workload verifies the bundled `test/resources/unittests.crt`, which expired on 2026-08-06 at 17:07:04 UTC. A fresh precompile fails with `tls: certificate has expired or is not yet valid`, and the failure propagates to HTTP and its dependents.

The certificate was replaced in [Reseau PR #140](https://github.com/JuliaServices/Reseau.jl/pull/140), released as 1.3.5. The original failure is documented in [Reseau #139](https://github.com/JuliaServices/Reseau.jl/issues/139).

This follows [the discussion in #165283](https://github.com/JuliaRegistries/General/pull/165283#issuecomment-5563071321). I prefer excluding the broken Reseau releases directly so the fix applies to all consumers.

The range starts at **1.1.0**, not 1.0.0. Versions 1.0.0 and 1.0.1 contain the same expired fixture, but their precompile client uses `verify_peer = false`. Version 1.1.0 introduces the verified roundtrip that uses this certificate. Releases 1.3.5 and later contain the replacement certificate, valid until 2036-01-01.

Validation: checked all 18 registered release tree hashes against their tags, inspected the precompile workloads, and decoded certificate validity with OpenSSL. Parsed the edited TOML and confirmed that the only changes are 12 `yanked = true` flags. All version entries and source hashes are preserved. `git diff --check` passes.

Fresh precompilation checks on Julia 1.12.7 (macOS ARM64), using isolated source directories and a task-local writable depot, confirm the boundaries:

| Release | Result |
| --- | --- |
| 1.0.1 | Precompiles successfully |
| 1.1.0 | Fails with the expired-certificate error |
| 1.3.4 | Fails with the expired-certificate error |
| 1.3.5 | Precompiles successfully |

As documented in General's yank policy, this prevents new resolutions from selecting these releases. It does not repair existing manifests: `Pkg.instantiate()` can still install a yanked version recorded in a manifest, so affected environments must update Reseau to 1.3.5 or later.

Co-authored by Codex
