### PR TITLE
Update MonteCarloIntegration repo URL to SciML/MonteCarloIntegration.jl

### DIFF
--- a/M/MonteCarloIntegration/Package.toml
+++ b/M/MonteCarloIntegration/Package.toml
@@ -1,3 +1,3 @@
 name = "MonteCarloIntegration"
 uuid = "4886b29c-78c9-11e9-0a6e-41e1f4161f7b"
-repo = "https://github.com/ranjanan/MonteCarloIntegration.jl.git"
+repo = "https://github.com/SciML/MonteCarloIntegration.jl.git"


### PR DESCRIPTION
`MonteCarloIntegration` has moved from `ranjanan/MonteCarloIntegration.jl` to `SciML/MonteCarloIntegration.jl`. The old location now redirects to the new one, and the SciML organization maintains it.

Registrator blocks new versions until the registry records the new URL:

```
Error while trying to register: Changing package repo URL not allowed,
please submit a pull request with the URL change to the target registry and retry.
```

This changes only the `repo` field in `M/MonteCarloIntegration/Package.toml`. The name and UUID are unchanged.

## Context

Version 0.3.0 has been sitting unregistered since 2026-08-27. The earlier registration attempt, #166242, is still open: it was blocked on missing breaking release notes, and the agent working on it could not re-trigger Registrator because it was not a collaborator on the personal repository. The move to SciML resolves the collaborator problem, so once this URL change lands, 0.3.0 can be re-registered with proper breaking notes.

Downstream, `Integrals.jl` currently carries a `[sources]` git override pointing at the old URL to reach this code, which breaks its i686 CI lanes. Registering 0.3.0 lets that override be removed.

---
🤖 Posted by an AI agent — harness: Claude Code, model: claude-opus-5[1m]. Chris asked for this work; he has not reviewed this specific pull request.

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R