### PR TITLE
Retroactive OrdinaryDiffEqCore lower bound for four broken OrdinaryDiffEq sublibrary releases

### DIFF
--- a/O/OrdinaryDiffEqDefault/Compat.toml
+++ b/O/OrdinaryDiffEqDefault/Compat.toml
@@ -131,7 +131,6 @@ LinearSolve = "5.1.0 - 5"
 SciMLBase = "3.39.0 - 3"
 
 ["2.4.1 - 2.6.1"]
-OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.4.4 - 2"]
 SciMLBase = "3.46.0 - 3"
@@ -149,4 +148,10 @@ DiffEqBase = "7.15.0 - 7"
 Reexport = "1.2.2 - 1"
 
 ["2.6.2 - 2"]
+OrdinaryDiffEqCore = "4.17.1 - 4"
+
+["2.4.1 - 2.6.0"]
+OrdinaryDiffEqCore = "4.11.0 - 4"
+
+["2.6.1"]
 OrdinaryDiffEqCore = "4.17.1 - 4"

--- a/O/OrdinaryDiffEqFIRK/Compat.toml
+++ b/O/OrdinaryDiffEqFIRK/Compat.toml
@@ -223,10 +223,15 @@ OrdinaryDiffEqDifferentiation = "3.9.0 - 3"
 LinearSolve = "5.12.0 - 5"
 
 ["2.8.1 - 2.8.5"]
-OrdinaryDiffEqCore = "4.15.1 - 4"
 
 ["2.8.2 - 2"]
 OrdinaryDiffEqDifferentiation = "3.11.0 - 3"
 
 ["2.8.6 - 2"]
+OrdinaryDiffEqCore = "4.17.1 - 4"
+
+["2.8.1 - 2.8.4"]
+OrdinaryDiffEqCore = "4.15.1 - 4"
+
+["2.8.5"]
 OrdinaryDiffEqCore = "4.17.1 - 4"

--- a/O/OrdinaryDiffEqRosenbrock/Compat.toml
+++ b/O/OrdinaryDiffEqRosenbrock/Compat.toml
@@ -222,7 +222,6 @@ ArrayInterface = "7.28.0 - 7"
 SciMLBase = "3.39.0 - 3"
 
 ["2.6.1 - 2.7.2"]
-OrdinaryDiffEqCore = "4.11.0 - 4"
 
 ["2.6.3 - 2"]
 OrdinaryDiffEqDifferentiation = "3.3.0 - 3"
@@ -232,4 +231,10 @@ DiffEqBase = "7.14.0 - 7"
 SciMLBase = "3.46.0 - 3"
 
 ["2.7.3 - 2"]
+OrdinaryDiffEqCore = "4.17.1 - 4"
+
+["2.6.1 - 2.7.1"]
+OrdinaryDiffEqCore = "4.11.0 - 4"
+
+["2.7.2"]
 OrdinaryDiffEqCore = "4.17.1 - 4"

--- a/S/StochasticDiffEqCore/Compat.toml
+++ b/S/StochasticDiffEqCore/Compat.toml
@@ -46,7 +46,6 @@ RecursiveArrayTools = "4"
 SciMLBase = "3.0 - 3.39"
 
 ["2 - 2.2.2"]
-OrdinaryDiffEqCore = "4"
 
 ["2.0.0"]
 SciMLLogging = "1.7.1 - 1"
@@ -94,4 +93,10 @@ SciMLLogging = "2"
 ForwardDiff = "1"
 
 ["2.2.3 - 2"]
+OrdinaryDiffEqCore = "4.17.1 - 4"
+
+["2 - 2.2.1"]
+OrdinaryDiffEqCore = "4"
+
+["2.2.2"]
 OrdinaryDiffEqCore = "4.17.1 - 4"


### PR DESCRIPTION
Four already-published releases can be resolved into a configuration that fails to load. This adds the retroactive lower bound to make them uninstallable in that broken pairing.

## The failure

```
WARNING: Imported binding OrdinaryDiffEqCore._is_identity_massmatrix was undeclared
at import time during import to OrdinaryDiffEqDefault.
ERROR: LoadError: UndefVarError: `_is_identity_massmatrix` not defined in `OrdinaryDiffEqDefault`
```

SciML/OrdinaryDiffEq.jl#4502 added the internals `_is_identity_massmatrix`, `_is_zero_massmatrix` and `_diff_alg_vars` to `OrdinaryDiffEqCore` and, in the same commit, began using them from four sublibraries. Those sublibraries were released without raising their `OrdinaryDiffEqCore` floor. The three names first exist in **OrdinaryDiffEqCore 4.17.1**, so any resolution that picks an older Core produces the `UndefVarError` above at load time.

## The change

Each broken version is carved out of its existing range and given the correct floor. Nothing else moves.

| package | version | before | after | internal used |
|---|---|---|---|---|
| `OrdinaryDiffEqDefault` | 2.6.1 | `4.11.0 - 4` | `4.17.1 - 4` | `_is_identity_massmatrix` |
| `OrdinaryDiffEqFIRK` | 2.8.5 | `4.15.1 - 4` | `4.17.1 - 4` | `_is_identity_massmatrix` |
| `OrdinaryDiffEqRosenbrock` | 2.7.2 | `4.11.0 - 4` | `4.17.1 - 4` | `_diff_alg_vars` |
| `StochasticDiffEqCore` | 2.2.2 | `4` | `4.17.1 - 4` | `_is_identity_massmatrix` |

`_is_zero_massmatrix` is used only within Core itself and needs no bound.

Mechanically, the `OrdinaryDiffEqCore` entry is removed from the enclosing range section and re-added as two sections, one for the versions below the break keeping the original bound, one for the single broken version with the new bound. Other dependencies in the original section are untouched.

## Upstream fix

SciML/OrdinaryDiffEq.jl#4525 raised the floors in the repository and released 2.6.2, 2.8.6, 2.7.3 and 2.2.3, which are already registered and carry `4.17.1` correctly. This pull request is only about repairing the four versions that shipped before that.

## Verification

Checked with `Pkg.Versions.VersionRange` against the edited files:

- for every registered version of all four packages, exactly one `Compat.toml` section supplies an `OrdinaryDiffEqCore` bound, so no version is left ambiguous or uncovered;
- each of the four broken versions now resolves to a bound that admits 4.17.1 and excludes 4.17.0;
- the immediate neighbours are unchanged: 2.6.0 still `4.11.0 - 4`, 2.8.4 still `4.15.1 - 4`, 2.7.1 still `4.11.0 - 4`, 2.2.1 still `4`, and the new 2.6.2 / 2.8.6 / 2.7.3 / 2.2.3 still `4.17.1 - 4`.

---
🤖 Posted by an AI agent — harness: Claude Code, model: claude-opus-5[1m]. Chris asked for this fix; he has not reviewed this specific pull request.

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R