### PR TITLE
[New package] AiresDB

### DIFF
--- a/A/AiresDB/Compat.toml
+++ b/A/AiresDB/Compat.toml
@@ -1,0 +1,12 @@
+["0"]
+Base64 = "1.11.0"
+Dates = "1.11.0"
+HTTP = "2.6.7"
+JSON3 = "1.14.3"
+OpenSSL_jll = "3.5.6"
+Random = "1.11.0"
+SHA = "0.7.0"
+Serialization = "1.11.0"
+TOML = "1.0.3"
+UUIDs = "1.11.0"
+julia = "1.12"

--- a/A/AiresDB/Deps.toml
+++ b/A/AiresDB/Deps.toml
@@ -1,0 +1,11 @@
+["0"]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/A/AiresDB/Package.toml
+++ b/A/AiresDB/Package.toml
@@ -1,0 +1,3 @@
+name = "AiresDB"
+uuid = "e39701c5-c21a-4d73-a911-e02c68a3ca10"
+repo = "https://github.com/aires-id/AiresDB.git"

--- a/A/AiresDB/Versions.toml
+++ b/A/AiresDB/Versions.toml
@@ -1,0 +1,2 @@
+["0.1.0"]
+git-tree-sha1 = "a922b6288ffd337d3cc5cf62ab20c32b2aeefbef"


### PR DESCRIPTION
## Summary

Register AiresDB v0.1.0 in the Julia General registry.

- Package UUID: e39701c5-c21a-4d73-a911-e02c68a3ca10
- Repository: https://github.com/aires-id/AiresDB
- License: MIT
- Julia compatibility: 1.12

The package has a valid Project.toml, CI, tests, and TagBot workflow.