### PR TITLE
Yank Sparlectra versions below 0.7.0

### DIFF
--- a/S/Sparlectra/Versions.toml
+++ b/S/Sparlectra/Versions.toml
@@ -1,98 +1,130 @@
 ["0.4.8"]
 git-tree-sha1 = "50ed26e5d8dea1a7d446a0e2ce485e0b0b85a64f"
+yanked = true
 
 ["0.4.10"]
 git-tree-sha1 = "35421a00f0d3ba44f8456c6f5c00b8243a9a419d"
+yanked = true
 
 ["0.4.11"]
 git-tree-sha1 = "653bef49c772338838e06a7434cd5a236bf775da"
+yanked = true
 
 ["0.4.12"]
 git-tree-sha1 = "c91979b549c0bfbb9fa28f18fd76d7807f59da3f"
+yanked = true
 
 ["0.4.13"]
 git-tree-sha1 = "20dec440fc424a3b53c9c4874bd9704c9a59949f"
+yanked = true
 
 ["0.4.14"]
 git-tree-sha1 = "323882af403a4c187b1ff260c067ddd8b6cc50e3"
+yanked = true
 
 ["0.4.15"]
 git-tree-sha1 = "a8ab12aa97bee65d6d01bad9f6212982d4b7b940"
+yanked = true
 
 ["0.4.16"]
 git-tree-sha1 = "a03a0ae648bb15c5dc4b49ae3a1eaa82387dc9f1"
+yanked = true
 
 ["0.4.17"]
 git-tree-sha1 = "7a785f8f09ef328ad50c4cf1841ea73fdcb0cdb9"
+yanked = true
 
 ["0.4.18"]
 git-tree-sha1 = "dce13576f0496df5ed3b3216e571b5d8556a2a52"
+yanked = true
 
 ["0.4.19"]
 git-tree-sha1 = "a817ed553ab7c895c5f86bd31717e1daf609e51a"
+yanked = true
 
 ["0.4.20"]
 git-tree-sha1 = "b0cf662ed1538d8c58b3fcfc7b1e1e790ddabf22"
+yanked = true
 
 ["0.4.21"]
 git-tree-sha1 = "9a31c25616a7de96d32b8d63aa7166372124e319"
+yanked = true
 
 ["0.4.22"]
 git-tree-sha1 = "6649684be28e29e56c21fccd26c46457295479df"
+yanked = true
 
 ["0.4.23"]
 git-tree-sha1 = "cdcfeafbeaa0a077bd5675f36e972378eb543831"
+yanked = true
 
 ["0.4.24"]
 git-tree-sha1 = "b16249451c7641bb577ab07d9a6a12c7da391f9c"
+yanked = true
 
 ["0.4.25"]
 git-tree-sha1 = "608a008af70b94544fa96b1cb19b3f22a31a556c"
+yanked = true
 
 ["0.4.26"]
 git-tree-sha1 = "9850e306dad986a0bfaf11ae4ff7a7a923ed483e"
+yanked = true
 
 ["0.4.27"]
 git-tree-sha1 = "df6f4590b01acc82ffcdab482bb85d56847efdb5"
+yanked = true
 
 ["0.4.28"]
 git-tree-sha1 = "b8727165b09e0c880634c1bd66b71c2b350ba0da"
+yanked = true
 
 ["0.4.29"]
 git-tree-sha1 = "83bc42e438fa272a03c2e9e53be2bd657e583801"
+yanked = true
 
 ["0.4.30"]
 git-tree-sha1 = "975140bf4a861bbf992d839d8b8586e3e83aeade"
+yanked = true
 
 ["0.4.31"]
 git-tree-sha1 = "6faa5d6703dec5e8df8495a56984e54954ee0f8e"
+yanked = true
 
 ["0.4.32"]
 git-tree-sha1 = "55b43413cae7b227be0556fe8ff53fe9d972b761"
+yanked = true
 
 ["0.4.33"]
 git-tree-sha1 = "82b4d0ba221873b39b9fc420d91bf9368c3228f3"
+yanked = true
 
 ["0.4.34"]
 git-tree-sha1 = "15ee394fbde6ed851980f6b665d7e3add6f01256"
+yanked = true
 
 ["0.4.35"]
 git-tree-sha1 = "c2d40278b75e3556ad44448a067e29c6e221d23a"
+yanked = true
 
 ["0.5.0"]
 git-tree-sha1 = "661570d1ff37209930b369f315b983fccb2479c1"
+yanked = true
 
 ["0.6.0"]
 git-tree-sha1 = "9233315cc172fb0d97423ed1647ea3afc7f3184b"
+yanked = true
 
 ["0.6.1"]
 git-tree-sha1 = "010ef7d5a19d745e7571500c23aa76dedfa5989c"
+yanked = true
 
 ["0.6.2"]
 git-tree-sha1 = "752fcc0e882adc31c82c56f73f57079b36307b3f"
+yanked = true
 
 ["0.6.3"]
 git-tree-sha1 = "6a529715959e2d028da40cb7742a51ec51578482"
+yanked = true
 
 ["0.7.0"]
 git-tree-sha1 = "981e820b8c237af956d79f6c19ecc7747f8d9f75"


### PR DESCRIPTION
Yanks every registered version of Sparlectra below 0.7.0, per the "When is yanking a release appropriate?" section of this registry's README. Requested by the package maintainer (@Welthulk) as a routine cleanup.

**Why:** the pre-0.7 series predates the package's current API and its case and configuration formats and has been superseded for a long time; nothing depends on it and none of it should be picked by a fresh resolve. There is no security issue and nothing is deleted: a Manifest that already pins one of these versions keeps instantiating.

**What changes:** `S/Sparlectra/Versions.toml` gains one line `yanked = true` under each of the 32 entries below, directly after its `git-tree-sha1`. No tree hash, no other line and no version at or above 0.7.0 is touched (32 insertions, 0 deletions).

Yanked versions:

- 0.4.8
- 0.4.10, 0.4.11, 0.4.12, 0.4.13, 0.4.14, 0.4.15, 0.4.16, 0.4.17, 0.4.18, 0.4.19
- 0.4.20, 0.4.21, 0.4.22, 0.4.23, 0.4.24, 0.4.25, 0.4.26, 0.4.27, 0.4.28, 0.4.29
- 0.4.30, 0.4.31, 0.4.32, 0.4.33, 0.4.34, 0.4.35
- 0.5.0
- 0.6.0, 0.6.1, 0.6.2, 0.6.3

Every one of them corresponds to a tag of the same name in https://github.com/Welthulk/Sparlectra.jl, and none was yanked before. The oldest remaining version is 0.7.0.
